### PR TITLE
Separate evaluation prototype from field form factor (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ Until those validation gates are completed on target hardware, Phasmid should be
 
 The Raspberry Pi Zero 2 W remote SSH field-test harness work is tracked in GitHub issues `#89` through `#94`. Those issues define the planned validation workflow; they are not themselves evidence that target-hardware validation has been completed.
 
+## Hardware Form Factor Boundary
+
+Current Phasmid hardware is an evaluation prototype, not a hostile-inspection-ready field form factor.
+
+Evaluation prototype (current):
+
+- Raspberry Pi Zero 2 W-based build;
+- visible camera module and development-oriented wiring may be present;
+- intended for development, benchmarking, protocol validation, and controlled operator training.
+
+Future field form factor (not solved in current codebase):
+
+- benign external appearance appropriate to operating context;
+- no visually obvious camera/security-hardware signal;
+- possession plausibility and interaction pattern that do not attract unnecessary inspection.
+
+This distinction is operational, not cosmetic. Validation on Raspberry Pi Zero 2 W does not by itself solve physical plausibility under hostile inspection.
+
 ## Safe Use Boundary
 
 Phasmid is intended for lawful local protection of sensitive material where device seizure, compelled access, or over-disclosure are realistic risks.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -53,6 +53,16 @@ A structured STRIDE analysis mapping this model to the six threat categories is 
 
 ---
 
+## Hardware Form Factor Considerations
+
+Phasmid currently targets a transparent evaluation prototype form factor (for example, Raspberry Pi Zero 2 W with visible camera hardware) to support reproducible testing and operator evaluation.
+
+This prototype form factor is not designed to appear benign under hostile physical inspection. Hardware recognition by technically informed examiners, visible camera modules, and conspicuous enclosure/wiring choices are operational threat vectors separate from software security properties.
+
+The current codebase does not claim to solve possession plausibility or hostile-inspection-safe industrial design. Those are separate engineering and deployment problems.
+
+---
+
 ## Assets
 
 - Payload bytes and encrypted payload metadata.


### PR DESCRIPTION
## Summary
- add README section that separates current evaluation prototype hardware from future field form factor requirements
- add threat-model section for hardware visibility and possession-plausibility risk
- clarify that hardware-form-factor plausibility is separate from current software/security validation

## Why
Implements #107 to avoid overstating operational readiness under hostile physical inspection.

## Validation
- python3 -m unittest discover -s tests

Closes #107