### PR TITLE
feat(m6): reproducible builds, dependency pinning/audit, changelog and versioning policy (SH-21..24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run Python security scanner
         run: python -m bandit -r src -q --severity-level medium --confidence-level high
 
+      - name: Run dependency vulnerability audit
+        run: python -m pip_audit -r requirements.txt
+
       - name: Run unit tests with coverage and enforce threshold
         run: |
           python -m coverage run --source=src -m unittest discover -s tests
@@ -63,3 +66,30 @@ jobs:
         with:
           name: phasmid-release-review
           path: /tmp/phasmid-release
+
+  reproducible-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-dev.txt
+
+      - name: Build artifacts twice and compare hashes
+        run: |
+          export SOURCE_DATE_EPOCH=1700000000
+          python scripts/generate_release_artifacts.py --output-dir /tmp/repro-a --archive
+          python scripts/generate_release_artifacts.py --output-dir /tmp/repro-b --archive
+          sha256sum /tmp/repro-a/MANIFEST.sha256 /tmp/repro-a/sbom.cyclonedx.json /tmp/repro-a/release-summary.json /tmp/repro-a/phasmid-release.tar.gz | awk '{print $1}' > /tmp/repro-a.sha
+          sha256sum /tmp/repro-b/MANIFEST.sha256 /tmp/repro-b/sbom.cyclonedx.json /tmp/repro-b/release-summary.json /tmp/repro-b/phasmid-release.tar.gz | awk '{print $1}' > /tmp/repro-b.sha
+          diff -u /tmp/repro-a.sha /tmp/repro-b.sha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows SemVer-style release intent for documented interfaces.
+
+## [Unreleased]
+
+### Added
+
+- M6 release-discipline controls for reproducible artifact generation, dependency audit checks, and release policy documentation.
+
+### Security
+
+- Dependency vulnerability scanning via `pip-audit` in CI.
+- Reproducible-build verification job added to CI to detect artifact drift.
+
+## [0.1.0-prototype] - 2026-05-07
+
+### Added
+
+- Unified JES operator interface (TUI + WebUI alignment and operator pages).
+- Threat model consolidation and claim/non-claim documentation baseline.
+- Crypto hygiene inventory and tests (nonce, constant-time, randomness checks).
+- M3 scenario/property/headerless invariant testing suite.
+- M4 operational artifact checks and WebUI source leakage checks.
+
+### Security
+
+- Restricted action policy enforcement and capture-visible response neutrality hardening.
+- Process hardening and volatile state support (`PHASMID_TMPFS_STATE`) with diagnostics.
+- Optional signed release manifest and SBOM generation.
+
+### Changed
+
+- Terminology alignment toward neutral operator-facing language.
+
+### Documentation
+
+- STRIDE analysis, device-binding analysis, split-key recovery analysis.
+- Security policy (`SECURITY.md`) and maintainer continuity note (`docs/BUS_FACTOR.md`).
+
+## Changelog Rule
+
+Security-impacting changes must be listed under a `### Security` section.
+

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Threat model and security review documents:
 - [`docs/NON_CLAIMS.md`](docs/NON_CLAIMS.md) — explicit non-claims and rationale
 - [`SECURITY.md`](SECURITY.md) — vulnerability disclosure policy
 - [`docs/BUS_FACTOR.md`](docs/BUS_FACTOR.md) — maintainer continuity note
+- [`docs/REPRODUCIBLE_BUILDS.md`](docs/REPRODUCIBLE_BUILDS.md) — reproducible release-review artifact procedure
+- [`docs/DEPENDENCIES.md`](docs/DEPENDENCIES.md) — dependency pinning and update policy
+- [`docs/VERSIONING.md`](docs/VERSIONING.md) — versioning and compatibility policy
+- [`CHANGELOG.md`](CHANGELOG.md) — release history and security-impact notes
 
 Operational review and deployment guidance can be found in:
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,35 @@
+# Dependency Policy
+
+This document defines dependency pinning and update discipline for Phasmid.
+
+## Pinning Rules
+
+- Runtime dependencies are pinned in `requirements.txt` with exact versions (`==`).
+- `cryptography` and `argon2-cffi` must remain fully pinned.
+- `pyproject.toml` `[project].dependencies` must match runtime dependency intent.
+- Development tooling dependencies are pinned in `requirements-dev.txt`.
+
+## Security Checks
+
+- CI runs `pip-audit` for known vulnerability checks.
+- CI also runs `bandit` for source-level security scanning.
+
+## Update Cadence
+
+- Default cadence: monthly dependency review.
+- Emergency cadence: immediate update for critical security advisories.
+- Every update must include:
+  - changelog note (`CHANGELOG.md`, include `### Security` when relevant),
+  - CI green status,
+  - no expansion of project claims beyond documented scope.
+
+## Alignment Expectation
+
+Dependency declarations in:
+
+- `requirements.txt`
+- `requirements-dev.txt`
+- `pyproject.toml`
+
+must stay consistent with each file’s role (runtime vs development tooling).
+

--- a/docs/REPRODUCIBLE_BUILDS.md
+++ b/docs/REPRODUCIBLE_BUILDS.md
@@ -1,0 +1,49 @@
+# Reproducible Builds
+
+Phasmid release-review artifacts are generated with deterministic settings so the same commit can produce bit-for-bit identical outputs.
+
+## Scope
+
+Reproducibility here applies to:
+
+- `MANIFEST.sha256`
+- `sbom.cyclonedx.json`
+- `release-summary.json`
+- `phasmid-release.tar.gz`
+
+via `scripts/generate_release_artifacts.py`.
+
+## Procedure
+
+Use a fixed source date epoch:
+
+```bash
+export SOURCE_DATE_EPOCH=1700000000
+python3 scripts/generate_release_artifacts.py --output-dir /tmp/repro-a --archive
+python3 scripts/generate_release_artifacts.py --output-dir /tmp/repro-b --archive
+sha256sum /tmp/repro-a/MANIFEST.sha256 /tmp/repro-a/sbom.cyclonedx.json /tmp/repro-a/release-summary.json /tmp/repro-a/phasmid-release.tar.gz > /tmp/repro-a.sha
+sha256sum /tmp/repro-b/MANIFEST.sha256 /tmp/repro-b/sbom.cyclonedx.json /tmp/repro-b/release-summary.json /tmp/repro-b/phasmid-release.tar.gz > /tmp/repro-b.sha
+diff -u /tmp/repro-a.sha /tmp/repro-b.sha
+```
+
+CI runs this comparison in the `reproducible-build` job.
+
+## Determinism Controls
+
+- Stable file ordering (`sorted` paths).
+- Fixed SBOM timestamp from `SOURCE_DATE_EPOCH` (or explicit `--source-date-epoch`).
+- Deterministic tar member metadata (uid/gid/uname/gname/mode/mtime).
+- Deterministic gzip timestamp (`mtime`).
+- Stable JSON key ordering (`sort_keys=True`).
+
+## Known Non-Determinism Sources
+
+- Building from a dirty tree or different commit contents.
+- Changing dependency declarations in `pyproject.toml`.
+- Different script versions or Python behavior changes outside supported range.
+- External files included by mistake outside repository controls.
+
+## Limits
+
+This process provides reproducibility for release-review artifacts, not for all possible runtime environments or OS package layers.
+

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,33 @@
+# Versioning Policy
+
+Phasmid uses a SemVer-style policy for documented interfaces and operational expectations.
+
+## SemVer Baseline
+
+- `MAJOR`: incompatible changes to documented behavior or compatibility contracts.
+- `MINOR`: backward-compatible functionality additions.
+- `PATCH`: backward-compatible fixes and maintenance updates.
+
+## Breaking-Change Rules Specific to Phasmid
+
+- Any `vault.bin` format change is a **MAJOR** bump.
+- Any removal of an existing claim from `docs/CLAIMS.md` is treated as a **MAJOR** change.
+
+## Prototype Naming Rule
+
+Pre-release prototype tags use:
+
+- `0.x.y-prototype`
+
+Example:
+
+- `0.1.0-prototype`
+
+## Documentation Alignment Requirement
+
+A version update should ship with:
+
+- `CHANGELOG.md` entry,
+- updated security-impact notes under `### Security` when applicable,
+- claims and non-claims consistency checks (`docs/CLAIMS.md` / `docs/NON_CLAIMS.md`).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,21 @@ name = "phasmid"
 version = "0.1.0"
 description = "Phasmid local-only coercion-aware storage prototype"
 requires-python = ">=3.10"
+dependencies = [
+    "cryptography==46.0.7",
+    "argon2-cffi==25.1.0",
+    "fastapi==0.136.1",
+    "jinja2==3.1.6",
+    "numpy==2.2.6",
+    "opencv-python-headless==4.13.0.92",
+    "platformdirs==4.9.6",
+    "python-multipart==0.0.27",
+    "rich==15.0.0",
+    "textual==8.2.5",
+    "tomli==2.4.1; python_version < \"3.11\"",
+    "tomli-w==1.2.0",
+    "uvicorn==0.46.0",
+]
 
 [project.scripts]
 phasmid = "phasmid.cli:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ coverage==7.12.0
 hypothesis>=6.100.0
 ruff==0.9.4
 mypy==1.15.0
+pip-audit==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
-cryptography==46.0.4
+cryptography==46.0.7
+argon2-cffi==25.1.0
 fastapi==0.136.1
 jinja2==3.1.6
 numpy==2.2.6
 opencv-python-headless==4.13.0.92
-platformdirs>=4.0.0
+platformdirs==4.9.6
 python-multipart==0.0.27
-rich>=13.0.0
-textual>=0.47.0
-tomli>=2.0.0; python_version < "3.11"
-tomli-w>=1.0.0
+rich==15.0.0
+textual==8.2.5
+tomli==2.4.1; python_version < "3.11"
+tomli-w==1.2.0
 uvicorn==0.46.0

--- a/scripts/generate_release_artifacts.py
+++ b/scripts/generate_release_artifacts.py
@@ -4,8 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import hashlib
+import io
 import json
+import os
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -44,6 +47,16 @@ INCLUDED_SUFFIXES = {
 INCLUDED_NAMES = {".gitignore", "LICENSE", "README.md"}
 
 
+def _source_date_epoch(explicit: int | None = None) -> int:
+    if explicit is not None:
+        return max(0, int(explicit))
+    value = os.environ.get("SOURCE_DATE_EPOCH", "0")
+    try:
+        return max(0, int(value))
+    except ValueError:
+        return 0
+
+
 def should_include(path: Path, base_dir: Path):
     relative = path.relative_to(base_dir)
     if any(part in EXCLUDED_DIRS for part in relative.parts):
@@ -55,9 +68,13 @@ def should_include(path: Path, base_dir: Path):
     return path.suffix in INCLUDED_SUFFIXES
 
 
-def collect_release_files(base_dir: Path):
+def collect_release_files(base_dir: Path, excluded_roots: list[Path] | None = None):
+    excluded_roots = [root.resolve() for root in (excluded_roots or [])]
     files = []
     for path in base_dir.rglob("*"):
+        resolved = path.resolve()
+        if any(resolved.is_relative_to(root) for root in excluded_roots):
+            continue
         if path.is_file() and should_include(path, base_dir):
             files.append(path.relative_to(base_dir))
     return sorted(files, key=lambda item: item.as_posix())
@@ -97,14 +114,15 @@ def read_project_dependencies(pyproject_path: Path):
         value = line.strip(",").strip('"')
         if value:
             dependencies.append(value)
-    return dependencies
+    return sorted(set(dependencies))
 
 
 def dependency_component(dependency: str):
-    if "==" in dependency:
-        name, version = dependency.split("==", 1)
+    normalized = dependency.split(";", 1)[0].strip()
+    if "==" in normalized:
+        name, version = normalized.split("==", 1)
     else:
-        name, version = dependency, None
+        name, version = normalized, None
     component = {
         "type": "library",
         "name": name,
@@ -116,14 +134,15 @@ def dependency_component(dependency: str):
     return component
 
 
-def write_sbom(base_dir: Path, output_path: Path):
+def write_sbom(base_dir: Path, output_path: Path, source_date_epoch: int):
     dependencies = read_project_dependencies(base_dir / "pyproject.toml")
+    timestamp = datetime.fromtimestamp(source_date_epoch, tz=timezone.utc).isoformat()
     sbom = {
         "bomFormat": "CycloneDX",
         "specVersion": "1.5",
         "version": 1,
         "metadata": {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": timestamp,
             "component": {
                 "type": "application",
                 "name": "phasmid-vault",
@@ -137,10 +156,28 @@ def write_sbom(base_dir: Path, output_path: Path):
     return sbom
 
 
-def write_archive(base_dir: Path, output_path: Path, files):
-    with tarfile.open(output_path, "w:gz") as archive:
-        for relative in files:
-            archive.add(base_dir / relative, arcname=relative.as_posix())
+def write_archive(base_dir: Path, output_path: Path, files, source_date_epoch: int):
+    with open(output_path, "wb") as raw:
+        with gzip.GzipFile(
+            filename="",
+            mode="wb",
+            fileobj=raw,
+            mtime=source_date_epoch,
+            compresslevel=9,
+        ) as gz:
+            with tarfile.open(fileobj=gz, mode="w") as archive:
+                for relative in files:
+                    abs_path = base_dir / relative
+                    data = abs_path.read_bytes()
+                    info = tarfile.TarInfo(name=relative.as_posix())
+                    info.size = len(data)
+                    info.mtime = source_date_epoch
+                    info.uid = 0
+                    info.gid = 0
+                    info.uname = ""
+                    info.gname = ""
+                    info.mode = 0o644
+                    archive.addfile(info, io.BytesIO(data))
 
 
 def sign_manifest(manifest_path: Path, signature_path: Path, key_path: Path):
@@ -154,7 +191,9 @@ def sign_manifest(manifest_path: Path, signature_path: Path, key_path: Path):
     signature_path.write_bytes(signature)
 
 
-def verify_manifest_signature(manifest_path: Path, signature_path: Path, key_path: Path):
+def verify_manifest_signature(
+    manifest_path: Path, signature_path: Path, key_path: Path
+):
     public_key = serialization.load_pem_public_key(key_path.read_bytes())
     if not isinstance(public_key, Ed25519PublicKey):
         raise ValueError("verify key must be an Ed25519 public key")
@@ -164,10 +203,18 @@ def verify_manifest_signature(manifest_path: Path, signature_path: Path, key_pat
         raise ValueError("manifest signature verification failed") from exc
 
 
-def generate(base_dir: Path, output_dir: Path, archive: bool = False, signing_key: Path | None = None):
+def generate(
+    base_dir: Path,
+    output_dir: Path,
+    archive: bool = False,
+    signing_key: Path | None = None,
+    source_date_epoch: int | None = None,
+):
     base_dir = base_dir.resolve()
+    output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
-    files = collect_release_files(base_dir)
+    files = collect_release_files(base_dir, excluded_roots=[output_dir])
+    epoch = _source_date_epoch(source_date_epoch)
 
     manifest_path = output_dir / "MANIFEST.sha256"
     manifest_sig_path = output_dir / "MANIFEST.sha256.sig"
@@ -175,13 +222,13 @@ def generate(base_dir: Path, output_dir: Path, archive: bool = False, signing_ke
     summary_path = output_dir / "release-summary.json"
 
     manifest_lines = write_manifest(base_dir, manifest_path, files)
-    sbom = write_sbom(base_dir, sbom_path)
+    sbom = write_sbom(base_dir, sbom_path, epoch)
     if signing_key is not None:
         sign_manifest(manifest_path, manifest_sig_path, signing_key)
     archive_path = None
     if archive:
         archive_path = output_dir / "phasmid-release.tar.gz"
-        write_archive(base_dir, archive_path, files)
+        write_archive(base_dir, archive_path, files, epoch)
 
     summary = {
         "archive": archive_path.name if archive_path else None,
@@ -193,6 +240,7 @@ def generate(base_dir: Path, output_dir: Path, archive: bool = False, signing_ke
         "manifest_signature": manifest_sig_path.name if signing_key else None,
         "sbom": sbom_path.name,
         "sbom_components": len(sbom["components"]),
+        "source_date_epoch": epoch,
     }
     summary_path.write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
@@ -216,6 +264,15 @@ def main(argv=None):
         default=None,
         help="optional Ed25519 private key PEM for manifest signing",
     )
+    parser.add_argument(
+        "--source-date-epoch",
+        type=int,
+        default=None,
+        help=(
+            "UNIX epoch to stamp reproducible artifacts "
+            "(default: SOURCE_DATE_EPOCH env or 0)"
+        ),
+    )
     args = parser.parse_args(argv)
 
     summary = generate(
@@ -223,6 +280,7 @@ def main(argv=None):
         output_dir=Path(args.output_dir),
         archive=args.archive,
         signing_key=Path(args.signing_key) if args.signing_key else None,
+        source_date_epoch=args.source_date_epoch,
     )
     print(f"release artifacts generated: {summary['manifest']}, {summary['sbom']}")
 

--- a/src/phasmid/config.py
+++ b/src/phasmid/config.py
@@ -31,7 +31,7 @@ def env_int(name: str, default: int, minimum: int | None = None) -> int:
     return value
 
 
-def state_dir():
+def state_dir() -> str:
     tmpfs = tmpfs_state_dir()
     if tmpfs:
         return tmpfs
@@ -43,46 +43,46 @@ def tmpfs_state_dir() -> str | None:
     return value or None
 
 
-def env_flag(name, default=False):
+def env_flag(name: str, default: bool = False) -> bool:
     value = os.environ.get(name)
     if value is None:
         return default
     return value.lower() not in {"0", "false", "off", "no", ""}
 
 
-def purge_confirmation_required():
+def purge_confirmation_required() -> bool:
     return env_flag("PHASMID_PURGE_CONFIRMATION", default=True)
 
 
-def duress_mode_enabled():
+def duress_mode_enabled() -> bool:
     return env_flag("PHASMID_DURESS_MODE", default=False)
 
 
-def ui_face_lock_enabled():
+def ui_face_lock_enabled() -> bool:
     return env_flag("PHASMID_UI_FACE_LOCK", default=False)
 
 
-def ui_face_enrollment_enabled():
+def ui_face_enrollment_enabled() -> bool:
     return env_flag("PHASMID_UI_FACE_ENROLL", default=False)
 
 
-def field_mode_enabled():
+def field_mode_enabled() -> bool:
     return env_flag("PHASMID_FIELD_MODE", default=False)
 
 
-def passphrase_min_length():
+def passphrase_min_length() -> int:
     return env_int("PHASMID_MIN_PASSPHRASE_LENGTH", 10, minimum=1)
 
 
-def access_max_failures():
+def access_max_failures() -> int:
     return env_int("PHASMID_ACCESS_MAX_FAILURES", 5, minimum=1)
 
 
-def access_lockout_seconds():
+def access_lockout_seconds() -> int:
     return env_int("PHASMID_ACCESS_LOCKOUT_SECONDS", 60, minimum=1)
 
 
-def dual_approval_enabled():
+def dual_approval_enabled() -> bool:
     return env_flag("PHASMID_DUAL_APPROVAL", default=False)
 
 

--- a/tests/test_dependency_policy.py
+++ b/tests/test_dependency_policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _read_lines(path: Path) -> list[str]:
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def _extract_runtime_requirements(req_lines: list[str]) -> dict[str, str]:
+    deps: dict[str, str] = {}
+    for line in req_lines:
+        marker_split = line.split(";", 1)[0].strip()
+        match = re.match(r"^([A-Za-z0-9_.-]+)==(.+)$", marker_split)
+        if not match:
+            continue
+        deps[match.group(1).lower()] = match.group(2).strip()
+    return deps
+
+
+def _extract_pyproject_deps(pyproject_text: str) -> dict[str, str]:
+    deps: dict[str, str] = {}
+    in_deps = False
+    for raw in pyproject_text.splitlines():
+        line = raw.strip()
+        if line == "dependencies = [":
+            in_deps = True
+            continue
+        if in_deps and line == "]":
+            break
+        if not in_deps or not line.startswith('"'):
+            continue
+        dep = line.strip(",").strip('"')
+        marker_split = dep.split(";", 1)[0].strip()
+        match = re.match(r"^([A-Za-z0-9_.-]+)==(.+)$", marker_split)
+        if not match:
+            continue
+        deps[match.group(1).lower()] = match.group(2).strip()
+    return deps
+
+
+class DependencyPolicyTests(unittest.TestCase):
+    def test_runtime_requirements_are_pinned(self):
+        reqs = _read_lines(ROOT / "requirements.txt")
+        for line in reqs:
+            marker_split = line.split(";", 1)[0].strip()
+            self.assertRegex(
+                marker_split,
+                r"^[A-Za-z0-9_.-]+==.+$",
+                msg=f"requirement must be pinned: {line}",
+            )
+
+    def test_critical_crypto_dependencies_are_fully_pinned(self):
+        runtime = _extract_runtime_requirements(_read_lines(ROOT / "requirements.txt"))
+        self.assertIn("cryptography", runtime)
+        self.assertIn("argon2-cffi", runtime)
+        self.assertRegex(runtime["cryptography"], r"^\d")
+        self.assertRegex(runtime["argon2-cffi"], r"^\d")
+
+    def test_pyproject_and_requirements_runtime_sets_match(self):
+        runtime = _extract_runtime_requirements(_read_lines(ROOT / "requirements.txt"))
+        pyproject_runtime = _extract_pyproject_deps(
+            (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        )
+        self.assertEqual(runtime, pyproject_runtime)
+
+    def test_dependency_policy_docs_exist(self):
+        self.assertTrue((ROOT / "docs" / "DEPENDENCIES.md").exists())
+        self.assertTrue((ROOT / "docs" / "REPRODUCIBLE_BUILDS.md").exists())
+        self.assertTrue((ROOT / "docs" / "VERSIONING.md").exists())
+        self.assertTrue((ROOT / "CHANGELOG.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib.util
 import json
 import tempfile
@@ -22,6 +23,11 @@ def load_release_script():
 
 
 class ReleaseArtifactTests(unittest.TestCase):
+    def _sha256_file(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        digest.update(path.read_bytes())
+        return digest.hexdigest()
+
     def test_manifest_and_sbom_generation_exclude_runtime_files(self):
         module = load_release_script()
         tmpdir = Path(tempfile.mkdtemp())
@@ -35,7 +41,7 @@ class ReleaseArtifactTests(unittest.TestCase):
         (tmpdir / ".state" / "access.bin").write_bytes(b"local")
         (tmpdir / "vault.bin").write_bytes(b"vault")
         (tmpdir / "pyproject.toml").write_text(
-            '[project]\ndependencies = [\n    "cryptography==46.0.4",\n]\n',
+            '[project]\ndependencies = [\n    "cryptography==46.0.7",\n]\n',
             encoding="utf-8",
         )
 
@@ -52,6 +58,10 @@ class ReleaseArtifactTests(unittest.TestCase):
         )
         self.assertEqual(sbom["bomFormat"], "CycloneDX")
         self.assertEqual(sbom["components"][0]["name"], "cryptography")
+        self.assertEqual(
+            sbom["metadata"]["timestamp"],
+            "1970-01-01T00:00:00+00:00",
+        )
 
     def test_dependency_parser_handles_unpinned_values(self):
         module = load_release_script()
@@ -95,6 +105,38 @@ class ReleaseArtifactTests(unittest.TestCase):
             output_dir / "MANIFEST.sha256.sig",
             public_key_path,
         )
+
+    def test_generate_release_artifacts_is_bit_reproducible(self):
+        module = load_release_script()
+        tmpdir = Path(tempfile.mkdtemp())
+        (tmpdir / "src" / "phasmid").mkdir(parents=True)
+        (tmpdir / "src" / "phasmid" / "example.py").write_text(
+            "print('ok')\n",
+            encoding="utf-8",
+        )
+        (tmpdir / "README.md").write_text("phasmid\n", encoding="utf-8")
+        (tmpdir / "pyproject.toml").write_text(
+            '[project]\ndependencies = [\n    "cryptography==46.0.7",\n]\n',
+            encoding="utf-8",
+        )
+
+        out1 = Path(tempfile.mkdtemp()) / "out1"
+        out2 = Path(tempfile.mkdtemp()) / "out2"
+        module.generate(tmpdir, out1, archive=True, source_date_epoch=1700000000)
+        module.generate(tmpdir, out2, archive=True, source_date_epoch=1700000000)
+
+        files = [
+            "MANIFEST.sha256",
+            "sbom.cyclonedx.json",
+            "release-summary.json",
+            "phasmid-release.tar.gz",
+        ]
+        for name in files:
+            self.assertEqual(
+                self._sha256_file(out1 / name),
+                self._sha256_file(out2 / name),
+                msg=f"non-reproducible artifact: {name}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- SH-21: make scripts/generate_release_artifacts.py deterministic (fixed epoch, deterministic tar and gzip metadata, stable dependency ordering) and add a CI reproducibility job that builds twice and compares hashes.
- SH-22: align runtime dependencies between requirements.txt and pyproject.toml, fully pin cryptography and argon2-cffi, add a pip-audit CI gate, and add docs/DEPENDENCIES.md.
- SH-23: add CHANGELOG.md in Keep a Changelog format and define the Security section recording rule.
- SH-24: add docs/VERSIONING.md with SemVer policy, vault-format major bump rule, and claim-removal breaking-change rule.
- Add regression tests for release artifact reproducibility and dependency policy alignment.

## What this enables to claim
Phasmid now has a reproducible release-review artifact path with CI verification, explicit dependency pinning and vulnerability auditing policy, and documented release/versioning discipline aligned with claims management.

## What remains unclaimable
This PR does not claim field-proven security outcomes, forensic guarantees, or universal reproducibility across arbitrary external build systems; it scopes reproducibility to Phasmid release-review artifacts under documented controls.

## Validation
- python3 -m ruff check src tests scripts
- python3 -m black --check scripts/generate_release_artifacts.py tests/test_release_artifacts.py tests/test_dependency_policy.py
- python3 -m bandit -r src -q --severity-level medium --confidence-level high
- python3 -m unittest discover -s tests (467 passed)
- python3 -m pip_audit -r requirements.txt (no known vulnerabilities)
- reproducibility check: two builds with identical SOURCE_DATE_EPOCH produced identical hashes

Closes #74
Closes #75
Closes #76
Closes #77