### PR TITLE
Add hardware binding status reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-dev.txt
-          python -m pip install -e .
 
       - name: Check formatting with black
         run: python -m black --check src tests scripts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,19 +33,16 @@ The goal is to transition from a "field-evaluation prototype" to a "local applia
 
 ### Next Priority Issues
 
-1. **#31 Audit Integrity**: Implement hash-chaining and integrity verification for audit logs.
-2. **#32 Tamper Evidence**: Implement hardware-binding status reporting for field-evaluation units.
-3. **#32 Tamper Evidence**: Implement hardware-binding status reporting for field-evaluation units.
-4. **#33 UX Hardening**: Optimize Field Mode emergency flows for high-stress operational use.
-5. **#16 Integrity Manifest**: Implement a workflow for generating signed release manifests and SBOMs.
-6. **#27 AI Gate Decoupling**: Separate camera handling, object matching, and face lock logic.
-5. **#16 Integrity Manifest**: Implement a workflow for generating signed release manifests and SBOMs.
-6. **#27 AI Gate Decoupling**: Separate camera handling, object matching, and face lock logic.
+1. **#33 UX Hardening**: Optimize Field Mode emergency flows for high-stress operational use.
+2. **#16 Integrity Manifest**: Implement a workflow for generating signed release manifests and SBOMs.
+3. **#27 AI Gate Decoupling**: Separate camera handling, object matching, and face lock logic.
 
 ### Completed Milestones
 
 - `#8` & `#9`: CI pipeline with static analysis (`ruff`, `mypy`) and 70% coverage gate. ✅
 - `#19`: Multi-source KDF provider pipeline with hardware binding. ✅
+- `#31`: Audit log hash-chaining and integrity verification. ✅
+- `#32`: Hardware-binding status reporting for field-evaluation units. ✅
 - `#22`: Centralized restricted action policy enforcement. ✅
 - `#30`: Rigorous metadata scrubbing for JPEG, PNG, and Office ZIP formats. ✅
 - `#23`: Typed local state store with atomic transitions. ✅

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -12,6 +12,8 @@ Check local state readiness:
 python3 main.py verify-state
 ```
 
+On hosts that expose device-binding inputs, `verify-state` also reports whether local hardware binding material is available and whether a supplemental key-material source has been configured.
+
 Expected neutral output shape:
 
 ```text

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -196,6 +196,8 @@ Mutating endpoints require `X-Phantasm-Token`. Sensitive endpoints also require 
 
 The normal UI must not display internal entry labels, internal retrieval order, or restricted local-state behavior after retrieval.
 
+Detailed maintenance diagnostics may include neutral hardware-binding availability fields after restricted confirmation or when Field Mode is not suppressing detail.
+
 Optional UI face lock is enabled with `PHANTASM_UI_FACE_LOCK=1`. It gates access to normal WebUI routes with a short-lived local session cookie. Face templates are encrypted in the runtime state directory. This lock is not used in Argon2id input and does not participate in vault encryption or retrieval.
 
 First-time face enrollment is disabled unless the WebUI process is started with `PHANTASM_UI_FACE_ENROLL=1` or a valid `.state/face.enroll` request exists. The setup flag is intended for device provisioning only. The enrollment request is created by `python3 main.py reset-face-lock`, is checked when `/ui-lock` is reloaded, and is removed after successful enrollment.

--- a/src/phantasm/kdf_providers.py
+++ b/src/phantasm/kdf_providers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import getpass
 import os
 from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass
 
 
 class SecretProvider(ABC):
@@ -65,3 +66,31 @@ class PromptSecretProvider(SecretProvider):
             if val:
                 self._cache = val.encode("utf-8")
         return self._cache
+
+
+@dataclass(frozen=True)
+class HardwareBindingStatus:
+    host_supported: bool
+    device_binding_available: bool
+    external_binding_configured: bool
+
+    def to_dict(self):
+        return asdict(self)
+
+
+def hardware_binding_status(path: str = "/proc/cpuinfo") -> HardwareBindingStatus:
+    provider = HardwareBindingProvider(path=path)
+    file_path = os.environ.get("PHANTASM_HARDWARE_SECRET_FILE", "")
+    external_binding_configured = any(
+        (
+            bool(os.environ.get("PHANTASM_HARDWARE_SECRET")),
+            bool(file_path and os.path.exists(file_path)),
+            os.environ.get("PHANTASM_HARDWARE_SECRET_PROMPT") == "1",
+        )
+    )
+    device_binding = provider.get_secret()
+    return HardwareBindingStatus(
+        host_supported=os.path.exists(path),
+        device_binding_available=bool(device_binding),
+        external_binding_configured=external_binding_configured,
+    )

