### PR TITLE
feat(m4): operational artifact checks and source leakage coverage (SH-14..16)

### DIFF
--- a/docs/DESIGN_NOTE_TOUCH_VAULT.md
+++ b/docs/DESIGN_NOTE_TOUCH_VAULT.md
@@ -1,0 +1,34 @@
+# Design Note: `phasmid touch-vault` (SH-15)
+
+## Question
+
+Should Phasmid add a `phasmid touch-vault` command to rewrite `vault.bin` timestamps
+(mtime/atime) in order to reduce recent-use inference?
+
+## Current Decision
+
+Do **not** add this command in the current cycle.
+
+## Rationale
+
+- Timestamp rewriting can itself create an observable pattern if operators run it
+  inconsistently.
+- Automatic timestamp randomization is operationally risky and can interfere with
+  backup/sync workflows and forensic timeline interpretation.
+- The new Doctor checks already surface timestamp hygiene (`Recent File Activity`)
+  and baseline-size drift (`Vault Size Record`) without mutating user data.
+
+## Safe Interim Posture
+
+- Keep `phasmid doctor` as a non-gating diagnostic tool.
+- Provide warning-level feedback when recent vault usage is visible.
+- Document local operational procedures separately for environments that need
+  explicit timestamp management.
+
+## Revisit Criteria
+
+Revisit this decision only if:
+
+- there is a documented operator workflow for deterministic timestamp handling, and
+- tests demonstrate that the command does not create new capture-visible leakage
+  patterns or compatibility regressions.

--- a/src/phasmid/services/doctor_service.py
+++ b/src/phasmid/services/doctor_service.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import os
+import resource
 import stat
+import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
+from ..config import state_dir
 from ..models.doctor import DoctorCheck, DoctorLevel, DoctorResult
 from ..process_hardening import hardening_status
 from ..volatile_state import check_volatile_state, volatile_state_path
@@ -100,6 +104,19 @@ def _check_shell_history() -> DoctorCheck:
 
     hist_file = os.environ.get("HISTFILE", "")
     if hist_file:
+        hist_path = Path(hist_file).expanduser()
+        if hist_path.exists():
+            try:
+                content = hist_path.read_text(encoding="utf-8", errors="ignore")
+                if any(term in content for term in ("phasmid", "vault.bin")):
+                    return DoctorCheck(
+                        name="Shell History",
+                        level=DoctorLevel.WARN,
+                        message="Shell history contains recent Phasmid-related commands.",
+                        detail="Clear history and prefer TUI passphrase input.",
+                    )
+            except OSError:
+                pass
         return DoctorCheck(
             name="Shell History",
             level=DoctorLevel.WARN,
@@ -239,8 +256,246 @@ def _check_debug_logging() -> DoctorCheck:
     )
 
 
