### PR TITLE
docs(analysis): STRIDE analysis, device binding, and split-key evaluation (#1, #13, #14)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,12 @@ The following issues were resolved in order and merged to `main` via pull reques
 - `#3`: Observable difference reduction — response/header neutrality tests, timing normalization documentation. ✅
 - `#4`: Cryptographic erase formalization — key-material invalidation sequence spec, ordering tests, best-effort overwrite language. ✅
 - `#5`: Argon2id + HKDF-SHA-256 key schedule design — domain-separated subkey module (`kdf_subkeys.py`), deterministic test vectors, v4 design documented in SPECIFICATION.md. ✅
+- `#11`: Process hardening — umask 0o077, RLIMIT_CORE=0, prctl dumpable clear (Linux), mlockall (Linux); `process_hardening.py` module, Doctor page integration, CLI/WebUI startup hooks. ✅
+- `#12`: Volatile key-material store — `PHASMID_TMPFS_STATE` env var, `volatile_state.py`, `config.py` state-dir routing, fail-closed startup guard, Doctor page check, systemd tmpfs mount example in `RPI_ZERO_APPLIANCE_DEPLOYMENT.md`. ✅
+- `#17`: Optional LUKS encrypted storage layer — systemd crypttab + fstab + `Requires=` ordering documented in `RPI_ZERO_APPLIANCE_DEPLOYMENT.md`; fail-closed guarantee; no code changes required. ✅
+- `#1`: Threat model structured STRIDE analysis — `docs/THREAT_ANALYSIS_STRIDE.md` covering all six STRIDE categories with controls and residual risks; `docs/THREAT_MODEL.md` updated with cross-reference. ✅
+- `#13`: Device binding input evaluation — `docs/DEVICE_BINDING_ANALYSIS.md` covering CPU serial, machine-id, SD CID, and deploy-time seed; current `HardwareBindingProvider` confirmed as correct approach. ✅
+- `#14`: Threshold split-key recovery evaluation — `docs/SPLIT_KEY_RECOVERY_ANALYSIS.md` evaluating split files, memorized values, Shamir threshold schemes, and removable media; no custom SSS implementation; recommends reviewed external tool. ✅
 
 ---
 

--- a/docs/DEVICE_BINDING_ANALYSIS.md
+++ b/docs/DEVICE_BINDING_ANALYSIS.md
@@ -1,0 +1,171 @@
+# Device Binding Input Evaluation
+
+## Purpose
+
+This document evaluates whether device-specific inputs — such as the Raspberry Pi CPU
+serial, machine-id, or SD card CID — should be mixed into Phasmid's key derivation
+pipeline.
+
+Device binding reduces portability: a container bound to a specific board cannot be
+recovered on a different board without explicit migration steps.  This is a tradeoff,
+not a free hardening upgrade.
+
+**Device binding inputs are not high-entropy cryptographic material.**  The CPU serial
+and hardware revision are semi-public values: they appear in `/proc/cpuinfo` and may
+be recoverable by an attacker with physical access to the board.  Their value lies in
+*device-tying*, not in providing additional entropy.
+
+---
+
+## Current State
+
+`HardwareBindingProvider` in `src/phasmid/kdf_providers.py` already reads
+`/proc/cpuinfo` for `Serial`, `Hardware`, and `Revision` lines on Linux.  These are
+concatenated and passed as the Argon2id key-material input alongside any configured
+`PHASMID_HARDWARE_SECRET`, `PHASMID_HARDWARE_SECRET_FILE`, or prompted value.
+
+The binding is **active by default on Raspberry Pi** (where `/proc/cpuinfo` includes
+`Serial`) and silently absent on platforms that do not expose it (macOS, x86 Linux
+without board serial).
+
+`hardware_binding_status()` reports whether device binding is available and whether
+external binding is also configured; this appears in the Doctor page.
+
+---
+
+## Evaluated Binding Inputs
+
+### 1. Raspberry Pi CPU Serial (`/proc/cpuinfo` — `Serial` field)
+
+| Property | Value |
+|---|---|
+| Stability | Stable across reboots and OS reinstalls on the same board |
+| Attacker visibility | Visible to any process with `/proc/cpuinfo` access; recoverable with physical board access |
+| Failure modes | Board replacement → binding lost; recovery requires explicit migration |
+| Entropy | Low (predictable range for a given board revision) |
+| Recommendation | Use as implemented: opt-in via `HardwareBindingProvider` presence |
+
+### 2. Linux machine-id (`/etc/machine-id`)
+
+| Property | Value |
+|---|---|
+| Stability | Stable within one OS install; regenerated on OS reinstall, container migration, or SD clone |
+| Attacker visibility | Readable by any local user |
+| Failure modes | OS reinstall breaks binding; SD card cloning copies machine-id, reducing differentiation |
+| Entropy | 128-bit random value; high entropy but not a privately-held value |
+| Recommendation | Not currently used; lower value than CPU serial for Pi appliance because cloning copies it |
+
+### 3. SD Card CID (Card IDentification Register)
+
+| Property | Value |
+|---|---|
+| Stability | Stable for the physical SD card; tied to storage medium, not the board |
+| Attacker visibility | Readable via `/sys/block/mmcblk0/device/cid` on Linux; requires local access |
+| Failure modes | SD card replacement → binding lost; SD cloning copies the CID |
+| Entropy | Manufacturer + serial; low entropy, not cryptographically random |
+| Recommendation | Not recommended: SD cards are frequently replaced; binding to the card rather than the board is usually wrong |
+
+### 4. Deploy-Time Seed (`PHASMID_HARDWARE_SECRET_FILE` / `PHASMID_HARDWARE_SECRET`)
+
+| Property | Value |
+|---|---|
+| Stability | Controlled by operator; explicit and auditable |
+| Attacker visibility | Kept by operator; not exposed via OS APIs |
+| Failure modes | Lost file → binding lost; explicit backup required |
+| Entropy | Operator-controlled; can be high-entropy (256-bit random) |
+| Recommendation | Preferred external binding method; already implemented and documented |
+
+---
+
+## Threat Analysis
+
+### Reduces Attack Surface When
+
+- An attacker obtains a copy of `vault.bin` and the state directory but not the
+  physical board.  Without the CPU serial in the KDF, a correct passphrase alone is
+  sufficient to attempt recovery; with the serial, the attacker also needs the board
+  or its serial number.
+
+- An attacker captures the state directory from a backup or SD clone but not the
+  original board.  The serial provides a weak additional gate.
+
+### Does Not Help When
+
+- An attacker has physical access to the board.  The CPU serial is readable via
+  `/proc/cpuinfo`.
+
+- The attacker knows the board serial number from other sources (purchase record,
+  device registration, physical inspection of the board's markings).
+
+- The OS is compromised: a root-level process can read both the serial and any
+  plaintext key material from memory.
+
+### Failure Mode Risk
+
+Device binding without documented recovery is a data-loss risk.  If the board fails or
+is replaced, the container becomes unrecoverable unless:
+
+1. The operator has a backup of the state directory from the original board, and
+2. The operator restores state and re-derives the key on a board with the same serial.
+
+Requirement 2 is infeasible: CPU serials are unique.  Practical recovery requires
+an explicit migration step: retrieve on the original board before it fails.
+
+---
+
+## Recommendation
+
+**Keep the current implementation with the following documentation additions:**
+
+1. `HardwareBindingProvider` is opt-in via `/proc/cpuinfo` presence on Linux.  It is
+   not a key-material source and must not be described as one.
+
+2. `PHASMID_HARDWARE_SECRET_FILE` or `PHASMID_HARDWARE_SECRET_PROMPT=1` is the
+   preferred external binding for high-risk deployments.  These provide operator-chosen
+   entropy that can be backed up and controlled.
+
+3. Machine-id binding is not implemented and not recommended: SD cloning copies it,
+   reducing the device-tying benefit.
+
+4. SD card CID binding is not implemented and not recommended: card replacement is
+   common; tying to the card rather than the board creates the wrong failure mode.
+
+5. No default behavior risks locking users out without an explicit opt-in.  The
+   `HardwareBindingProvider` silently returns `None` on platforms without a board serial.
+
+---
+
+## Recovery and Migration Notes
+
+If a Raspberry Pi board must be replaced and the vault was protected with hardware
+binding active:
+
+1. Retrieve all entries on the original board before it becomes unavailable.
+2. Re-initialize the container on the new board.
+3. Re-store entries.
+
+This is the only supported recovery path when hardware binding is active.  There is
+no key-escrow mechanism for the hardware-derived binding material.
+
+---
+
+## Field Test Updates
+
+The field test procedure should include:
+
+- Confirm `hardware_binding_status()` via the Doctor page before field evaluation.
+- If external key material is configured, confirm it is accessible and not stored
+  together with `vault.bin`.
+- Record the board serial number in deployment notes for reference if board
+  replacement is ever needed.
+- Test retrieve and re-store after a simulated board replacement (i.e., reset the
+  binding material and confirm old containers cannot be opened without migration).
+
+---
+
+## References
+
+- `src/phasmid/kdf_providers.py` — `HardwareBindingProvider`, `hardware_binding_status()`
+- `docs/THREAT_MODEL.md` — hardware binding residual risks
+- `docs/SPECIFICATION.md` — v4 key schedule design (HKDF subkeys)
+- `docs/RPI_ZERO_APPLIANCE_DEPLOYMENT.md` — key material and storage section

--- a/docs/SPLIT_KEY_RECOVERY_ANALYSIS.md
+++ b/docs/SPLIT_KEY_RECOVERY_ANALYSIS.md
@@ -1,0 +1,173 @@
+# Threshold Split-Key Recovery Evaluation
+
+## Purpose
+
+This document evaluates threshold split-key recovery for Phasmid deployments that
+cannot use hardware tokens.  The goal is to identify whether split-key approaches
+belong in Phasmid's core, in operational documentation, or in a separate tool.
+
+**No custom threshold cryptography implementation is included in this evaluation.**
+Any production use of Shamir Secret Sharing or similar schemes requires a
+well-reviewed library and independently verified test vectors.  This document
+describes the design space and recommends a path that does not introduce
+unreviewed cryptographic code.
+
+---
+
+## User Problem
+
+The local vault access key and optional external key material currently live on the
+same SD card as `vault.bin`.  If that SD card is the only copy of all required
+key material, physical seizure or destruction of the card is a single point of
+failure for both the protected content and the ability to recover it.
+
+Split-key recovery addresses this by distributing key material across multiple
+locations so that no single location holds enough to reconstruct the key alone.
+
+---
+
+## Evaluated Approaches
+
+### 1. Split Key Files on Separate Media
+
+**Description**: Divide the external key material into two or more files.  Store
+one on the SD card, one on a USB drive, one on a separately stored device, etc.
+Recovery requires all pieces.
+
+| Property | Assessment |
+|---|---|
+| Cryptographic complexity | None beyond XOR or concatenation |
+| Loss risk | Loss of any one piece → complete loss (no threshold) |
+| Coercion risk | Each holder can be compelled independently |
+| User error | Misplacing one piece is unrecoverable |
+| Implementation | Already supported: `PHASMID_HARDWARE_SECRET_FILE` can point to any path |
+| Recommendation | Suitable for simple n-of-n separation; not a threshold scheme |
+
+This is the currently documented approach: store `vault.bin`, the state directory,
+and optional external key material under separate physical control conditions.
+
+### 2. Memorized Values (n-of-n)
+
+**Description**: The passphrase itself is a combined value known only in full by the
+operator.  No files are split; the split happens in the operator's memory.
+
+| Property | Assessment |
+|---|---|
+| Cryptographic complexity | None |
+| Loss risk | Memory failure → complete loss |
+| Coercion risk | Single operator compelled → full disclosure |
+| User error | Misremembering any component → no recovery |
+| Implementation | Already supported: use a long, structured passphrase |
+| Recommendation | Suitable for single-operator deployments; not a threshold scheme |
+
+### 3. Printed Shares (Shamir Secret Sharing)
+
+**Description**: Use Shamir Secret Sharing to split a key into N shares such that
+any K shares reconstruct the key.  Print or store shares on physically separate media.
+
+| Property | Assessment |
+|---|---|
+| Cryptographic complexity | Requires a reviewed SSS library (e.g., `sss-py`, `sslib`) |
+| Loss risk | Loss of any K shares → complete loss; loss of fewer than K → no loss |
+| Coercion risk | An attacker who captures K share holders can reconstruct |
+| User error | Misplaced share below threshold → no loss; above threshold → loss |
+| Implementation | Not currently implemented; requires library selection and review |
+| Recommendation | Best threshold model, but requires external library and workflow tooling |
+
+**Critical requirement**: Shamir Secret Sharing implementations vary in security.
+Common pitfalls include non-uniform randomness, missing finite-field consistency checks,
+and share encoding errors.  A production deployment should use an independently
+reviewed library with published test vectors, not a handwritten implementation.
+
+### 4. Removable Media Separation
+
+**Description**: Store the external key material (`PHASMID_HARDWARE_SECRET_FILE`)
+on a USB drive or microSD card kept physically separate from the main SD card.  Remove
+and secure the removable media after each access session.
+
+| Property | Assessment |
+|---|---|
+| Cryptographic complexity | None |
+| Loss risk | Physical loss of the removable media → binding lost |
+| Coercion risk | Attacker must obtain both the main device and the removable media |
+| User error | Forgetting to re-insert → startup fails; recoverable by inserting and restarting |
+| Implementation | Already supported: `PHASMID_HARDWARE_SECRET_FILE` |
+| Recommendation | Practical and immediately available; not a threshold scheme |
+
+---
+
+## Risk Matrix
+
+| Threat | Separate Files | Memorized | Shamir (K-of-N) | Removable Media |
+|---|---|---|---|---|
+| Single-media seizure | Mitigated | Mitigated | Mitigated | Mitigated |
+| Loss of one piece | Complete loss | Complete loss | Threshold-bounded | Complete loss |
+| Coercion of one holder | Mitigated (all needed) | Complete disclosure | Threshold-bounded | Mitigated (both needed) |
+| User error (forget location) | Complete loss | Complete loss | Threshold-bounded | Recoverable |
+| Implementation risk | None | None | Library-dependent | None |
+
+---
+
+## Recommendation
+
+**For the current Phasmid prototype, threshold split-key is not added to core.**
+
+Rationale:
+
+1. The removable media pattern (`PHASMID_HARDWARE_SECRET_FILE` on a USB drive)
+   provides practical two-location separation with no additional code or cryptographic
+   assumptions.  This is the recommended operational approach.
+
+2. True threshold recovery (Shamir K-of-N) provides better loss and coercion
+   properties, but requires a reviewed library, share management workflow, and
+   recovery documentation that go beyond the current prototype scope.
+
+3. The existing `PHASMID_HARDWARE_SECRET_FILE` mechanism is already the correct
+   interface for external key material.  Any future threshold implementation should
+   produce a file at that path (i.e., reconstruct and write the key to a tmpfs path)
+   rather than modifying the vault KDF.
+
+**Threshold split-key as a separate tool**: A command-line tool that takes a
+`PHASMID_HARDWARE_SECRET_FILE` value, splits it into N Shamir shares using a reviewed
+library, and reconstructs it back into a file would compose cleanly with the current
+design.  This tool belongs in a separate repository with independent review, not in
+Phasmid core.
+
+---
+
+## Operational Guidance (Current)
+
+Until a reviewed threshold tool exists, the recommended approach for deployments
+that need key-material separation:
+
+1. Generate a high-entropy external key material value:
+   ```bash
+   python3 -c "import secrets; print(secrets.token_hex(32))" > /media/usb/phasmid.key
+   ```
+2. Set `PHASMID_HARDWARE_SECRET_FILE=/media/usb/phasmid.key` in the service environment.
+3. Store the USB drive separately from the device.
+4. Keep a second encrypted copy (e.g., in a password manager or separately secured media).
+5. Document the recovery procedure: to recover on a new device, both the main SD card
+   and the USB drive (or its backup) are required.
+
+This provides two-location separation with no new code and acceptable user-error
+resistance for a single operator or small team.
+
+---
+
+## Claims Not Made
+
+This analysis does not claim that split-key approaches provide:
+
+- Perfect protection against compelled disclosure (all holders can be compelled)
+- Guaranteed availability (shares can be lost)
+- Protection against a compromised OS or physical hardware capture
+
+---
+
+## References
+
+- `docs/THREAT_MODEL.md` — key material separation and operational guidance
+- `docs/SOURCE_SAFE_WORKFLOW.md` — external key material storage guidance
+- `docs/RPI_ZERO_APPLIANCE_DEPLOYMENT.md` — key material and storage section
+- `src/phasmid/kdf_providers.py` — `FileSecretProvider`, `EnvSecretProvider`

--- a/docs/THREAT_ANALYSIS_STRIDE.md
+++ b/docs/THREAT_ANALYSIS_STRIDE.md
@@ -1,0 +1,314 @@
+# Phasmid Threat Analysis — STRIDE Framework
+
+## Scope and Caveats
+
+This document maps the Phasmid threat model to the STRIDE framework.  It covers the
+WebUI, CLI, metadata workflow, object cue matching, local state, restricted actions,
+audit logging, and deployment posture.
+
+**This document does not claim that Phasmid is field-proven, certified, approved for
+classified-data handling, or guaranteed to resist compelled disclosure.**  It records
+known risks and current mitigations to support structured review.
+
+See `docs/THREAT_MODEL.md` for the base model, `docs/SPECIFICATION.md` for the full
+system description, and `docs/SEIZURE_REVIEW_CHECKLIST.md` for the pre-field review.
+
+---
+
+## STRIDE Summary Table
+
+| Category | Key Risks | Primary Controls |
+|---|---|---|
+| Spoofing | Web token replay, restricted session fixation, face lock bypass | Per-session token, session TTL, client binding |
+| Tampering | Vault ciphertext modification, state directory manipulation | AES-GCM authentication, key-material separation |
+| Repudiation | Missing audit trail | Optional HMAC-chained audit log |
+| Information Disclosure | Response headers, download filename, CLI output, browser cache | Neutral filenames, security headers, Field Mode |
+| Denial of Service | Repeated access failures, rate limit bypass | Per-client limiter, access lockout |
+| Elevation of Privilege | Restricted confirmation bypass, unrestricted action access | Server-side session check, typed confirmation |
+
+---
+
+## S — Spoofing
+
+### Assets at Risk
+
+- WebUI mutation token (`X-Phasmid-Token`)
+- Restricted confirmation session cookie
+- UI face lock session
+- Object cue match state
+
+### Attack Vectors and Controls
+
+**Web token replay**: An attacker who obtains `PHASMID_WEB_TOKEN` or observes a
+request containing `X-Phasmid-Token` can replay it until the process restarts.
+
+*Controls*: Token is per-process by default.  `PHASMID_WEB_TOKEN` can be rotated via
+the restricted action endpoint.  WebUI binds to `127.0.0.1` by default, limiting
+token exposure to local sessions.
+
+**Restricted session fixation**: The restricted confirmation cookie binds to the
+originating client IP but not to a cryptographic session.  An attacker with local
+network access and knowledge of the cookie value could attempt replay.
+
+*Controls*: Cookie is `HttpOnly`, short TTL (120 s default), bound to client IP.
+Field Mode limits restricted action pages until a fresh restricted session is active.
+
+**UI face lock bypass**: An attacker can attempt to spoof the enrolled face by
+presenting a photo or screen.
+
+*Controls*: Face lock is a UI gate only, not vault encryption.  A compromised face
+lock does not expose vault contents without the correct passphrase and object cue.
+The enrolled template is AES-GCM encrypted at rest.
+
+**Object cue spoofing**: An attacker who knows the reference object can present it to
+the camera to match the cue.
+
+*Controls*: Object matching is an operational access cue, not cryptographic material.
+The vault requires the correct passphrase in addition to the object match.
+
+### Residual Risks
+
+- Web token has process-lifetime validity; restart or explicit rotation required to
+  invalidate a captured token.
+- Face lock does not protect against a determined attacker with a physical copy of the
+  enrollment reference and the ability to present it to the camera.
+
+---
+
+## T — Tampering
+
+### Assets at Risk
+
+- `vault.bin` ciphertext
+- `.state/` directory (access key, state blob, audit log)
+- Phasmid source files and configuration
+
+### Attack Vectors and Controls
+
+**Vault ciphertext modification**: An attacker with filesystem access can modify
+`vault.bin` bytes.
+
+*Controls*: Each slot uses AES-GCM with a fresh random nonce and per-record AAD
+`phasmid-record-v3:<mode>:<role>:<size>`.  Bit flips in the ciphertext produce an
+`InvalidTag` exception; the slot returns `(None, None)` rather than modified
+plaintext.
+
+**Access key replacement**: Replacing `.state/access.bin` with a known value would
+allow an attacker to attempt brute-force derivation without the original key.
+
+*Controls*: Access key is mixed into Argon2id as a key-material input.  Without
+the original key, the derived AES-GCM key differs; decryption fails.  The state
+directory should be mode 0700 and on encrypted storage.
+
+**State blob manipulation**: The ORB reference template and face lock template are
+both AES-GCM encrypted in the state directory.
+
+*Controls*: Corruption or replacement produces decryption failure at load time.
+
+**Source code modification**: An attacker with write access to the project directory
+can alter behavior.
+
+*Controls*: The optional release manifest (Ed25519-signed) covers source files.
+The CI pipeline runs `ruff`, `mypy`, and the full test suite on each commit.
+
+### Residual Risks
+
+- Vault ciphertext authentication protects against passive modification, not against
+  an attacker who can observe the AES-GCM key (e.g., from a compromised process).
+- The state directory is not cryptographically sealed; an attacker who can delete
+  or replace `access.bin` before re-provisioning may be able to introduce a known key.
+
+---
+
+## R — Repudiation
+
+### Assets at Risk
+
+- Evidence that a retrieve, store, or restricted action occurred
+- Tamper-detection evidence for the audit log
+
+### Attack Vectors and Controls
+
+**Denial of a retrieve event**: A user may claim they never retrieved a protected
+entry.
+
+*Controls*: Audit logging is opt-in (`PHASMID_AUDIT=1`).  When enabled, versioned
+JSONL records include an HMAC-SHA-256 chain so that record insertion, deletion, or
+modification is locally detectable.  Audit events do not record passwords, payload
+bytes, plaintext filenames, or internal slot labels.
+
+**Audit log truncation**: An attacker with filesystem access can truncate or delete
+the audit log.
+
+*Controls*: Log integrity verification checks the chain; gaps or hash mismatches are
+reported.  This detects tampering after the fact but does not prevent it.
+
+### Residual Risks
+
+- Audit logging is disabled by default to minimize local metadata.  Deployers who
+  require accountability must enable it explicitly.
+- An attacker who can delete `events.log` removes all local accountability evidence.
+  Off-device log shipping is out of scope for the current prototype.
+
+---
+
+## I — Information Disclosure
+
+### Assets at Risk
+
+- Payload content and metadata
+- Existence of restricted recovery configuration
+- Internal slot structure and mode labels
+- Operator identity or workflow context
+
+### Attack Vectors and Controls
+
+**Response header leakage**: HTTP responses could expose slot labels, restricted
+action outcomes, or stored filenames.
+
+*Controls*: `create_file_response()` always uses `retrieved_payload.bin` regardless
+of the original stored filename.  The `purge_applied` internal flag does not appear in
+any response header.  Security headers include `X-Content-Type-Options`, `X-Frame-Options`,
+`Referrer-Policy`, and a `Content-Security-Policy` with `frame-ancestors 'none'`.
+
+**Browser cache leakage**: Responses cached by the browser could reveal payload
+content or filenames to a later visitor.
+
+*Controls*: All responses include `Cache-Control: no-store, no-cache` and
+`Pragma: no-cache`.
+
+**CLI output leakage**: Shell history or terminal scrollback may record passphrase
+arguments or operation results.
+
+*Controls*: The TUI avoids passing passphrases as command-line arguments.  The Doctor
+page warns when shell history is active.  Field Mode suppresses diagnostic detail until
+restricted confirmation is active.
+
+**Metadata leakage**: Stored files may contain EXIF, Office, or PDF metadata that
+reveals authorship, device, or location information.
+
+*Controls*: The metadata risk check warns on store; best-effort scrubbing is available
+for supported file types (JPEG, PNG, Office ZIP).  Unsupported types fail safely.
+
+**State directory filename leakage**: Files named `access.bin`, `store.bin`, `lock.bin`
+in the state directory reveal the presence of a Phasmid installation.
+
+*Controls*: Field Mode (and LUKS layer) reduce casual exposure.  File names cannot be
+changed without a format version bump.  The seizure review checklist covers state
+directory inspection.
+
+**Audit log leakage**: Enabled audit logs create local metadata about operations.
+
+*Controls*: Events record only operation type, timestamp, source, and length — not
+passwords, payload bytes, plaintext filenames, or internal slot labels.
+
+### Residual Risks
+
+- Browser cache, shell history, systemd logs, and temporary files are all potential
+  disclosure surfaces that depend on careful operational configuration.
+- The state directory filename set (`access.bin`, `store.bin`, `lock.bin`) is
+  consistent across deployments and recognisable to an informed examiner.
+
+---
+
+## D — Denial of Service
+
+### Assets at Risk
+
+- Availability of the WebUI retrieve endpoint
+- Availability of the local access key after repeated failures
+
+### Attack Vectors and Controls
+
+**Repeated incorrect access attempts**: An attacker with local network access can
+repeatedly submit wrong passwords to exhaust the attempt counter.
+
+*Controls*: `AttemptLimiter` applies per-client lockout after a configurable failure
+threshold (`PHASMID_ACCESS_MAX_FAILURES`, default 5) for a configurable period
+(`PHASMID_ACCESS_LOCKOUT_SECONDS`, default 60 s).  The limiter is in-process and
+resets on restart; it does not substitute for a hardware-backed counter.
+
+**Rate limit exhaustion**: An attacker can send rapid requests to exhaust the rate
+limiter.
+
+*Controls*: `enforce_rate_limit()` limits requests per client per time window
+(default: 20 requests per 60 s).  Exceeded rate returns HTTP 429.
+
+**Process crash**: A panic event or deliberate process termination disrupts service.
+
+*Controls*: The systemd unit restarts on failure (`Restart=on-failure`, `RestartSec=2`).
+The TUI auto-kills the WebUI after 10 minutes of inactivity to limit exposure.
+
+**LUKS mount unavailability**: If the optional LUKS layer or tmpfs mount is
+unavailable, Phasmid refuses to start rather than falling back to unencrypted storage.
+
+*Controls*: This is intentional fail-closed behavior.  The systemd unit uses
+`Requires=` to declare the dependency.
+
+### Residual Risks
+
+- The in-process attempt limiter resets on restart; an attacker can restart the
+  process to clear the counter.
+- DoS via file descriptor exhaustion, memory pressure, or kernel-level resource limits
+  is not mitigated beyond standard systemd hardening options.
+
+---
+
+## E — Elevation of Privilege
+
+### Assets at Risk
+
+- Restricted confirmation session (gates destructive local actions)
+- Capability policy enforcement
+
+### Attack Vectors and Controls
+
+**Restricted confirmation bypass**: An attacker who can forge or replay the restricted
+session cookie can access restricted action endpoints without the confirmation step.
+
+*Controls*: The cookie is validated server-side against an in-memory session store
+(not a static value).  Sessions are bound to client IP and expire after TTL.  Actions
+additionally require typed confirmation phrases.
+
+**Capability policy bypass**: Disabling a capability via the environment or policy
+file should prevent the corresponding action.
+
+*Controls*: `require_capability()` checks the active policy before allowing each
+capability-gated endpoint.  Disabled capabilities return HTTP 403 with the neutral
+`operation unavailable` message.
+
+**Privilege escalation via file permission weakness**: If the state directory or vault
+file has permissive permissions, another local user may read or modify them.
+
+*Controls*: The service unit sets `UMask=0077` and `ProtectHome=true`.
+`_write_new_access_key()` sets `access.bin` to mode 0600 after creation.  The Doctor
+page checks directory and file permissions.
+
+### Residual Risks
+
+- Server-side session validation is in-process; a crash or restart clears all
+  restricted sessions, requiring re-confirmation.
+- `ProtectSystem=strict` limits write paths to those in `ReadWritePaths`.  Misconfigured
+  `ReadWritePaths` can expand the writable surface.
+
+---
+
+## Follow-Up Issues
+
+| Issue | STRIDE Category | Description |
+|---|---|---|
+| `#11` | D, E | Process hardening (umask, RLIMIT_CORE, prctl, mlockall) ✅ |
+| `#12` | T, I | Volatile tmpfs key-material store ✅ |
+| `#13` | T, I | Device binding evaluation ✅ |
+| `#17` | T, I | LUKS optional storage layer ✅ |
+| `#14` | I, D | Threshold split-key recovery evaluation ✅ |
+
+---
+
+## References
+
+- `docs/THREAT_MODEL.md`
+- `docs/SPECIFICATION.md`
+- `docs/SEIZURE_REVIEW_CHECKLIST.md`
+- `docs/FIELD_TEST_PROCEDURE.md`
+- `docs/RPI_ZERO_APPLIANCE_DEPLOYMENT.md`

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -6,6 +6,9 @@ Phasmid is a field-evaluation prototype for local-only coercion-aware storage. I
 
 It is not a substitute for audited full-disk encryption, hardware-backed key storage, classified-data handling procedures, or a complete answer to compelled disclosure.
 
+A structured STRIDE analysis mapping this model to the six threat categories is in
+`docs/THREAT_ANALYSIS_STRIDE.md`.
+
 ## Assets
 
 - Payload bytes and encrypted payload metadata.

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -12,6 +12,9 @@ USER_FACING_FILES = [
     "README.md",
     "docs/SPECIFICATION.md",
     "docs/THREAT_MODEL.md",
+    "docs/THREAT_ANALYSIS_STRIDE.md",
+    "docs/DEVICE_BINDING_ANALYSIS.md",
+    "docs/SPLIT_KEY_RECOVERY_ANALYSIS.md",
     "docs/RPI_ZERO_DEPLOYMENT.md",
     "docs/RPI_ZERO_APPLIANCE_DEPLOYMENT.md",
     "docs/SOURCE_SAFE_WORKFLOW.md",
@@ -177,6 +180,7 @@ def _line_is_allowed(line):
         or re.search(r"no lies, no unnecessary truth", line, flags=re.IGNORECASE)
         or re.search(r"PHASMID_HARDWARE_SECRET", line)
         or re.search(r"PHASMID_STATE_SECRET", line)
+        or re.search(r"Shamir Secret Sharing", line)
     )
 
 


### PR DESCRIPTION
## Summary

- **#1** — `docs/THREAT_ANALYSIS_STRIDE.md`: full six-category STRIDE analysis covering WebUI, CLI, metadata workflow, object cue matching, restricted actions, and audit logging. Cross-reference added to `THREAT_MODEL.md`.
- **#13** — `docs/DEVICE_BINDING_ANALYSIS.md`: evaluates CPU serial, machine-id, SD card CID, and deploy-time seed as binding inputs; confirms the existing `HardwareBindingProvider` approach is correct; documents failure modes and migration path for board replacement.
- **#14** — `docs/SPLIT_KEY_RECOVERY_ANALYSIS.md`: evaluates split files, memorized values, Shamir threshold schemes (SSS), and removable media separation; recommends `PHASMID_HARDWARE_SECRET_FILE` on USB as the current operational approach; defers Shamir SSS to a separate independently-reviewed tool.

Supporting changes:
- `tests/test_terminology.py`: adds all three docs to `USER_FACING_FILES`; exempts "Shamir Secret Sharing" (proper cryptographic term) in `_line_is_allowed`
- `AGENTS.md`: records #11, #12, #17, #1, #13, #14 as completed

## Test plan

- [x] `python -m pytest tests/test_terminology.py -v` — 4/4 passed
- [x] `python -m pytest --tb=short -q` — 426 passed, 0 failures
- [x] `ruff check src/ tests/` — no issues
- [x] `python -m mypy src/phasmid/ --ignore-missing-imports` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)