### PR TITLE
Analysis #20: multi-object cue and sequence gate evaluation

### DIFF
--- a/docs/MULTI_OBJECT_CUE_EVALUATION_PLAN.md
+++ b/docs/MULTI_OBJECT_CUE_EVALUATION_PLAN.md
@@ -1,0 +1,104 @@
+# Multi-Object Cue and Visual Sequence Evaluation Plan (Issue #20)
+
+## Purpose
+
+This document defines an analysis plan for evaluating multi-object cues and short visual sequence matching as operational access-cue enhancements.
+
+The goal is to improve reliability and operator control while preserving neutral capture-visible behavior and the existing cryptographic boundary.
+
+## Constraints
+
+- Camera cues remain operational gates, not cryptographic secrets.
+- No direct cryptographic dependence on unstable coordinates, bounding boxes, or frame-order artifacts.
+- No cloud services or remote inference.
+- No requirement for heavyweight machine-learning models.
+- Neutral UI and API behavior must be preserved.
+
+## Candidate Patterns
+
+### Multi-Object Scene Cue
+
+- Two or more registered objects in one frame.
+- Relation checks:
+  - left/right ordering
+  - above/below ordering
+  - minimum relative distance bucket
+
+### Visual Sequence Cue
+
+- Short sequence of cue states over time.
+- Example sequence token model:
+  - `object_a_visible`
+  - `object_b_visible`
+  - `relation_ok`
+- Sequence validation uses bounded windows and timeout limits.
+
+### Stability and Ambiguity
+
+- Require stable acceptance across a frame window.
+- Reject ambiguous scenes that satisfy multiple candidate cues.
+- Preserve explicit `ambiguous` state and neutral reject behavior.
+
+## Measurement Plan
+
+Target hardware baseline:
+
+- Raspberry Pi Zero 2 W
+- Camera Module 3 NoIR Wide (or equivalent)
+
+For each pattern, record:
+
+- false accept observations
+- false reject observations
+- latency (p50/p95)
+- CPU and memory behavior
+- thermal behavior
+- operator retry burden
+
+Test dimensions:
+
+- lighting variation
+- angle variation
+- distance variation
+- placement jitter
+- motion blur
+- partial occlusion
+
+## Threat and Failure Analysis Checklist
+
+- photo/screen replay observations
+- scene ambiguity when multiple cues are present
+- stress-path behavior under repeated rejection
+- capture-visible branch leakage risk
+- failure behavior when no object is visible
+
+## Recommendation Outcomes
+
+- reject
+- documentation-only
+- minimal implementation (experimental/off by default)
+
+Any implementation recommendation must define:
+
+- neutral API contract
+- neutral UI wording
+- bounded runtime policy
+- explicit non-cryptographic boundary statement
+
+## Proposed Neutral API Shape (Analysis Draft)
+
+```json
+{
+  "camera_ready": true,
+  "object_state": "none|detected|matched|ambiguous",
+  "cue_confidence": 0.0,
+  "sequence_state": "idle|collecting|matched|timeout|ambiguous"
+}
+```
+
+## Out of Scope
+
+- biometric identity claims
+- anti-spoof guarantees
+- compliance/certification claims
+- automatic route disclosure in user-visible surfaces

--- a/docs/MULTI_OBJECT_CUE_RECOMMENDATION.md
+++ b/docs/MULTI_OBJECT_CUE_RECOMMENDATION.md
@@ -1,0 +1,35 @@
+# Multi-Object Cue Recommendation (Issue #20)
+
+## Decision
+
+Current recommendation: **minimal implementation (experimental only), default off**.
+
+The repository now includes:
+
+- a neutral evaluation plan
+- an experimental policy-gate prototype for sequence and ambiguity handling
+- ambiguity and no-object regression tests
+
+This is enough to continue analysis work safely without changing cryptographic behavior.
+
+## Why Not Default-On Yet
+
+- No Raspberry Pi Zero 2 W hardware benchmark record has been captured for this issue.
+- Lighting/angle/distance stress behavior for multi-object relation checks is not yet field-validated.
+- Replay and operator-stress observations are not yet recorded in a target-hardware run log.
+
+## Boundary Statement
+
+Multi-object and visual-sequence outputs remain operational gate signals only.
+They are not key material and must not directly affect KDF inputs, AEAD parameters, or container layout values.
+
+## Next Validation Gate
+
+Before changing default posture:
+
+1. run target-hardware benchmarks across lighting, angle, and placement jitter
+2. record false reject/false accept observations and operator retry burden
+3. verify neutral capture-visible behavior under ambiguous scenes
+4. confirm no cryptographic-boundary coupling is introduced
+
+If any gate fails, keep the feature experimental or reject deployment use.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -317,6 +317,10 @@ Retrieval:
 
 The physical object is an operational cue, not a high-entropy cryptographic factor.
 