+def _check_recent_documents_cache() -> DoctorCheck:
+    """Best-effort check for recent-document artifact leakage.
+
+    Threat model reference: docs/THREAT_MODEL.md (Attack Surfaces / local passive observer).
+    """
+    xbel = Path.home() / ".local" / "share" / "recently-used.xbel"
+    if not xbel.exists():
+        return DoctorCheck(
+            name="Recent Documents Cache",
+            level=DoctorLevel.INFO,
+            message="Recent documents cache not found (unknown on this host).",
+        )
+    try:
+        content = xbel.read_text(encoding="utf-8", errors="ignore").lower()
+    except OSError as exc:
+        return DoctorCheck(
+            name="Recent Documents Cache",
+            level=DoctorLevel.INFO,
+            message=f"Could not inspect recent documents cache: {exc}",
+        )
+    if any(term in content for term in ("vault.bin", "phasmid")):
+        return DoctorCheck(
+            name="Recent Documents Cache",
+            level=DoctorLevel.WARN,
+            message="Recent documents cache contains Phasmid-related references.",
+            detail="Clear recently-used entries before high-risk movement.",
+        )
+    return DoctorCheck(
+        name="Recent Documents Cache",
+        level=DoctorLevel.OK,
+        message="No obvious Phasmid references in recent documents cache.",
+    )
+
+
+def _check_thumbnail_cache() -> DoctorCheck:
+    """Best-effort thumbnail cache leak check using Freedesktop Thumb::URI hints."""
+    thumbs_dir = Path.home() / ".cache" / "thumbnails"
+    if not thumbs_dir.exists():
+        return DoctorCheck(
+            name="Thumbnail Cache",
+            level=DoctorLevel.INFO,
+            message="Thumbnail cache not found (unknown on this host).",
+        )
+    inspected = 0
+    try:
+        for candidate in thumbs_dir.rglob("*.png"):
+            inspected += 1
+            if inspected > 500:
+                break
+            blob = candidate.read_bytes()
+            lowered = blob.lower()
+            if any(
+                term in lowered for term in (b"thumb::uri", b"phasmid", b"vault.bin")
+            ):
+                return DoctorCheck(
+                    name="Thumbnail Cache",
+                    level=DoctorLevel.WARN,
+                    message="Thumbnail cache may contain Phasmid-related file traces.",
+                    detail="Consider clearing thumbnail cache for local hygiene.",
+                )
+    except OSError as exc:
+        return DoctorCheck(
+            name="Thumbnail Cache",
+            level=DoctorLevel.INFO,
+            message=f"Could not inspect thumbnail cache: {exc}",
+        )
+    return DoctorCheck(
+        name="Thumbnail Cache",
+        level=DoctorLevel.OK,
+        message="No obvious Phasmid traces detected in thumbnail cache sample.",
+    )
+
+
+def _check_system_journal() -> DoctorCheck:
+    """Best-effort systemd journal trace check; non-Linux returns unknown."""
+    if sys.platform != "linux":
+        return DoctorCheck(
+            name="System Journal",
+            level=DoctorLevel.INFO,
+            message="System journal check is Linux-only (unknown on this platform).",
+        )
+    try:
+        proc = subprocess.run(
+            ["journalctl", "--user", "-n", "200", "--no-pager"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return DoctorCheck(
+            name="System Journal",
+            level=DoctorLevel.INFO,
+            message="System journal not accessible for inspection.",
+        )
+    content = (proc.stdout or "").lower()
+    if any(term in content for term in ("phasmid", "vault.bin")):
+        return DoctorCheck(
+            name="System Journal",
+            level=DoctorLevel.WARN,
+            message="System journal contains recent Phasmid-related process traces.",
+            detail="Review and prune logs as required by local policy.",
+        )
+    return DoctorCheck(
+        name="System Journal",
+        level=DoctorLevel.OK,
+        message="No obvious Phasmid traces in recent user journal sample.",
+    )
+
+
+def _check_core_dumps() -> DoctorCheck:
+    """Check whether process core dumps are disabled (`ulimit -c` equivalent)."""
+    try:
+        soft, _hard = resource.getrlimit(resource.RLIMIT_CORE)
+    except (ValueError, OSError):
+        return DoctorCheck(
+            name="Core Dumps",
+            level=DoctorLevel.INFO,
+            message="Core dump limit could not be determined.",
+        )
+    if soft == 0:
+        return DoctorCheck(
+            name="Core Dumps",
+            level=DoctorLevel.OK,
+            message="Core dumps are disabled for this session.",
+        )
+    return DoctorCheck(
+        name="Core Dumps",
+        level=DoctorLevel.WARN,
+        message=f"Core dump limit is non-zero ({soft}).",
+        detail="Set `ulimit -c 0` for sensitive sessions.",
+    )
+
+
+def _check_compressed_swap() -> DoctorCheck:
+    """Check zswap/zram posture because compressed swap can retain sensitive pages."""
+    if sys.platform != "linux":
+        return DoctorCheck(
+            name="Compressed Swap",
+            level=DoctorLevel.INFO,
+            message="Compressed swap check is Linux-only (unknown on this platform).",
+        )
+    try:
+        zswap_flag = Path("/sys/module/zswap/parameters/enabled")
+        zswap_enabled = zswap_flag.exists() and zswap_flag.read_text(
+            encoding="utf-8", errors="ignore"
+        ).strip().upper() in {"Y", "1"}
+    except OSError:
+        zswap_enabled = False
+    zram_devices = list(Path("/sys/block").glob("zram*"))
+    if zswap_enabled or zram_devices:
+        return DoctorCheck(
+            name="Compressed Swap",
+            level=DoctorLevel.WARN,
+            message="Compressed swap (zswap/zram) appears enabled.",
+            detail="Disable compressed swap for stricter local artifact hygiene.",
+        )
+    return DoctorCheck(
+        name="Compressed Swap",
+        level=DoctorLevel.OK,
+        message="No active zswap/zram indicators detected.",
+    )
+
+
+def _check_recent_file_activity(vault_path: Path) -> DoctorCheck:
+    """Warn when vault atime/mtime imply very recent usage exposure."""
+    if not vault_path.exists():
+        return DoctorCheck(
+            name="Recent File Activity",
+            level=DoctorLevel.INFO,
+            message="Vault file not present; recent activity check unavailable.",
+        )
+    try:
+        st = vault_path.stat()
+    except OSError as exc:
+        return DoctorCheck(
+            name="Recent File Activity",
+            level=DoctorLevel.INFO,
+            message=f"Could not inspect vault timestamps: {exc}",
+        )
+    now = time.time()
+    threshold = int(os.environ.get("PHASMID_DOCTOR_RECENT_SECONDS", "86400"))
+    if now - max(st.st_mtime, st.st_atime) <= threshold:
+        return DoctorCheck(
+            name="Recent File Activity",
+            level=DoctorLevel.WARN,
+            message="Vault file timestamps indicate recent local use.",
+            detail="Recent atime/mtime can reveal operational timing.",
+        )
+    return DoctorCheck(
+        name="Recent File Activity",
+        level=DoctorLevel.OK,
+        message="Vault file timestamps are not recent.",
+    )
+
+
+def _check_vault_size_record(vault_path: Path) -> DoctorCheck:
+    """Compare vault size against optional local baseline record.
+
+    Baseline file: `<state_dir>/vault.size` (bytes as integer).
+    """
+    if not vault_path.exists():
+        return DoctorCheck(
+            name="Vault Size Record",
+            level=DoctorLevel.INFO,
+            message="Vault file not present; size baseline check unavailable.",
+        )
+    baseline_file = Path(state_dir()) / "vault.size"
+    if not baseline_file.exists():
+        return DoctorCheck(
+            name="Vault Size Record",
+            level=DoctorLevel.INFO,
+            message="Vault size baseline is not recorded (unknown).",
+        )
+    try:
+        expected = int(baseline_file.read_text(encoding="utf-8").strip())
+        actual = vault_path.stat().st_size
+    except (OSError, ValueError) as exc:
+        return DoctorCheck(
+            name="Vault Size Record",
+            level=DoctorLevel.INFO,
+            message=f"Vault size baseline could not be parsed: {exc}",
+        )
+    if actual != expected:
+        return DoctorCheck(
+            name="Vault Size Record",
+            level=DoctorLevel.WARN,
+            message=f"Vault size differs from baseline (expected {expected}, actual {actual}).",
+            detail="Investigate unexpected container-size drift.",
+        )
+    return DoctorCheck(
+        name="Vault Size Record",
+        level=DoctorLevel.OK,
+        message="Vault size matches local baseline record.",
+    )
+
+
 def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
     cfg = config_dir()
+    vault_path = Path("vault.bin")
     checks = [
         _check_dir_permissions(cfg, "Configuration directory"),
         _check_dir_permissions(cfg / "profiles", "Profile directory"),
@@ -256,7 +511,14 @@ def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
         _check_secure_random(),
         _check_volatile_state(),
         _check_process_hardening(),
+        _check_recent_documents_cache(),
+        _check_thumbnail_cache(),
+        _check_system_journal(),
+        _check_core_dumps(),
+        _check_compressed_swap(),
         _check_shell_history(),
+        _check_recent_file_activity(vault_path),
+        _check_vault_size_record(vault_path),
         _check_swap(),
         _check_scrollback(),
         _check_debug_logging(),

--- a/src/phasmid/templates/store.html
+++ b/src/phasmid/templates/store.html
@@ -44,7 +44,7 @@
             <details>
                 <summary>Advanced</summary>
                 <div class="detail-body">
-                    {{ ui.password_field("restricted_recovery_password", "Optional restricted recovery passphrase", "May update local state after successful recovery", False) }}
+                    {{ ui.password_field("secondary_passphrase", "Optional secondary passphrase", "May update local state after successful recovery", False) }}
                     <label class="field">
                         <span>Local note label</span>
                         <input type="text" name="local_note_label" placeholder="Optional local label">
@@ -197,7 +197,7 @@
             return;
         }
         const accessPassword = formData.get('password') || '';
-        const restrictedPassword = formData.get('restricted_recovery_password') || '';
+        const restrictedPassword = formData.get('secondary_passphrase') || '';
         if (restrictedPassword && restrictedPassword === accessPassword) {
             toast('Access and restricted recovery passwords must be different.', 'error');
             return;

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -301,7 +301,9 @@ def _template_context(request: Request, active="home", **extra):
         "deployment_mode": active_policy().name,
         "restricted_confirmed": restricted_confirmed,
         "restricted_session_seconds_remaining": (
-            _restricted_session_seconds_remaining(request) if restricted_confirmed else 0
+            _restricted_session_seconds_remaining(request)
+            if restricted_confirmed
+            else 0
         ),
         "face_enrollment_enabled": _face_enrollment_allowed(),
         "face_lock": _face_lock_status(request),
@@ -632,6 +634,7 @@ async def store(
     request: Request,
     file: UploadFile = File(...),
     password: str = Form(...),
+    secondary_passphrase: str = Form(default=""),
     restricted_recovery_password: str = Form(default=""),
     local_note_label: str = Form(default=""),
     entry_hint: str = Form(default=""),
@@ -645,9 +648,12 @@ async def store(
     try:
         if not password:
             return {"error": text.ACCESS_PASSWORD_REQUIRED}
+        effective_secondary_passphrase = (
+            secondary_passphrase or restricted_recovery_password
+        )
         passphrase_check = check_store_passphrases(
             password,
-            restricted_recovery_password,
+            effective_secondary_passphrase,
         )
         if not passphrase_check.ok:
             return {"error": passphrase_check.message}
@@ -681,7 +687,7 @@ async def store(
             access_cue_service.sequence_for_mode(mode),
             filename=orig_filename,
             mode=mode,
-            restricted_recovery_password=restricted_recovery_password or None,
+            restricted_recovery_password=effective_secondary_passphrase or None,
         )
         audit_event(
             "payload_stored",
@@ -1045,7 +1051,9 @@ async def operator_guided(request: Request):
     return templates.TemplateResponse(
         request=request,
         name="operator_guided.html",
-        context=_template_context(request, active="operator-guided", workflows=workflows),
+        context=_template_context(
+            request, active="operator-guided", workflows=workflows
+        ),
     )
 
 
@@ -1070,7 +1078,10 @@ async def operator_inspect_post(
     if guard:
         return guard
     import tempfile as _tmpfile
-    suffix = "".join(c for c in (file.filename or "upload") if c.isalnum() or c in "._-")[-64:]
+
+    suffix = "".join(
+        c for c in (file.filename or "upload") if c.isalnum() or c in "._-"
+    )[-64:]
     with _tmpfile.NamedTemporaryFile(delete=False, suffix="_" + suffix) as tmp:
         tmp.write(await file.read())
         tmp_path = tmp.name
@@ -1078,6 +1089,7 @@ async def operator_inspect_post(
         inspection = inspect_vessel(tmp_path)
     finally:
         import os as _os
+
         _os.unlink(tmp_path)
     result: dict[str, object] | None = None
     if inspection.error:
@@ -1085,7 +1097,10 @@ async def operator_inspect_post(
     else:
         result = {
             "error": None,
-            "fields": [{"label": f.label, "value": f.value, "note": f.note or ""} for f in inspection.fields],
+            "fields": [
+                {"label": f.label, "value": f.value, "note": f.note or ""}
+                for f in inspection.fields
+            ],
             "notes": inspection.notes,
         }
     return templates.TemplateResponse(

--- a/tests/test_doctor_m4.py
+++ b/tests/test_doctor_m4.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from phasmid.services.doctor_service import run_doctor_checks
+
+
+class DoctorM4Checks(unittest.TestCase):
+    def test_doctor_includes_sh14_and_sh15_checks(self):
+        result = run_doctor_checks()
+        names = {check.name for check in result.checks}
+        expected = {
+            "Recent File Activity",
+            "Vault Size Record",
+            "Recent Documents Cache",
+            "Thumbnail Cache",
+            "System Journal",
+            "Core Dumps",
+            "Compressed Swap",
+            "Shell History",
+        }
+        self.assertTrue(expected.issubset(names))
+
+    def test_shell_history_warns_when_histfile_contains_phasmid_usage(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "SHELL": "/bin/bash",
+                "HISTFILE": "/tmp/fake_hist",
+            },
+            clear=False,
+        ):
+            fake_history = "python -m phasmid doctor --no-tui\n"
+            with (
+                mock.patch("pathlib.Path.exists", return_value=True),
+                mock.patch("pathlib.Path.read_text", return_value=fake_history),
+            ):
+                result = run_doctor_checks()
+        shell_check = next(
+            check for check in result.checks if check.name == "Shell History"
+        )
+        self.assertIn("contains recent Phasmid-related commands", shell_check.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/webui/test_source_leakage.py
+++ b/tests/webui/test_source_leakage.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from tests.scenarios.forbidden_terms import (
+    FORBIDDEN_IN_ALL_MODES_HTML,
+    FORBIDDEN_IN_FIELD_MODE_HTML,
+)
+
+TEMPLATES_DIR = Path(ROOT) / "src" / "phasmid" / "templates"
+
+
+class WebUISourceLeakageTests(unittest.TestCase):
+    def test_templates_do_not_include_forbidden_internal_terms(self):
+        terms = sorted(
+            {
+                term
+                for term, _reason in (
+                    FORBIDDEN_IN_ALL_MODES_HTML + FORBIDDEN_IN_FIELD_MODE_HTML
+                )
+            }
+        )
+        offenders: list[str] = []
+        for template in TEMPLATES_DIR.glob("*.html"):
+            content = template.read_text(encoding="utf-8")
+            for term in terms:
+                if term in content:
+                    offenders.append(f"{template.name}: {term}")
+        self.assertFalse(
+            offenders,
+            "Forbidden internal terms found in template sources:\n"
+            + "\n".join(offenders),
+        )
+
+    def test_templates_do_not_include_html_comments(self):
+        offenders: list[str] = []
+        for template in TEMPLATES_DIR.glob("*.html"):
+            content = template.read_text(encoding="utf-8")
+            if "<!--" in content or "-->" in content:
+                offenders.append(template.name)
+        self.assertFalse(
+            offenders,
+            "HTML comments should not remain in production templates:\n"
+            + "\n".join(offenders),
+        )
+
+    def test_no_i18n_keys_use_forbidden_terms(self):
+        # i18n key transport is attribute-based in templates if used at all.
+        terms = sorted(
+            {
+                term
+                for term, _reason in (
+                    FORBIDDEN_IN_ALL_MODES_HTML + FORBIDDEN_IN_FIELD_MODE_HTML
+                )
+            }
+        )
+        offenders: list[str] = []
+        for template in TEMPLATES_DIR.glob("*.html"):
+            content = template.read_text(encoding="utf-8")
+            if "data-i18n" not in content:
+                continue
+            for term in terms:
+                if term in content:
+                    offenders.append(f"{template.name}: {term}")
+        self.assertFalse(
+            offenders,
+            "Forbidden terms found in i18n key-bearing template source:\n"
+            + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement SH-14 doctor expansions with best-effort host-artifact checks (recent documents cache, thumbnail cache, system journal traces, core dump posture, compressed swap posture, shell history file inspection)
- implement SH-15 hygiene checks in doctor (recent vault activity via atime/mtime and optional size-baseline comparison), and add a design note for `phasmid touch-vault`
- implement SH-16 source leakage test coverage for template source terms, JS-visible content, i18n-bearing source checks, and HTML comment absence
- keep existing doctor output contract non-blocking and compatible
- replace WebUI field name exposure in template source with neutral `secondary_passphrase` while preserving backward-compatible server input handling

## What this enables to claim
This PR enables M4 claims that Phasmid can self-diagnose additional host artifact risks and can test WebUI source surfaces for internal-term leakage using the shared forbidden-term inventory.

## What remains unclaimable
This PR does not claim forensic erasure, complete host artifact elimination, or deterministic suppression of all platform-specific traces; checks remain best-effort and observational.

## Tests
- `python3 -m unittest tests.test_doctor_m4 tests.webui.test_source_leakage tests.test_web_server tests.test_tui tests.test_operations tests.scenarios.test_field_mode_visibility`
- `python3 -m ruff check src/phasmid/services/doctor_service.py src/phasmid/web_server.py tests/test_doctor_m4.py tests/webui/test_source_leakage.py`
- `python3 -m black --check src/phasmid/services/doctor_service.py src/phasmid/web_server.py tests/test_doctor_m4.py tests/webui/test_source_leakage.py`

Closes #67
Closes #68
Closes #69