--- a/src/phantasm/metadata.py
+++ b/src/phantasm/metadata.py
@@ -292,7 +292,10 @@ def _scrub_office_zip(data: bytes) -> Optional[bytes]:
     """Blank sensitive author/title fields in docProps/core.xml and docProps/app.xml."""
     try:
         buf = io.BytesIO()
-        with zipfile.ZipFile(io.BytesIO(data)) as zin, zipfile.ZipFile(buf, "w") as zout:
+        with (
+            zipfile.ZipFile(io.BytesIO(data)) as zin,
+            zipfile.ZipFile(buf, "w") as zout,
+        ):
             for info in zin.infolist():
                 content = zin.read(info.filename)
                 if info.filename == "docProps/core.xml":

--- a/src/phantasm/operations.py
+++ b/src/phantasm/operations.py
@@ -15,6 +15,7 @@ from .config import (
     VAULT_KEY_NAME,
     state_dir,
 )
+from .kdf_providers import hardware_binding_status
 from .state_store import LocalStateStore
 
 STATUS_READY = "ready"
@@ -130,6 +131,48 @@ def verify_state(base_dir: str | None = None, vault_path: str = "vault.bin"):
                 "local container is present"
                 if os.path.exists(vault_path)
                 else "local container is not initialized"
+            ),
+        )
+    )
+
+    binding_status = hardware_binding_status()
+    if not binding_status.host_supported:
+        checks.append(
+            OperationCheck(
+                "hardware_binding",
+                STATUS_NOT_ENABLED,
+                "device binding status is not available on this host",
+            )
+        )
+    else:
+        checks.append(
+            OperationCheck(
+                "hardware_binding",
+                (
+                    STATUS_READY
+                    if binding_status.device_binding_available
+                    else STATUS_ATTENTION
+                ),
+                (
+                    "device binding material is available"
+                    if binding_status.device_binding_available
+                    else "device binding material is not present"
+                ),
+            )
+        )
+
+    checks.append(
+        OperationCheck(
+            "external_binding",
+            (
+                STATUS_READY
+                if binding_status.external_binding_configured
+                else STATUS_NOT_ENABLED
+            ),
+            (
+                "supplemental key material source is configured"
+                if binding_status.external_binding_configured
+                else "supplemental key material source is not configured"
             ),
         )
     )

