### PR TITLE
Improve audit integrity verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .ruff_cache/
 .venv/
 venv/
+.claude/
 .coverage
 *.egg-info/
 
@@ -26,4 +27,3 @@ dump.txt
 
 !requirements.txt
 !MIO _Logo.png
-

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -28,6 +28,8 @@ python3 main.py verify-audit-log
 
 If audit logging is disabled or no audit log is present, the command reports `not_enabled`. This is not a failure by itself because audit logging is disabled by default for field deployments.
 
+When audit records include integrity fields, `verify-audit-log` also checks the local verifier material in `.state/events.auth` and reports attention if the verifier material is missing or if record integrity does not validate.
+
 Summarize local health:
 
 ```bash

--- a/docs/STATE_RECOVERY.md
+++ b/docs/STATE_RECOVERY.md
@@ -30,6 +30,8 @@ python3 main.py verify-audit-log
 python3 main.py export-redacted-log --out review-events.jsonl
 ```
 
+`verify-audit-log` checks the local audit chain and the verifier material used for local integrity review.
+
 The redacted export is intended for review. It should not include local paths, file labels, object-cue features, face-lock templates, or password-derived data.
 
 ## Field Review

--- a/main.py
+++ b/main.py
@@ -1,12 +1,10 @@
 import os
 import sys
 
-
 ROOT = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from phantasm.cli import main
-
 
 if __name__ == "__main__":
     main()

--- a/src/phantasm/metadata.py
+++ b/src/phantasm/metadata.py
@@ -230,28 +230,36 @@ def _scrub_jpeg(data: bytes) -> Optional[bytes]:
         out = bytearray(b"\xff\xd8")
         pos = 2
         n = len(data)
+        saw_terminal_marker = False
         while pos + 3 < n:
             if data[pos] != 0xFF:
-                out += data[pos:]
-                break
+                return None
             marker = data[pos + 1]
             if marker == 0xDA:  # SOS: copy everything from here to end verbatim
                 out += data[pos:]
+                saw_terminal_marker = True
                 break
             if marker == 0xD9:  # EOI
                 out += b"\xff\xd9"
+                saw_terminal_marker = True
                 break
             if 0xD0 <= marker <= 0xD7:  # RST0–RST7: standalone, no length field
                 out += bytes([0xFF, marker])
                 pos += 2
                 continue
             if pos + 4 > n:
-                break
+                return None
             seg_len = struct.unpack(">H", data[pos + 2 : pos + 4])[0]
+            if seg_len < 2:
+                return None
             seg_end = pos + 2 + seg_len
+            if seg_end > n:
+                return None
             if marker not in _JPEG_STRIP_MARKERS:
                 out += data[pos:seg_end]
             pos = seg_end
+        if not saw_terminal_marker:
+            return None
         return bytes(out)
     except Exception:
         return None

--- a/src/phantasm/operations.py
+++ b/src/phantasm/operations.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 from dataclasses import asdict, dataclass
 
+from .audit import verify_log_integrity
 from .config import (
+    AUDIT_AUTH_NAME,
     AUDIT_LOG_NAME,
     STATE_BLOB_NAME,
     STATE_KEY_NAME,
@@ -139,12 +140,17 @@ def _audit_path(path: str | None = None) -> str:
     return path or os.path.join(state_dir(), AUDIT_LOG_NAME)
 
 
-def _canonical_record(record: dict):
-    return json.dumps(record, sort_keys=True, separators=(",", ":")).encode("utf-8")
+def _audit_auth_path(path: str | None = None, audit_path: str | None = None) -> str:
+    if path:
+        return path
+    if audit_path:
+        return os.path.join(os.path.dirname(audit_path), AUDIT_AUTH_NAME)
+    return os.path.join(state_dir(), AUDIT_AUTH_NAME)
 
 
-def verify_audit_log(path: str | None = None):
+def verify_audit_log(path: str | None = None, auth_path: str | None = None):
     path = _audit_path(path)
+    auth_path = _audit_auth_path(auth_path, audit_path=path)
     checks: list[OperationCheck] = []
 
     if not os.path.exists(path):
@@ -197,26 +203,28 @@ def verify_audit_log(path: str | None = None):
         if _previous_hash_field(record) and _entry_hash_field(record)
     ]
     if chain_records and len(chain_records) == len(records):