+Multi-object and visual-sequence cue extensions are analysis-only at this stage. Any future implementation must preserve neutral capture-visible behavior, explicit ambiguity rejection, and no direct cryptographic dependence on unstable image coordinates.
+
+An experimental policy-layer prototype can evaluate neutral frame signals (for example `none|detected|matched|ambiguous`) and optional short token sequences, but this remains a local operational gate decision and not a cryptographic input path.
+
 ## 13. Runtime Policy
 
 | Variable | Purpose | Default |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -81,6 +81,7 @@ These surfaces should not reveal the internal disclosure model, internal trial o
 - The v3 format avoids a plaintext format marker, but surrounding tool files can still reveal that a Phasmid-style container may be in use.
 - Dual password slots duplicate encrypted payload material within the selected internal storage span. This improves operational control but reduces maximum payload size.
 - UI face lock can be affected by lighting, camera angle, false rejects, false accepts, and presentation attacks using photos or screens.
+- Multi-object cues and visual sequence cues can increase ambiguity risk and operator retry burden if relation checks are unstable under lighting, angle, or motion changes.
 - The in-memory Web rate limiter and restricted confirmation state reset on process restart and are not substitutes for a full access-control layer.
 - Access-attempt limiting slows repeated local failures but does not stop offline guessing against copied data, compromised hosts, or deliberate state rollback.
 - UI tokens can be read from a compromised browser or host session.
@@ -112,3 +113,4 @@ These surfaces should not reveal the internal disclosure model, internal trial o
 - Review metadata before storing source, evidence, notes, or travel material.
 - Keep only necessary data on the device and remove stale entries after the task or trip.
 - Run tests before changing cryptographic or Web boundary behavior.
+- If evaluating multi-object or sequence cues, require bounded runtime windows and neutral reject behavior before enabling any experimental gate by default.

--- a/src/phasmid/object_cue_policy_gate.py
+++ b/src/phasmid/object_cue_policy_gate.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CueFrameSignal:
+    """Single-frame neutral cue signal used by policy evaluation."""
+
+    object_state: str
+    relation_ok: bool = False
+    token: str = ""
+
+
+@dataclass(frozen=True)
+class CuePolicyResult:
+    """Neutral policy outcome. Not cryptographic material."""
+
+    sequence_state: str
+    accepted: bool
+    ambiguous: bool
+    reason: str
+
+
+class ObjectCuePolicyGate:
+    """
+    Experimental policy gate for multi-object and short sequence evaluation.
+
+    This layer combines neutral per-frame signals only. It must never derive
+    or modify cryptographic keys, KDF inputs, or container layout values.
+    """
+
+    VALID_STATES = {"none", "detected", "matched", "ambiguous"}
+
+    def __init__(self, *, required_stable_frames: int = 3, sequence_timeout_frames: int = 8):
+        self.required_stable_frames = max(1, int(required_stable_frames))
+        self.sequence_timeout_frames = max(self.required_stable_frames, int(sequence_timeout_frames))
+
+    def evaluate(self, frames: list[CueFrameSignal], expected_sequence: list[str] | None = None) -> CuePolicyResult:
+        if not frames:
+            return CuePolicyResult(
+                sequence_state="idle",
+                accepted=False,
+                ambiguous=False,
+                reason="no_signal",
+            )
+
+        normalized = [self._normalize(frame) for frame in frames]
+        if any(frame.object_state == "ambiguous" for frame in normalized):
+            return CuePolicyResult(
+                sequence_state="ambiguous",
+                accepted=False,
+                ambiguous=True,
+                reason="ambiguous_scene",
+            )
+
+        if all(frame.object_state == "none" for frame in normalized):
+            return CuePolicyResult(
+                sequence_state="idle",
+                accepted=False,
+                ambiguous=False,
+                reason="no_object",
+            )
+
+        if expected_sequence:
+            return self._evaluate_sequence(normalized, expected_sequence)
+
+        stable = self._stable_match_count(normalized)
+        if stable >= self.required_stable_frames:
+            return CuePolicyResult(
+                sequence_state="matched",
+                accepted=True,
+                ambiguous=False,
+                reason="stable_match",
+            )
+
+        return CuePolicyResult(
+            sequence_state="collecting",
+            accepted=False,
+            ambiguous=False,
+            reason="insufficient_stability",
+        )
+
+    def _evaluate_sequence(self, frames: list[CueFrameSignal], expected_sequence: list[str]) -> CuePolicyResult:
+        if not expected_sequence:
+            return CuePolicyResult(
+                sequence_state="idle",
+                accepted=False,
+                ambiguous=False,
+                reason="empty_sequence",
+            )
+
+        idx = 0
+        frame_budget = min(len(frames), self.sequence_timeout_frames)
+        for frame in frames[:frame_budget]:
+            if frame.object_state != "matched":
+                continue
+            if not frame.relation_ok:
+                continue
+            if frame.token == expected_sequence[idx]:
+                idx += 1
+                if idx == len(expected_sequence):
+                    return CuePolicyResult(
+                        sequence_state="matched",
+                        accepted=True,
+                        ambiguous=False,
+                        reason="sequence_complete",
+                    )
+
+        if frame_budget >= self.sequence_timeout_frames:
+            return CuePolicyResult(
+                sequence_state="timeout",
+                accepted=False,
+                ambiguous=False,
+                reason="sequence_timeout",
+            )
+
+        return CuePolicyResult(
+            sequence_state="collecting",
+            accepted=False,
+            ambiguous=False,
+            reason="sequence_incomplete",
+        )
+
+    def _stable_match_count(self, frames: list[CueFrameSignal]) -> int:
+        count = 0
+        for frame in frames:
+            if frame.object_state == "matched":
+                count += 1
+        return count
+
+    def _normalize(self, frame: CueFrameSignal) -> CueFrameSignal:
+        state = frame.object_state if frame.object_state in self.VALID_STATES else "none"
+        token = frame.token.strip()
+        return CueFrameSignal(object_state=state, relation_ok=bool(frame.relation_ok), token=token)