--- a/src/phantasm/web_server.py
+++ b/src/phantasm/web_server.py
@@ -40,6 +40,7 @@ from .config import (
 from .crypto_boundary import ensure_crypto_self_tests
 from .face_lock import face_lock
 from .gv_core import GhostVault
+from .kdf_providers import hardware_binding_status
 from .metadata import metadata_risk_report, scrub_metadata
 from .passphrase_policy import check_store_passphrases
 from .restricted_actions import (
@@ -958,9 +959,11 @@ async def diagnostics(request: Request):
     if (not field_mode_enabled() or restricted) and capability_enabled(
         Capability.DIAGNOSTICS_DETAIL
     ):
+        binding_status = hardware_binding_status().to_dict()
         data.update(
             {
                 "sensor_link": status_data["object_state"] != "none",
+                "hardware_binding": binding_status,
                 "state_directory": state_dir(),
                 "storage_node": _deceptive_path(state_dir()),
                 "audit_enabled": os.environ.get("PHANTASM_AUDIT", "0").lower()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -42,7 +42,7 @@ def _make_docx_with_author():
     """Minimal DOCX-like ZIP with docProps/core.xml containing author fields."""
     core_xml = (
         b'<?xml version="1.0" encoding="UTF-8"?>'
-        b'<cp:coreProperties'
+        b"<cp:coreProperties"
         b' xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"'
         b' xmlns:dc="http://purl.org/dc/elements/1.1/">'
         b"<dc:creator>Alice Smith</dc:creator>"

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -18,6 +18,7 @@ from phantasm.config import (
     STATE_KEY_NAME,
     VAULT_KEY_NAME,
 )
+from phantasm.kdf_providers import HardwareBindingStatus
 from phantasm.operations import (
     export_redacted_log,
     verify_audit_log,
@@ -51,9 +52,48 @@ class LocalOperationTests(unittest.TestCase):
         with open(vault_path, "wb") as handle:
             handle.write(b"vault")
 
-        report = verify_state(base_dir=state_path, vault_path=vault_path)
+        with mock.patch(
+            "phantasm.operations.hardware_binding_status",
+            return_value=HardwareBindingStatus(
+                host_supported=True,
+                device_binding_available=True,
+                external_binding_configured=False,
+            ),
+        ):
+            report = verify_state(base_dir=state_path, vault_path=vault_path)
 
         self.assertEqual(report["status"], "ready")
+
+    def test_verify_state_reports_hardware_binding_attention_on_supported_host(self):
+        tmpdir = tempfile.mkdtemp()
+        state_path = os.path.join(tmpdir, ".state")
+        os.mkdir(state_path, 0o700)
+        for name in (STATE_BLOB_NAME, STATE_KEY_NAME, VAULT_KEY_NAME):
+            path = os.path.join(state_path, name)
+            with open(path, "wb") as handle:
+                handle.write(b"x")
+            os.chmod(path, 0o600)
+        vault_path = os.path.join(tmpdir, "vault.bin")
+        with open(vault_path, "wb") as handle:
+            handle.write(b"vault")
+
+        with mock.patch(
+            "phantasm.operations.hardware_binding_status",
+            return_value=HardwareBindingStatus(
+                host_supported=True,
+                device_binding_available=False,
+                external_binding_configured=False,
+            ),
+        ):
+            report = verify_state(base_dir=state_path, vault_path=vault_path)
+
+        self.assertEqual(report["status"], "attention")
+        rendered = json.dumps(report)
+        self.assertIn("device binding material is not present", rendered)
+        self.assertIn(
+            "supplemental key material source is not configured",
+            rendered,
+        )
 
     def test_verify_audit_log_accepts_minimal_schema(self):
         tmpdir = tempfile.mkdtemp()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -569,6 +569,48 @@ class WebServerBoundaryTests(unittest.TestCase):
 
         asyncio.run(run())
 
+    def test_diagnostics_include_hardware_binding_details_after_restricted_access(self):
+        async def run():
+            request = SimpleNamespace(
+                client=SimpleNamespace(host="127.0.0.1"),
+                cookies={},
+                url=SimpleNamespace(path="/maintenance/diagnostics"),
+            )
+            with (
+                mock.patch.object(web_server, "field_mode_enabled", return_value=True),
+                mock.patch.object(
+                    web_server, "_restricted_session_valid", return_value=True
+                ),
+                mock.patch.object(
+                    web_server,
+                    "neutral_status",
+                    return_value={
+                        "camera_ready": True,
+                        "object_state": "none",
+                        "device_state": "ready",
+                        "local_mode": True,
+                    },
+                ),
+                mock.patch.object(
+                    web_server,
+                    "hardware_binding_status",
+                    return_value=SimpleNamespace(
+                        to_dict=lambda: {
+                            "host_supported": True,
+                            "device_binding_available": True,
+                            "external_binding_configured": False,
+                        }
+                    ),
+                ),
+            ):
+                response = await web_server.diagnostics(request)
+            self.assertIn("hardware_binding", response)
+            self.assertEqual(
+                response["hardware_binding"]["device_binding_available"], True
+            )
+
+        asyncio.run(run())
+
     def test_field_mode_rejects_log_export_without_restricted_confirmation(self):
         async def run():
             request = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add neutral hardware-binding status reporting to local operations and restricted maintenance diagnostics
- cover supported-host, missing-binding, and restricted diagnostics cases with tests
- remove the unnecessary editable install step from CI and align formatting with black

## Testing
- .venv/bin/python -m black --check src tests scripts
- .venv/bin/python -m ruff check src tests scripts
- .venv/bin/python -m mypy src
- .venv/bin/python -m bandit -r src -q --severity-level medium --confidence-level high
- .venv/bin/python -m unittest discover -s tests
- .venv/bin/python scripts/generate_release_artifacts.py --output-dir /tmp/phantasm-release --archive

Closes #32