-        expected_prev = "sha256:GENESIS"
-        chain_ok = True
-        for record in chain_records:
-            if record.get(_previous_hash_field(record)) != expected_prev:
-                chain_ok = False
-                break
-            event_hash = record.get(_entry_hash_field(record))
-            data = _entry_hashable_record(record)
-            expected_hash = (
-                "sha256:" + hashlib.sha256(_canonical_record(data)).hexdigest()
+        auth_present = os.path.exists(auth_path)
+        checks.append(
+            OperationCheck(
+                "audit_verifier",
+                STATUS_READY if auth_present else STATUS_ATTENTION,
+                (
+                    "audit verifier material is present"
+                    if auth_present
+                    else "audit verifier material is not present"
+                ),
             )
-            if event_hash != expected_hash:
-                chain_ok = False
-                break
-            expected_prev = event_hash
+        )
+        integrity_ok, _errors = verify_log_integrity(path=path, auth_path=auth_path)
         checks.append(
             OperationCheck(
                 "audit_chain",
-                STATUS_READY if chain_ok else STATUS_ATTENTION,
-                "audit chain verification completed",
+                STATUS_READY if integrity_ok else STATUS_ATTENTION,
+                (
+                    "audit integrity verification completed"
+                    if integrity_ok
+                    else "audit integrity verification requires attention"
+                ),
             )
         )
     else:
@@ -245,14 +253,6 @@ def _entry_hash_field(record):
     if "event_hash" in record:
         return "event_hash"
     return None
-
-
-def _entry_hashable_record(record):
-    return {
-        key: value
-        for key, value in record.items()
-        if key not in {"entry_hash", "event_hash", "hmac_sha256"}
-    }
 
 
 def redact_audit_record(record: dict):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -127,6 +127,13 @@ class MetadataScrubTests(unittest.TestCase):
         self.assertIn(b"\xff\xda", result["data"])  # SOS
         self.assertIn(b"\xff\xd9", result["data"])  # EOI
 
+    def test_malformed_jpeg_scrub_not_supported(self):
+        data = b"\xff\xd8Exif\x00\x00GPS"
+        result = scrub_metadata("photo.jpg", data)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["data"], b"")
+        self.assertIn("not supported", result["message"])
+
     def test_png_text_chunk_is_stripped(self):
         data = _make_png_with_text()
         result = scrub_metadata("image.png", data)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -10,8 +10,9 @@ from unittest import mock
 ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
-from phantasm import cli
+from phantasm import audit, cli
 from phantasm.config import (
+    AUDIT_AUTH_NAME,
     AUDIT_LOG_NAME,
     STATE_BLOB_NAME,
     STATE_KEY_NAME,
@@ -68,6 +69,44 @@ class LocalOperationTests(unittest.TestCase):
         rendered = json.dumps(report)
         self.assertIn("audit records parse as JSON lines", rendered)
         self.assertIn("audit chain data is not recorded", rendered)
+
+    def test_verify_audit_log_reports_missing_verifier_material(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(
+                os.environ, {"PHANTASM_STATE_DIR": tmpdir, "PHANTASM_AUDIT": "1"}
+            ):
+                audit.audit_event("payload_stored", bytes=10)
+
+            os.remove(os.path.join(tmpdir, AUDIT_AUTH_NAME))
+            report = verify_audit_log(os.path.join(tmpdir, AUDIT_LOG_NAME))
+
+            self.assertEqual(report["status"], "attention")
+            rendered = json.dumps(report)
+            self.assertIn("audit verifier material is not present", rendered)
+            self.assertIn("audit integrity verification requires attention", rendered)
+
+    def test_verify_audit_log_reports_integrity_tamper(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(
+                os.environ, {"PHANTASM_STATE_DIR": tmpdir, "PHANTASM_AUDIT": "1"}
+            ):
+                audit.audit_event("payload_stored", bytes=10)
+                audit.audit_event("payload_retrieved", bytes=10)
+
+            audit_path = os.path.join(tmpdir, AUDIT_LOG_NAME)
+            with open(audit_path, "r", encoding="utf-8") as handle:
+                records = [json.loads(line) for line in handle]
+            records[1]["bytes"] = 11
+            with open(audit_path, "w", encoding="utf-8") as handle:
+                for record in records:
+                    handle.write(json.dumps(record) + "\n")
+
+            report = verify_audit_log(audit_path)
+
+            self.assertEqual(report["status"], "attention")
+            rendered = json.dumps(report)
+            self.assertIn("audit verifier material is present", rendered)
+            self.assertIn("audit integrity verification requires attention", rendered)
 
     def test_verify_audit_log_reports_parse_error(self):
         tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
## Summary
- route audit verification through the full integrity checker, including local verifier material checks
- add regression coverage for verifier loss, tampered audit records, and malformed JPEG scrub handling
- ignore the local .claude workspace directory in git

## Testing
- .venv/bin/python -m unittest discover -s tests
- .venv/bin/ruff check .
- .venv/bin/mypy src