### PR TITLE
fix: resolve AGENTS.md conflict and implement metadata scrubbing (issue #30)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,101 +1,18 @@
 # AGENTS.md
 
-<<<<<<< HEAD
 > **Notice**: This file is the primary context entry point for AI-assisted development.
 > It defines the project boundaries, security invariants, and the current roadmap.
 
 ## 0. Quick Start for AI Agents
-1. **Identify the Task**: Match your task to a domain in the [Canonical Source Map](#2-canonical-source-map).
+
+1. **Identify the Task**: Match your task to a domain in the [Canonical Source Map](#canonical-source-map).
 2. **Load Minimal Context**: Load only the files and documentation sections listed for that domain.
-3. **Verify Invariants**: Check your proposed changes against the [Core Invariants](#3-core-invariants).
-4. **Follow Language Rules**: Ensure all user-visible text follows [Neutral Language Rules](#4-user-facing-language-rules).
-5. **Run Tests**: Execute the relevant tests and static analysis.
+3. **Verify Invariants**: Check your proposed changes against the [Core Invariants](#core-invariants).
+4. **Follow Language Rules**: Ensure all user-visible text follows [User-Facing Language Rules](#user-facing-language-rules).
+5. **Run Tests**: Execute the relevant tests and static analysis before submitting.
 
 ---
 
-## 1. Project Status & Roadmap
-
-### 🚩 Current Focus: Hardening & Modularity
-The goal is to transition from a "field-evaluation prototype" to a "local appliance solution" by strengthening boundaries and improving testability.
-
-### 🛤 Roadmap (Next Priority Issues)
-1.  **#19 Multi-source KDF**: Design and implement a pipeline for mixing local device-binding inputs into the KDF.
-2.  **#30 Metadata Reduction**: Implement rigorous metadata scrubbing for exported payloads.
-3.  **#31 Audit Integrity**: Implement hash-chaining and integrity verification for audit logs.
-4.  **#32 Tamper Evidence**: Implement hardware-binding status reporting for field-evaluation units.
-5.  **#33 UX Hardening**: Optimize Field Mode emergency flows for high-stress operational use.
-6.  **#16 Integrity Manifest**: Implement a workflow for generating signed release manifests and SBOMs.
-7.  **#27 AI Gate Decoupling**: Separate camera handling, object matching, and face lock logic.
-
-### ✅ Completed Milestones
--   `#8` & `#9`: CI pipeline with static analysis (`ruff`, `mypy`) and 70% coverage gate.
--   `#22`: Centralized restricted action policy enforcement.
--   `#23`: Typed local state store with atomic transitions.
--   `#24`: Local coercion scenario matrix and restricted-flow tests.
--   `#25`: Centralized user-visible strings in `strings.py`.
--   `#29`: Local operations commands (`doctor`, `verify-state`) and documentation alignment.
-
----
-
-## 2. Canonical Source Map
-
-| Domain | Key Source Files | Key Documentation | Relevant Issues |
-| :--- | :--- | :--- | :--- |
-| **Cryptography** | `gv_core.py`, `crypto_boundary.py` | `SPECIFICATION.md` (11, 15), `THREAT_MODEL.md` | #4, #5, #10, #19, #26 |
-| **WebUI / API** | `web_server.py`, `templates/` | `SPECIFICATION.md` (7-9), `THREAT_MODEL.md` | #3, #7, #15, #21 |
-| **CLI / Main** | `main.py`, `cli.py` | `SPECIFICATION.md` (6), `OPERATIONS.md` | #4, #6, #7, #11, #29 |
-| **Biometrics / AI**| `ai_gate.py`, `face_lock.py` | `SPECIFICATION.md` (12), `THREAT_MODEL.md` | #20, #27, #28 |
-| **State / Config** | `config.py`, `state_store.py` | `STATE_RECOVERY.md`, `DEPLOYMENT.md` | #12, #13, #17, #23 |
-| **Metadata** | `metadata.py` | `SPECIFICATION.md` (10) | #24, #25 |
-| **Audit / Logs** | `audit.py`, `operations.py` | `THREAT_MODEL.md` | #2, #16, #29 |
-| **CI / Testing** | `tests/`, `.github/workflows/` | `REVIEW_VALIDATION_RECORD.md` | #9, #16 |
-
----
-
-## 3. Core Invariants
-*Preserve these unless an explicit Threat Model update is requested.*
-
-- **Local-Only**: No cloud, no telemetry, binds to `127.0.0.1`.
-- **Deniable Access**: `vault.bin` + password is insufficient without local state (`lock.bin`).
-- **Access Cues**: Object matching is a *cue*, not a cryptographic key. Never treat low-entropy biometric data as high-entropy secrets.
-- **Neutral Language**: UI/CLI must not reveal internal semantics (dummy/secret, real/fake, decoy).
-- **Hardened Actions**: Restricted actions (e.g., `brick`) require server-side checks and short-lived confirmation.
-- **Quiet Mode**: "Field Mode" must reduce casual exposure without creating detectable timing or error differences.
-
----
-
-## 4. User-Facing Language Rules
-
-| Prefer | Avoid |
-| :--- | :--- |
-| Protected entry, Local entry | Dummy, Secret, Hidden slot |
-| Object cue, Access cue | Biometric proof, Image key |
-| Key-path invalidation, Access-path clearing | Secure delete, Self-destruct, Wipe |
-| Restricted local update | Panic password, Duress password |
-| Metadata risk, Metadata reduction | Sanitization, Unbreakable, Military grade |
-
----
-
-## 5. Operational Discipline
-
-### AI Context Management
-- Load only the **minimal set of files** required for the current domain.
-- Do not initiate broad repository-wide rewrites.
-- Check `ruff` and `mypy` before submitting any Python changes.
-
-### Change & Test Strategy
-- **Surgical Edits**: Use `replace` instead of `write_file` for large files.
-- **Verification**: Always run `python3 -m unittest discover -s tests` after changes.
-- **No Regressions**: Ensure coverage stays above **70%**.
-
----
-
-## 6. Scope & Authority
-1. `docs/THREAT_MODEL.md`: Controls security assumptions and risks.
-2. `docs/SPECIFICATION.md`: Controls behavior and implementation contracts.
-3. `README.md`: Controls project summary and installation.
-4. `AGENTS.md`: This file (Development Guidance only).
-=======
 ## Purpose
 
 This file is the first context entry point for AI-assisted development in this repository.
@@ -105,6 +22,36 @@ Phantasm is a field-evaluation prototype for local-only coercion-aware storage. 
 Phantasm is research software. It is not a replacement for full-disk encryption, hardware-backed key storage, an audited classified-data handling system, organizational records-management systems, or a complete solution to compelled disclosure.
 
 Use this file to keep AI-assisted changes small, scoped, and consistent with the project boundary.
+
+---
+
+## Project Status & Roadmap
+
+### Current Focus: Hardening & Modularity
+
+The goal is to transition from a "field-evaluation prototype" to a "local appliance solution" by strengthening boundaries and improving testability.
+
+### Next Priority Issues
+
+1. **#30 Metadata Reduction**: Implement rigorous metadata scrubbing for exported payloads.
+2. **#31 Audit Integrity**: Implement hash-chaining and integrity verification for audit logs.
+3. **#32 Tamper Evidence**: Implement hardware-binding status reporting for field-evaluation units.
+4. **#33 UX Hardening**: Optimize Field Mode emergency flows for high-stress operational use.
+5. **#16 Integrity Manifest**: Implement a workflow for generating signed release manifests and SBOMs.
+6. **#27 AI Gate Decoupling**: Separate camera handling, object matching, and face lock logic.
+
+### Completed Milestones
+
+- `#8` & `#9`: CI pipeline with static analysis (`ruff`, `mypy`) and 70% coverage gate. ✅
+- `#19`: Multi-source KDF provider pipeline with hardware binding. ✅
+- `#22`: Centralized restricted action policy enforcement. ✅
+- `#23`: Typed local state store with atomic transitions. ✅
+- `#24`: Local coercion scenario matrix and restricted-flow tests. ✅
+- `#25`: Centralized user-visible strings in `strings.py`. ✅
+- `#26`: Vault cryptographic core split (KDFEngine / RecordCipher / ContainerLayout). ✅
+- `#29`: Local operations commands (`doctor`, `verify-state`) and documentation alignment. ✅
+
+---
 
 ## Project Boundary
 
@@ -125,6 +72,8 @@ Preserve this boundary in code, documentation, tests, and UI behavior:
 - target-hardware field evaluation before stronger claims
 
 Do not expand Phantasm into remote management, cloud recovery, telemetry, covert communication, censorship bypass, surveillance evasion, malware storage, offensive operations, or classified-data handling infrastructure.
+
+---
 
 ## Non-Negotiable Security Claims
 
@@ -159,6 +108,8 @@ When discussing deletion, restricted recovery, panic behavior, bricking, or emer
 
 Never describe it as guaranteed secure deletion.
 
+---
+
 ## Core Invariants
 
 Preserve these invariants unless a change explicitly updates the threat model, specification, tests, and user-facing documentation.
@@ -179,6 +130,8 @@ Preserve these invariants unless a change explicitly updates the threat model, s
 - Metadata reduction is best-effort and must not be described as complete sanitization.
 - Passing automated tests does not prove field safety.
 
+---
+
 ## Canonical Source Map
 
 Load only the relevant files for the requested change. Do not load the whole repository by default.
@@ -188,6 +141,11 @@ Load only the relevant files for the requested change. Do not load the whole rep
 Use this context for changes involving `vault.bin`, GhostVault, Argon2id, AES-GCM, salts, nonces, local access key material, span layout, record parsing, restricted recovery slots, destructive behavior, or migration:
 
 - `src/phantasm/gv_core.py`
+- `src/phantasm/crypto_boundary.py`
+- `src/phantasm/kdf_engine.py`
+- `src/phantasm/kdf_providers.py`
+- `src/phantasm/container_layout.py`
+- `src/phantasm/record_cypher.py`
 - `docs/SPECIFICATION.md`, especially sections 11 and 15
 - `docs/THREAT_MODEL.md`
 - `tests/test_gv_core.py` and related tests
@@ -197,8 +155,8 @@ Relevant issues:
 - `#4` cryptographic erase and local access-path invalidation
 - `#5` Argon2id + HKDF-SHA-256 migration
 - `#10` cryptographic module boundary and startup self-tests
-- `#19` local multi-source key derivation pipeline
-- `#26` vault cryptographic core split
+- `#19` local multi-source key derivation pipeline ✅
+- `#26` vault cryptographic core split ✅
 
 ### WebUI, API Routes, and Restricted Actions
 
@@ -206,6 +164,10 @@ Use this context for changes involving FastAPI routes, Web mutation token, restr
 
 - `src/phantasm/web_server.py`
 - `src/phantasm/templates/`
+- `src/phantasm/restricted_actions.py`
+- `src/phantasm/capabilities.py`
+- `src/phantasm/emergency_daemon.py`
+- `src/phantasm/bridge_ui.py`
 - `docs/SPECIFICATION.md`, especially sections 7, 8, and 9
 - `docs/THREAT_MODEL.md`
 - `tests/test_web_server.py` and related tests
@@ -216,9 +178,9 @@ Relevant issues:
 - `#7` authentication attempt limiting and backoff
 - `#15` WebUI security headers and CSRF review
 - `#21` deployment profiles and capability table
-- `#22` restricted action policy enforcement
-- `#24` local coercion and restricted-flow scenario matrix
-- `#25` user-visible UI and CLI strings
+- `#22` restricted action policy enforcement ✅
+- `#24` local coercion and restricted-flow scenario matrix ✅
+- `#25` user-visible UI and CLI strings ✅
 
 ### CLI Behavior
 
@@ -226,6 +188,7 @@ Use this context for changes involving `main.py`, command syntax, CLI output, co
 
 - `main.py`
 - `src/phantasm/cli.py`
+- `src/phantasm/passphrase_policy.py`
 - `docs/SPECIFICATION.md`, especially section 6
 - `docs/THREAT_MODEL.md`
 - `tests/test_cli.py` and related tests
@@ -236,8 +199,8 @@ Relevant issues:
 - `#6` access passphrase policy and strength checks
 - `#7` authentication attempt limiting and backoff
 - `#11` process hardening and secure memory best-effort support
-- `#25` user-visible UI and CLI strings
-- `#29` local operations commands and docs alignment
+- `#25` user-visible UI and CLI strings ✅
+- `#29` local operations commands and docs alignment ✅
 
 ### Object Cue, Camera Matching, and Face Lock
 
@@ -267,14 +230,16 @@ Use this context for changes involving metadata risk detection, metadata reducti
 
 Relevant issues:
 
-- `#24` scenario matrix
-- `#25` user-visible UI and CLI strings
+- `#24` scenario matrix ✅
+- `#25` user-visible UI and CLI strings ✅
+- `#30` metadata reduction for exported payloads
 
 ### Audit Logging
 
 Use this context for changes involving event logs, audit record shape, hash chains, HMACs, log export, audit filenames, event names, or audit metadata:
 
 - `src/phantasm/audit.py`
+- `src/phantasm/operations.py`
 - `src/phantasm/web_server.py` maintenance log export
 - `docs/THREAT_MODEL.md`
 - `docs/SPECIFICATION.md`
@@ -284,13 +249,16 @@ Relevant issues:
 
 - `#2` hash-chained audit log integrity checks
 - `#16` release integrity manifest and SBOM workflow
-- `#29` local operations commands and docs alignment
+- `#29` local operations commands and docs alignment ✅
+- `#31` audit integrity and hash-chaining
 
 ### Local State and Deployment Posture
 
-Use this context for changes involving `.state/`, state file names, state permissions, typed state, tmpfs, LUKS, deployment profile, appliance setup, service hardening, runtime secrets, or Raspberry Pi deployment:
+Use this context for changes involving `.state/`, state file names, state permissions, typed state, attempt limiting, tmpfs, LUKS, deployment profile, appliance setup, service hardening, runtime secrets, or Raspberry Pi deployment:
 
 - `src/phantasm/config.py`
+- `src/phantasm/state_store.py`
+- `src/phantasm/attempt_limiter.py`
 - `docs/RPI_ZERO_APPLIANCE_DEPLOYMENT.md`
 - `docs/RPI_ZERO_DEPLOYMENT.md`
 - `docs/FIELD_TEST_PROCEDURE.md`
@@ -307,8 +275,8 @@ Relevant issues:
 - `#17` optional LUKS layer
 - `#18` restricted recovery observability on target hardware
 - `#21` deployment profiles and capability table
-- `#23` typed local state store and transition checks
-- `#29` local operations commands and docs alignment
+- `#23` typed local state store and transition checks ✅
+- `#29` local operations commands and docs alignment ✅
 
 ### Testing, CI, Coverage, and Release Review
 
@@ -326,7 +294,9 @@ Use this context for changes involving tests, CI, static analysis, coverage, rel
 Relevant issues:
 
 - `#16` release integrity manifest and SBOM workflow
-- `#24` scenario matrix
+- `#24` scenario matrix ✅
+
+---
 
 ## Documentation Authority
 
@@ -340,6 +310,8 @@ When documents overlap, use this authority order:
 6. Issue descriptions describe planned work but do not override merged documentation.
 
 Do not silently resolve contradictions. If code, tests, README, specification, threat model, and issue text conflict, state the conflict and update the affected artifacts in the same change when appropriate.
+
+---
 
 ## User-Facing Language Rules
 
@@ -390,6 +362,8 @@ Avoid in normal user-facing surfaces:
 
 Internal implementation names may remain in code when necessary, but normal capture-visible behavior should stay neutral.
 
+---
+
 ## Capture-Visible Surface Rule
 
 Before changing any of the following, check whether the change reveals internal disclosure structure:
@@ -421,6 +395,8 @@ Do not reveal during normal operation:
 - original filenames where neutral filenames are required
 - whether a failure was caused by password, object cue, local state, restricted policy, or internal candidate mismatch, unless required for safe operation
 
+---
+
 ## AI Context Discipline
 
 For any AI-assisted task:
@@ -436,26 +412,7 @@ For any AI-assisted task:
 9. Do not change cryptographic behavior and UI language in the same patch unless the issue explicitly requires it.
 10. Do not modify container compatibility without a documented migration or compatibility plan.
 
-## Current Issue Priority Guidance
-
-When choosing the next work item, prefer changes that reduce future risk and AI context cost before making compatibility-sensitive cryptographic changes.
-
-Recommended order:
-
-1. Add or maintain this `AGENTS.md`.
-2. `#24` add local coercion and restricted-flow scenario matrix. ✅ Complete
-3. `#23` introduce typed local state store and transition checks. ✅ Complete
-4. `#26` split vault cryptographic core into reviewable modules. ✅ Complete
-5. `#19` design local multi-source key derivation pipeline.
-
-Completed implementations:
-- `#8` CI and static analysis gates ✅
-- `#9` coverage gating and operational procedure testing ✅
-- `#22` centralized restricted action policy ✅
-- `#25` centralized user-visible strings ✅
-- `#26` split vault cryptographic core into reviewable modules ✅
-- `#29` local operations commands and docs alignment ✅
-
+---
 
 ## Testing Expectations
 
@@ -494,6 +451,8 @@ python3 scripts/bench_kdf.py
 
 Passing automated tests do not prove field safety. They verify implementation contracts only. Field safety still requires target-hardware field testing and seizure review.
 
+---
+
 ## Change Discipline
 
 Make small, reviewable changes.
@@ -523,6 +482,8 @@ Do not:
 
 If a proposed change would improve convenience but weaken capture-visible quietness, local-only posture, or recovery safety, reject the change or require an explicit threat-model update.
 
+---
+
 ## Review Checklist for AI-Generated Changes
 
 Before finalizing an AI-generated change, verify:
@@ -541,9 +502,26 @@ Before finalizing an AI-generated change, verify:
 - Documentation claims match actual implementation.
 - Existing container compatibility is preserved or migration is explicitly documented.
 
+---
+
+## Operational Discipline
+
+### AI Context Management
+
+- Load only the **minimal set of files** required for the current domain.
+- Do not initiate broad repository-wide rewrites.
+- Check `ruff` and `mypy` before submitting any Python changes.
+
+### Change & Test Strategy
+
+- **Surgical Edits**: Prefer targeted edits over full-file rewrites for large files.
+- **Verification**: Always run `python3 -m unittest discover -s tests` after changes.
+- **No Regressions**: Ensure coverage stays above **70%**.
+
+---
+
 ## Scope of This File
 
 This file is development guidance only. It does not define user-facing product claims, legal advice, operational approval, or deployment authorization.
 
 If this file conflicts with the threat model or specification, the threat model and specification take precedence according to the Documentation Authority section.
->>>>>>> 0c73292 (Update AGENTS.md: Mark issue #26 as completed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,12 @@ The goal is to transition from a "field-evaluation prototype" to a "local applia
 
 ### Next Priority Issues
 
-1. **#30 Metadata Reduction**: Implement rigorous metadata scrubbing for exported payloads.
-2. **#31 Audit Integrity**: Implement hash-chaining and integrity verification for audit logs.
+1. **#31 Audit Integrity**: Implement hash-chaining and integrity verification for audit logs.
+2. **#32 Tamper Evidence**: Implement hardware-binding status reporting for field-evaluation units.
 3. **#32 Tamper Evidence**: Implement hardware-binding status reporting for field-evaluation units.
 4. **#33 UX Hardening**: Optimize Field Mode emergency flows for high-stress operational use.
+5. **#16 Integrity Manifest**: Implement a workflow for generating signed release manifests and SBOMs.
+6. **#27 AI Gate Decoupling**: Separate camera handling, object matching, and face lock logic.
 5. **#16 Integrity Manifest**: Implement a workflow for generating signed release manifests and SBOMs.
 6. **#27 AI Gate Decoupling**: Separate camera handling, object matching, and face lock logic.
 
@@ -45,6 +47,7 @@ The goal is to transition from a "field-evaluation prototype" to a "local applia
 - `#8` & `#9`: CI pipeline with static analysis (`ruff`, `mypy`) and 70% coverage gate. ✅
 - `#19`: Multi-source KDF provider pipeline with hardware binding. ✅
 - `#22`: Centralized restricted action policy enforcement. ✅
+- `#30`: Rigorous metadata scrubbing for JPEG, PNG, and Office ZIP formats. ✅
 - `#23`: Typed local state store with atomic transitions. ✅
 - `#24`: Local coercion scenario matrix and restricted-flow tests. ✅
 - `#25`: Centralized user-visible strings in `strings.py`. ✅

--- a/src/phantasm/metadata.py
+++ b/src/phantasm/metadata.py
@@ -1,7 +1,9 @@
 import io
 import os
 import re
+import struct
 import zipfile
+from typing import Optional
 
 METADATA_WARNING = (
     "This file may contain metadata that could reveal source, device, "
@@ -12,6 +14,32 @@ SCRUB_LIMITATION = (
     "identifier from every file format."
 )
 DETECTION_LIMITATION = "Metadata detection is best-effort."
+
+_OFFICE_EXTENSIONS = (".docx", ".xlsx", ".pptx", ".docm", ".xlsm", ".pptm")
+
+# Regex patterns for Office Open XML docProps scrubbing (bytes, case-insensitive)
+_CORE_FIELDS_RE = re.compile(
+    rb"(<(?:dc:creator|dc:title|dc:subject|dc:description"
+    rb"|cp:lastModifiedBy|cp:keywords)[^>]*>)[^<]*(</)",
+    re.IGNORECASE,
+)
+_APP_FIELDS_RE = re.compile(
+    rb"(<(?:Application|Company|Manager|Template)[^>]*>)[^<]*(</)",
+    re.IGNORECASE,
+)
+
+# JPEG APP markers to strip: APP1 (EXIF/XMP), APP13 (IPTC/Photoshop IRB)
+_JPEG_STRIP_MARKERS = frozenset([0xE1, 0xED])
+
+# PNG chunk types that carry metadata
+_PNG_METADATA_CHUNKS = frozenset([b"tEXt", b"iTXt", b"zTXt", b"eXIf", b"tIME"])
+_PNG_CHUNK_DESCRIPTIONS = {
+    b"tEXt": "embedded text metadata",
+    b"iTXt": "embedded international text metadata",
+    b"zTXt": "embedded compressed text metadata",
+    b"eXIf": "embedded EXIF metadata",
+    b"tIME": "image timestamp",
+}
 
 
 def metadata_risk_report(filename, data):
@@ -46,6 +74,9 @@ def metadata_risk_report(filename, data):
             },
         )
 
+    if _looks_like_png(data):
+        risks.extend(_png_risks(data))
+
     if _looks_like_zip(data):
         risks.extend(_office_zip_risks(data))
 
@@ -70,23 +101,42 @@ def metadata_risk_report(filename, data):
 
 def scrub_metadata(filename, data):
     lower_name = os.path.basename(filename or "").lower()
+
+    if _looks_like_jpeg(data):
+        result = _scrub_jpeg(data)
+        if result is not None:
+            return {
+                "success": True,
+                "filename": "metadata_reduced_payload.bin",
+                "data": result,
+                "message": "Best-effort metadata removal completed.",
+                "limitation": SCRUB_LIMITATION,
+            }
+
+    if _looks_like_png(data):
+        result = _scrub_png(data)
+        if result is not None:
+            return {
+                "success": True,
+                "filename": "metadata_reduced_payload.bin",
+                "data": result,
+                "message": "Best-effort metadata removal completed.",
+                "limitation": SCRUB_LIMITATION,
+            }
+
+    if _looks_like_zip(data) and lower_name.endswith(_OFFICE_EXTENSIONS):
+        result = _scrub_office_zip(data)
+        if result is not None:
+            return {
+                "success": True,
+                "filename": "metadata_reduced_payload.bin",
+                "data": result,
+                "message": "Best-effort metadata removal completed.",
+                "limitation": SCRUB_LIMITATION,
+            }
+
     if _looks_like_text(data) and lower_name.endswith((".txt", ".md", ".csv", ".log")):
-        text = data.decode("utf-8", errors="ignore")
-        scrubbed = re.sub(
-            r"(/Users/|/home/|[A-Za-z]:\\Users\\)[^\s]+", "[local-path]", text
-        )
-        scrubbed = re.sub(
-            r"(?im)^(author|creator|modified by|last saved by)\s*[:=].*$",
-            r"\1: [removed]",
-            scrubbed,
-        )
-        return {
-            "success": True,
-            "filename": "metadata_reduced_payload.bin",
-            "data": scrubbed.encode("utf-8"),
-            "message": "Best-effort metadata removal completed.",
-            "limitation": SCRUB_LIMITATION,
-        }
+        return _scrub_text(data)
 
     return {
         "success": False,
@@ -103,6 +153,10 @@ def _looks_like_jpeg(data):
 
 def _looks_like_zip(data):
     return data.startswith(b"PK\x03\x04")
+
+
+def _looks_like_png(data):
+    return data.startswith(b"\x89PNG\r\n\x1a\n")
 
 
 def _looks_like_text(data):
@@ -123,6 +177,25 @@ def _scan_ascii_tokens(data, risks, token_map):
     for token, description in token_map.items():
         if token in sample:
             risks.append(description)
+
+
+def _png_risks(data):
+    risks: list[str] = []
+    pos = 8  # skip PNG signature
+    limit = min(len(data), 262144)
+    while pos + 8 <= limit:
+        try:
+            chunk_len = struct.unpack(">I", data[pos : pos + 4])[0]
+            chunk_type = data[pos + 4 : pos + 8]
+        except struct.error:
+            break
+        desc = _PNG_CHUNK_DESCRIPTIONS.get(chunk_type)
+        if desc and desc not in risks:
+            risks.append(desc)
+        pos += 12 + chunk_len
+        if chunk_type == b"IEND":
+            break
+    return risks
 
 
 def _office_zip_risks(data):
@@ -151,7 +224,105 @@ def _office_zip_risks(data):
     return risks
 
 
+def _scrub_jpeg(data: bytes) -> Optional[bytes]:
+    """Strip APP1 (EXIF/XMP) and APP13 (IPTC) markers. Returns None on parse error."""
+    try:
+        out = bytearray(b"\xff\xd8")
+        pos = 2
+        n = len(data)
+        while pos + 3 < n:
+            if data[pos] != 0xFF:
+                out += data[pos:]
+                break
+            marker = data[pos + 1]
+            if marker == 0xDA:  # SOS: copy everything from here to end verbatim
+                out += data[pos:]
+                break
+            if marker == 0xD9:  # EOI
+                out += b"\xff\xd9"
+                break
+            if 0xD0 <= marker <= 0xD7:  # RST0–RST7: standalone, no length field
+                out += bytes([0xFF, marker])
+                pos += 2
+                continue
+            if pos + 4 > n:
+                break
+            seg_len = struct.unpack(">H", data[pos + 2 : pos + 4])[0]
+            seg_end = pos + 2 + seg_len
+            if marker not in _JPEG_STRIP_MARKERS:
+                out += data[pos:seg_end]
+            pos = seg_end
+        return bytes(out)
+    except Exception:
+        return None
+
+
+def _scrub_png(data: bytes) -> Optional[bytes]:
+    """Strip metadata chunks (tEXt, iTXt, zTXt, eXIf, tIME). Returns None on parse error."""
+    _PNG_SIG = b"\x89PNG\r\n\x1a\n"
+    try:
+        out = bytearray(_PNG_SIG)
+        pos = 8
+        n = len(data)
+        while pos + 8 <= n:
+            chunk_len = struct.unpack(">I", data[pos : pos + 4])[0]
+            chunk_type = data[pos + 4 : pos + 8]
+            chunk_end = pos + 12 + chunk_len
+            if chunk_end > n:
+                break
+            if chunk_type not in _PNG_METADATA_CHUNKS:
+                out += data[pos:chunk_end]
+            pos = chunk_end
+            if chunk_type == b"IEND":
+                break
+        return bytes(out)
+    except Exception:
+        return None
+
+
+def _scrub_office_zip(data: bytes) -> Optional[bytes]:
+    """Blank sensitive author/title fields in docProps/core.xml and docProps/app.xml."""
+    try:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(io.BytesIO(data)) as zin, zipfile.ZipFile(buf, "w") as zout:
+            for info in zin.infolist():
+                content = zin.read(info.filename)
+                if info.filename == "docProps/core.xml":
+                    content = _CORE_FIELDS_RE.sub(rb"\1\2", content)
+                elif info.filename == "docProps/app.xml":
+                    content = _APP_FIELDS_RE.sub(rb"\1\2", content)
+                zout.writestr(info.filename, content)
+        return buf.getvalue()
+    except Exception:
+        return None
+
+
+def _scrub_text(data: bytes) -> dict:
+    text = data.decode("utf-8", errors="ignore")
+    scrubbed = re.sub(
+        r"(/Users/|/home/|[A-Za-z]:\\Users\\)[^\s]+", "[local-path]", text
+    )
+    scrubbed = re.sub(
+        r"(?im)^(author|creator|modified by|last saved by)\s*[:=].*$",
+        r"\1: [removed]",
+        scrubbed,
+    )
+    return {
+        "success": True,
+        "filename": "metadata_reduced_payload.bin",
+        "data": scrubbed.encode("utf-8"),
+        "message": "Best-effort metadata removal completed.",
+        "limitation": SCRUB_LIMITATION,
+    }
+
+
 def _scrub_supported(lower_name, data):
+    if _looks_like_jpeg(data):
+        return True
+    if _looks_like_png(data):
+        return True
+    if _looks_like_zip(data) and lower_name.endswith(_OFFICE_EXTENSIONS):
+        return True
     return _looks_like_text(data) and lower_name.endswith(
         (".txt", ".md", ".csv", ".log")
     )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,6 +1,10 @@
+import io
 import os
+import struct
 import sys
 import unittest
+import zipfile
+import zlib
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(ROOT, "src"))
@@ -8,7 +12,52 @@ sys.path.insert(0, os.path.join(ROOT, "src"))
 from phantasm.metadata import metadata_risk_report, scrub_metadata
 
 
-class MetadataTests(unittest.TestCase):
+def _make_jpeg_with_exif():
+    """Minimal JPEG containing an APP1 (EXIF) segment with GPS data."""
+    exif_payload = b"Exif\x00\x00II\x2a\x00GPS location info"
+    app1_len = struct.pack(">H", 2 + len(exif_payload))
+    app1 = b"\xff\xe1" + app1_len + exif_payload
+    sos_payload = b"\x00\x08\x01\x01\x00\x00\x3f\x00"
+    sos_len = struct.pack(">H", 2 + len(sos_payload))
+    sos = b"\xff\xda" + sos_len + sos_payload + b"\xfe\xdc\xba"
+    return b"\xff\xd8" + app1 + sos + b"\xff\xd9"
+
+
+def _make_png_with_text():
+    """Minimal 1x1 RGB PNG with a tEXt metadata chunk."""
+
+    def chunk(ctype, data=b""):
+        length = struct.pack(">I", len(data))
+        crc = struct.pack(">I", zlib.crc32(ctype + data) & 0xFFFFFFFF)
+        return length + ctype + data + crc
+
+    ihdr = chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))
+    text = chunk(b"tEXt", b"Author\x00Alice")
+    idat = chunk(b"IDAT", zlib.compress(b"\x00\xff\x00\x00"))
+    iend = chunk(b"IEND")
+    return b"\x89PNG\r\n\x1a\n" + ihdr + text + idat + iend
+
+
+def _make_docx_with_author():
+    """Minimal DOCX-like ZIP with docProps/core.xml containing author fields."""
+    core_xml = (
+        b'<?xml version="1.0" encoding="UTF-8"?>'
+        b'<cp:coreProperties'
+        b' xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"'
+        b' xmlns:dc="http://purl.org/dc/elements/1.1/">'
+        b"<dc:creator>Alice Smith</dc:creator>"
+        b"<cp:lastModifiedBy>Bob Jones</cp:lastModifiedBy>"
+        b"<dc:title>Secret Document</dc:title>"
+        b"</cp:coreProperties>"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("docProps/core.xml", core_xml)
+        zf.writestr("[Content_Types].xml", b'<?xml version="1.0"?><Types/>')
+    return buf.getvalue()
+
+
+class MetadataRiskReportTests(unittest.TestCase):
     def test_text_path_and_author_metadata_are_reported(self):
         data = b"author: Alice\nsource path: /Users/alice/interview.txt\n"
         report = metadata_risk_report("interview.txt", data)
@@ -18,7 +67,41 @@ class MetadataTests(unittest.TestCase):
         self.assertTrue(report["scrub_supported"])
         self.assertIn("best-effort", report["limitation"])
 
-    def test_metadata_scrub_returns_neutral_filename_without_overwriting_original(self):
+    def test_jpeg_exif_risk_is_reported(self):
+        data = _make_jpeg_with_exif()
+        report = metadata_risk_report("photo.jpg", data)
+        self.assertIn("embedded image metadata", report["findings"])
+        self.assertIn("possible location metadata", report["findings"])
+        self.assertTrue(report["scrub_supported"])
+
+    def test_png_text_chunk_risk_is_reported(self):
+        data = _make_png_with_text()
+        report = metadata_risk_report("image.png", data)
+        self.assertIn("embedded text metadata", report["findings"])
+        self.assertTrue(report["scrub_supported"])
+
+    def test_office_zip_author_risk_is_reported(self):
+        data = _make_docx_with_author()
+        report = metadata_risk_report("report.docx", data)
+        self.assertIn("document author metadata", report["findings"])
+        self.assertTrue(report["scrub_supported"])
+
+    def test_pdf_author_risk_reported_but_scrub_not_supported(self):
+        data = b"%PDF-1.4 /Author Alice /Title Classified"
+        report = metadata_risk_report("document.pdf", data)
+        self.assertIn("document author metadata", report["findings"])
+        self.assertFalse(report["scrub_supported"])
+
+    def test_clean_file_without_identifying_content_has_low_risk(self):
+        # No filename so "original filename may reveal context" is not added
+        data = b"Hello, world.\n"
+        report = metadata_risk_report("", data)
+        self.assertEqual(report["risk"], "low")
+        self.assertEqual(report["findings"], [])
+
+
+class MetadataScrubTests(unittest.TestCase):
+    def test_text_scrub_removes_paths_and_authors(self):
         data = b"author: Alice\npath=/home/alice/source.txt\nbody\n"
         result = scrub_metadata("revealing-name.txt", data)
         self.assertTrue(result["success"])
@@ -26,11 +109,85 @@ class MetadataTests(unittest.TestCase):
         self.assertNotEqual(result["data"], data)
         self.assertIn("best-effort", result["limitation"].lower())
 
-    def test_unsupported_scrub_fails_safely(self):
-        result = scrub_metadata("image.jpg", b"\xff\xd8Exif\x00\x00GPS")
+    def test_jpeg_exif_segment_is_stripped(self):
+        data = _make_jpeg_with_exif()
+        self.assertIn(b"Exif\x00\x00", data)
+        result = scrub_metadata("photo.jpg", data)
+        self.assertTrue(result["success"])
+        self.assertNotIn(b"Exif\x00\x00", result["data"])
+        self.assertNotIn(b"GPS location", result["data"])
+        self.assertTrue(result["data"].startswith(b"\xff\xd8"))
+        self.assertEqual(result["filename"], "metadata_reduced_payload.bin")
+        self.assertIn("best-effort", result["limitation"].lower())
+
+    def test_jpeg_soi_and_image_data_preserved(self):
+        data = _make_jpeg_with_exif()
+        result = scrub_metadata("photo.jpg", data)
+        self.assertTrue(result["success"])
+        self.assertIn(b"\xff\xda", result["data"])  # SOS
+        self.assertIn(b"\xff\xd9", result["data"])  # EOI
+
+    def test_png_text_chunk_is_stripped(self):
+        data = _make_png_with_text()
+        result = scrub_metadata("image.png", data)
+        self.assertTrue(result["success"])
+        self.assertNotIn(b"tEXt", result["data"])
+        self.assertNotIn(b"Author", result["data"])
+        self.assertTrue(result["data"].startswith(b"\x89PNG"))
+        self.assertEqual(result["filename"], "metadata_reduced_payload.bin")
+
+    def test_png_image_chunks_preserved(self):
+        data = _make_png_with_text()
+        result = scrub_metadata("image.png", data)
+        self.assertTrue(result["success"])
+        self.assertIn(b"IHDR", result["data"])
+        self.assertIn(b"IDAT", result["data"])
+        self.assertIn(b"IEND", result["data"])
+
+    def test_office_zip_author_fields_blanked(self):
+        data = _make_docx_with_author()
+        result = scrub_metadata("report.docx", data)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["filename"], "metadata_reduced_payload.bin")
+        with zipfile.ZipFile(io.BytesIO(result["data"])) as zf:
+            core = zf.read("docProps/core.xml")
+        self.assertNotIn(b"Alice Smith", core)
+        self.assertNotIn(b"Bob Jones", core)
+        self.assertNotIn(b"Secret Document", core)
+
+    def test_office_zip_structure_preserved(self):
+        data = _make_docx_with_author()
+        result = scrub_metadata("report.docx", data)
+        self.assertTrue(result["success"])
+        with zipfile.ZipFile(io.BytesIO(result["data"])) as zf:
+            names = zf.namelist()
+        self.assertIn("docProps/core.xml", names)
+        self.assertIn("[Content_Types].xml", names)
+
+    def test_pdf_scrub_not_supported(self):
+        data = b"%PDF-1.4 /Author Alice /Title Classified"
+        result = scrub_metadata("document.pdf", data)
         self.assertFalse(result["success"])
         self.assertEqual(result["data"], b"")
         self.assertIn("not supported", result["message"])
+
+    def test_unknown_binary_scrub_not_supported(self):
+        result = scrub_metadata("binary.bin", bytes(range(256)))
+        self.assertFalse(result["success"])
+        self.assertEqual(result["data"], b"")
+
+    def test_scrub_result_always_has_limitation_field(self):
+        cases = [
+            ("photo.jpg", _make_jpeg_with_exif()),
+            ("image.png", _make_png_with_text()),
+            ("report.docx", _make_docx_with_author()),
+            ("notes.txt", b"author: Alice\n"),
+            ("doc.pdf", b"%PDF-1.4 /Author Alice"),
+        ]
+        for filename, data in cases:
+            with self.subTest(filename=filename):
+                result = scrub_metadata(filename, data)
+                self.assertIn("limitation", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Fix committed merge conflict in `AGENTS.md`**: conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) were accidentally committed to `main`. Resolved by adopting the detailed version as the base, integrating the Quick Start section from the compact version, and updating the roadmap to reflect current issue status.
- **Implement issue #30 — Metadata Reduction**: extend `scrub_metadata()` to support JPEG, PNG, and Office ZIP formats beyond the previous text-only implementation.
- **Update `AGENTS.md` Canonical Source Map**: add new modules introduced in issues #19 and #26 (`kdf_engine.py`, `kdf_providers.py`, `container_layout.py`, `record_cypher.py`, `attempt_limiter.py`, etc.) and mark completed issues (#19, #30).

## Changes

### `AGENTS.md`
- Resolve merge conflict between HEAD (compact/structured) and `0c73292` (detailed) versions
- Adopt detailed version: preserves security-critical sections absent from the compact version — Non-Negotiable Security Claims, Capture-Visible Surface Rule, Change Discipline (20+ prohibitions), Review Checklist for AI-Generated Changes
- Integrate Quick Start (5-step onboarding) and Roadmap from compact version
- Update Canonical Source Map with all modules added since last edit
- Mark issues #19 and #30 as complete; update Next Priority Issues list

### `src/phantasm/metadata.py`
- **JPEG**: strip APP1 (EXIF/XMP) and APP13 (IPTC/Photoshop IRB) markers by parsing the JPEG segment structure; SOI, APP0, and image data are preserved
- **PNG**: strip metadata chunks (`tEXt`, `iTXt`, `zTXt`, `eXIf`, `tIME`) while preserving `IHDR`, `IDAT`, `IEND`, and all other image chunks
- **Office ZIP** (`.docx`, `.xlsx`, `.pptx`, `.docm`, `.xlsm`, `.pptm`): blank sensitive fields in `docProps/core.xml` (`dc:creator`, `dc:title`, `dc:subject`, `cp:lastModifiedBy`, `cp:keywords`) and `docProps/app.xml` (`Application`, `Company`, `Manager`, `Template`) using regex substitution; ZIP structure and all other entries are preserved
- Add PNG metadata risk detection (`_looks_like_png`, `_png_risks`) integrated into `metadata_risk_report()`
- Update `_scrub_supported()` to reflect new format coverage
- All scrubbers return `None` on parse error and fall through to the "not supported" response — unsupported types continue to fail safely per spec

### `tests/test_metadata.py`
- Expand from 3 tests to 16 tests
- Add detection tests for JPEG, PNG, Office ZIP, and PDF
- Add scrubbing tests verifying metadata removal, neutral output filename, structure preservation, and safe failure for unsupported types

## Test plan

- [x] `python3 -m unittest tests.test_metadata -v` — all 16 tests pass
- [x] No regressions in other stdlib-only test modules (`test_state_store`, `test_strings`, `test_passphrase_policy`, etc.)
- [ ] CI: `ruff check`, `mypy`, coverage gate (requires full dependency install)

## Invariants preserved

- Metadata reduction is described as best-effort throughout; no completeness claims added
- Output filename remains neutral (`metadata_reduced_payload.bin`)
- No disk writes during metadata inspection (in-memory processing only)
- PDF and other unsupported formats continue to fail safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)