--- a/tests/test_object_cue_policy_gate.py
+++ b/tests/test_object_cue_policy_gate.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from phasmid.object_cue_policy_gate import CueFrameSignal, ObjectCuePolicyGate
+
+
+class ObjectCuePolicyGateTests(unittest.TestCase):
+    def test_no_signal_returns_idle(self):
+        gate = ObjectCuePolicyGate()
+        result = gate.evaluate([])
+        self.assertEqual(result.sequence_state, "idle")
+        self.assertFalse(result.accepted)
+
+    def test_ambiguous_scene_rejected(self):
+        gate = ObjectCuePolicyGate()
+        result = gate.evaluate(
+            [
+                CueFrameSignal("detected"),
+                CueFrameSignal("ambiguous"),
+                CueFrameSignal("matched"),
+            ]
+        )
+        self.assertEqual(result.sequence_state, "ambiguous")
+        self.assertTrue(result.ambiguous)
+        self.assertFalse(result.accepted)
+
+    def test_no_object_scene_rejected(self):
+        gate = ObjectCuePolicyGate()
+        result = gate.evaluate([CueFrameSignal("none"), CueFrameSignal("none")])
+        self.assertEqual(result.reason, "no_object")
+        self.assertFalse(result.accepted)
+
+    def test_stable_match_accepts(self):
+        gate = ObjectCuePolicyGate(required_stable_frames=3)
+        result = gate.evaluate(
+            [
+                CueFrameSignal("detected"),
+                CueFrameSignal("matched"),
+                CueFrameSignal("matched"),
+                CueFrameSignal("matched"),
+            ]
+        )
+        self.assertEqual(result.sequence_state, "matched")
+        self.assertTrue(result.accepted)
+
+    def test_sequence_timeout_rejected(self):
+        gate = ObjectCuePolicyGate(sequence_timeout_frames=4)
+        result = gate.evaluate(
+            [
+                CueFrameSignal("matched", relation_ok=True, token="a"),
+                CueFrameSignal("matched", relation_ok=False, token="b"),
+                CueFrameSignal("matched", relation_ok=False, token="b"),
+                CueFrameSignal("matched", relation_ok=False, token="b"),
+            ],
+            expected_sequence=["a", "b"],
+        )
+        self.assertEqual(result.sequence_state, "timeout")
+        self.assertFalse(result.accepted)
+
+    def test_sequence_complete_accepts(self):
+        gate = ObjectCuePolicyGate(sequence_timeout_frames=6)
+        result = gate.evaluate(
+            [
+                CueFrameSignal("matched", relation_ok=True, token="a"),
+                CueFrameSignal("matched", relation_ok=True, token="b"),
+            ],
+            expected_sequence=["a", "b"],
+        )
+        self.assertEqual(result.sequence_state, "matched")
+        self.assertTrue(result.accepted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -102,6 +102,7 @@ class TerminologyAuditTests(unittest.TestCase):
             "src/phasmid/face_session_store.py",
             "src/phasmid/local_state_crypto.py",
             "src/phasmid/object_cue_matcher.py",
+            "src/phasmid/object_cue_policy_gate.py",
             "src/phasmid/object_cue_store.py",
             "src/phasmid/vault_core.py",
             "src/phasmid/kdf_engine.py",


### PR DESCRIPTION
## Summary
- add a neutral multi-object / visual-sequence evaluation plan (`docs/MULTI_OBJECT_CUE_EVALUATION_PLAN.md`)
- add an experimental policy gate prototype for cue stability, ambiguity rejection, and short sequence evaluation (`src/phasmid/object_cue_policy_gate.py`)
- add focused tests for ambiguous scenes, no-object scenes, stability, and sequence timeout/completion (`tests/test_object_cue_policy_gate.py`)
- update threat/spec docs to encode boundary constraints and failure-mode guidance
- add final recommendation doc to keep this capability experimental and default-off until target hardware evidence is captured (`docs/MULTI_OBJECT_CUE_RECOMMENDATION.md`)

## Security Boundary
- visual cue outputs remain operational gate signals only
- no direct cryptographic dependence on coordinates, descriptors, embeddings, or sequence artifacts
- neutral capture-visible behavior is preserved

## Verification
- `python3 -m unittest discover -s tests` (223 tests, OK)
- `python3 -m ruff check src tests scripts`
- `python3 -m mypy src`
