### PR TITLE
Clarify security claims boundaries (Critique-1 / #103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ Phasmid is research software. It is not a replacement for full-disk encryption, 
 
 Phasmid does not promise perfect deniability. It reduces operational damage in some compelled-access scenarios by separating access conditions, local state, physical-object cues, and restricted recovery behavior.
 
+## Security Claims and Non-Claims
+
+Phasmid separates four concepts that are often conflated:
+
+- Software existence concealment: Phasmid does not claim this.
+- Data-existence deniability: partial and scenario-dependent.
+- Controlled disclosure: primary project claim.
+- Coercion-aware fallback behavior: operational goal.
+
+Phasmid claims:
+
+- separation of protected local state from coerced-disclosure output paths;
+- passphrase-based controlled disclosure of a specified local entry;
+- local-only operation by default, with WebUI bound to `127.0.0.1` unless explicitly changed;
+- reduced dependence on `vault.bin` alone through mixed local key material.
+
+Phasmid does not claim:
+
+- hiding the existence of the software from a capable forensic examiner;
+- perfect deniability under all adversary models;
+- guaranteed secure deletion on flash media;
+- protection against live memory capture, compromised hosts, or keyloggers;
+- forensic immunity of any kind.
+
+Tool discovery, repository discovery, process logs, shell history, and host artifacts can weaken operational deniability. Discovery of Phasmid does not by itself prove the existence of additional undisclosed data, but it does narrow ambiguity and should be treated as an operational risk.
+
 ## Philosophy
 
 Phasmid follows a simple rule: no lies, no unnecessary truth.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -431,3 +431,11 @@ This build reads and writes JES v3 records only. Earlier development containers 
 ## 19. Limits
 
 Phasmid does not guarantee protection against a compromised OS, live memory capture, keylogging, camera observation, forced disclosure, complete secure deletion, deniability, or unsafe network exposure.
+
+Phasmid does not claim software existence concealment. Discovery of project files, binaries, logs, or deployment traces can reveal that coercion-aware storage software is present.
+
+The intended claim boundary is:
+
+- controlled disclosure is in scope;
+- data-existence deniability is partial and scenario-dependent;
+- software existence concealment is out of scope.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -11,6 +11,30 @@ A structured STRIDE analysis mapping this model to the six threat categories is 
 
 ---
 
+## Security Claims and Non-Claims
+
+Phasmid does not claim to conceal the existence of encryption or coercion-aware storage software from a capable examiner. If the project files, binaries, or deployment traces are discovered, software existence is observable.
+
+The project distinguishes:
+
+- Software existence concealment: out of scope.
+- Data-existence deniability: partial and adversary-dependent.
+- Controlled disclosure: in scope and central to the design.
+- Coercion-aware fallback behavior: in scope as an operational objective.
+
+Discovery of Phasmid can weaken operational deniability, but software discovery alone does not prove the existence of additional undisclosed protected data.
+
+Non-claims are explicit:
+
+- no perfect deniability;
+- no guaranteed secure deletion on flash media;
+- no protection against compromised hosts, keyloggers, or live memory capture;
+- no forensic immunity.
+
+For the full non-claim inventory and rationale, see `docs/NON_CLAIMS.md`.
+
+---
+
 ## In-Scope Adversaries
 
 | Adversary | Capability | Goal |


### PR DESCRIPTION
## Summary
- add a dedicated "Security Claims and Non-Claims" section to README
- add corresponding claim-boundary section to docs/THREAT_MODEL.md
- align docs/SPECIFICATION.md limits section with explicit concealment boundary

## Why
Implements #103 by explicitly separating software-existence concealment, data-existence deniability, controlled disclosure, and coercion-aware fallback behavior.

## Validation
- python3 -m unittest discover -s tests

Closes #103