### PR TITLE
Add LUKS layer/key-store foundation with tests (#96)

### DIFF
--- a/src/phasmid/config.py
+++ b/src/phasmid/config.py
@@ -10,6 +10,14 @@ AUDIT_LOG_NAME = "events.log"
 AUDIT_AUTH_NAME = "events.auth"
 ROLE_STATE_NAME = "roles.bin"
 
+# LUKS layer configuration
+PHASMID_LUKS_MODE = os.getenv("PHASMID_LUKS_MODE", "disabled")
+PHASMID_LUKS_CONTAINER = os.getenv("PHASMID_LUKS_CONTAINER", "/opt/phasmid/luks.img")
+PHASMID_LUKS_MOUNT_POINT = os.getenv(
+    "PHASMID_LUKS_MOUNT_POINT", "/mnt/phasmid-vault"
+)
+PHASMID_LUKS_ITER_TIME_MS = int(os.getenv("PHASMID_LUKS_ITER_TIME_MS", "2000"))
+
 
 def env_text(name: str, default: str = "") -> str:
     value = os.environ.get(name)

--- a/src/phasmid/luks_key_store.py
+++ b/src/phasmid/luks_key_store.py
@@ -1,0 +1,44 @@
+"""Volatile key-store helper for LUKS wrapper integration."""
+
+from __future__ import annotations
+
+import os
+
+
+class LuksKeyStore:
+    """Manage ephemeral key material for LUKS helper scripts."""
+
+    KEY_FILE_NAME = "luks.key"
+    KEY_SIZE = 32
+
+    def __init__(self, base_dir: str = "/run/phasmid"):
+        self.base_dir = base_dir
+        self.key_path = os.path.join(base_dir, self.KEY_FILE_NAME)
+
+    def generate_and_store(self) -> bytes:
+        os.makedirs(self.base_dir, mode=0o700, exist_ok=True)
+        try:
+            os.chmod(self.base_dir, 0o700)
+        except OSError:
+            pass
+        key = os.urandom(self.KEY_SIZE)
+        with open(self.key_path, "wb") as handle:
+            handle.write(key)
+        try:
+            os.chmod(self.key_path, 0o600)
+        except OSError:
+            pass
+        return key
+
+    def destroy(self) -> bool:
+        if not os.path.exists(self.key_path):
+            return True
+        try:
+            length = os.path.getsize(self.key_path)
+            with open(self.key_path, "r+b") as handle:
+                handle.seek(0)
+                handle.write(os.urandom(max(length, self.KEY_SIZE)))
+            os.remove(self.key_path)
+            return True
+        except OSError:
+            return False

--- a/src/phasmid/luks_layer.py
+++ b/src/phasmid/luks_layer.py
@@ -8,6 +8,7 @@ import subprocess
 from dataclasses import dataclass
 from enum import Enum
 
+
 class LuksMode(str, Enum):
     FILE_CONTAINER = "file"
     PARTITION = "partition"

--- a/src/phasmid/luks_layer.py
+++ b/src/phasmid/luks_layer.py
@@ -1,0 +1,90 @@
+"""LUKS layer status and availability primitives (non-privileged phase)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+
+class LuksMode(str, Enum):
+    FILE_CONTAINER = "file"
+    PARTITION = "partition"
+    DISABLED = "disabled"
+
+    @classmethod
+    def from_text(cls, value: str) -> "LuksMode":
+        normalized = (value or "").strip().lower()
+        if normalized == cls.FILE_CONTAINER.value:
+            return cls.FILE_CONTAINER
+        if normalized == cls.PARTITION.value:
+            return cls.PARTITION
+        return cls.DISABLED
+
+
+@dataclass(slots=True)
+class LuksMountResult:
+    success: bool
+    mounted: bool
+    mode: LuksMode
+    mount_point: str
+    error_message: str = ""
+
+
+@dataclass(slots=True)
+class LuksConfig:
+    mode: LuksMode
+    container_path: str = "/opt/phasmid/luks.img"
+    mount_point: str = "/mnt/phasmid-vault"
+    iter_time_ms: int = 2000
+
+    @classmethod
+    def from_env(cls) -> "LuksConfig":
+        return cls(
+            mode=LuksMode.from_text(os.getenv("PHASMID_LUKS_MODE", "disabled")),
+            container_path=os.getenv("PHASMID_LUKS_CONTAINER", "/opt/phasmid/luks.img"),
+            mount_point=os.getenv("PHASMID_LUKS_MOUNT_POINT", "/mnt/phasmid-vault"),
+            iter_time_ms=max(1, int(os.getenv("PHASMID_LUKS_ITER_TIME_MS", "2000"))),
+        )
+
+
+class LuksLayer:
+    def __init__(self, cfg: LuksConfig | None = None):
+        self.cfg = cfg or LuksConfig.from_env()
+
+    def is_available(self) -> bool:
+        if self.cfg.mode == LuksMode.DISABLED:
+            return False
+        return shutil.which("cryptsetup") is not None
+
+    def status(self) -> LuksMountResult:
+        if self.cfg.mode == LuksMode.DISABLED:
+            return LuksMountResult(
+                success=True,
+                mounted=False,
+                mode=self.cfg.mode,
+                mount_point=self.cfg.mount_point,
+            )
+        if not self.is_available():
+            return LuksMountResult(
+                success=False,
+                mounted=False,
+                mode=self.cfg.mode,
+                mount_point=self.cfg.mount_point,
+                error_message="cryptsetup not available",
+            )
+
+        mount_point = self.cfg.mount_point
+        probe = subprocess.run(
+            ["mountpoint", "-q", mount_point],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return LuksMountResult(
+            success=True,
+            mounted=(probe.returncode == 0),
+            mode=self.cfg.mode,
+            mount_point=mount_point,
+        )

--- a/tests/test_luks_layer.py
+++ b/tests/test_luks_layer.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from phasmid import config
+from phasmid.luks_key_store import LuksKeyStore
+from phasmid.luks_layer import LuksConfig, LuksLayer, LuksMode
+
+
+class LuksConfigTests(unittest.TestCase):
+    def test_config_defaults_from_env(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            cfg = LuksConfig.from_env()
+        self.assertEqual(cfg.mode, LuksMode.DISABLED)
+        self.assertEqual(cfg.container_path, "/opt/phasmid/luks.img")
+        self.assertEqual(cfg.mount_point, "/mnt/phasmid-vault")
+        self.assertEqual(cfg.iter_time_ms, 2000)
+
+    def test_config_parses_file_mode(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_LUKS_MODE": "file",
+                "PHASMID_LUKS_CONTAINER": "/tmp/phasmid.img",
+                "PHASMID_LUKS_MOUNT_POINT": "/tmp/mnt",
+                "PHASMID_LUKS_ITER_TIME_MS": "2500",
+            },
+            clear=True,
+        ):
+            cfg = LuksConfig.from_env()
+        self.assertEqual(cfg.mode, LuksMode.FILE_CONTAINER)
+        self.assertEqual(cfg.container_path, "/tmp/phasmid.img")
+        self.assertEqual(cfg.mount_point, "/tmp/mnt")
+        self.assertEqual(cfg.iter_time_ms, 2500)
+
+
+class LuksLayerTests(unittest.TestCase):
+    @mock.patch("phasmid.luks_layer.shutil.which")
+    def test_is_available_false_when_disabled(self, which_mock):
+        layer = LuksLayer(LuksConfig(mode=LuksMode.DISABLED))
+        self.assertFalse(layer.is_available())
+        which_mock.assert_not_called()
+
+    @mock.patch("phasmid.luks_layer.shutil.which", return_value=None)
+    def test_is_available_false_without_cryptsetup(self, _which_mock):
+        layer = LuksLayer(LuksConfig(mode=LuksMode.FILE_CONTAINER))
+        self.assertFalse(layer.is_available())
+
+    @mock.patch("phasmid.luks_layer.shutil.which", return_value="/usr/sbin/cryptsetup")
+    def test_is_available_true(self, _which_mock):
+        layer = LuksLayer(LuksConfig(mode=LuksMode.FILE_CONTAINER))
+        self.assertTrue(layer.is_available())
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
+    @mock.patch("phasmid.luks_layer.shutil.which", return_value="/usr/sbin/cryptsetup")
+    def test_status_reports_mounted(self, _which_mock, run_mock):
+        run_mock.return_value = mock.Mock(returncode=0)
+        layer = LuksLayer(
+            LuksConfig(mode=LuksMode.FILE_CONTAINER, mount_point="/mnt/phasmid-vault")
+        )
+        status = layer.status()
+        self.assertTrue(status.success)
+        self.assertTrue(status.mounted)
+        self.assertEqual(status.mount_point, "/mnt/phasmid-vault")
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
+    @mock.patch("phasmid.luks_layer.shutil.which", return_value="/usr/sbin/cryptsetup")
+    def test_status_reports_unmounted(self, _which_mock, run_mock):
+        run_mock.return_value = mock.Mock(returncode=1)
+        layer = LuksLayer(
+            LuksConfig(mode=LuksMode.FILE_CONTAINER, mount_point="/mnt/phasmid-vault")
+        )
+        status = layer.status()
+        self.assertTrue(status.success)
+        self.assertFalse(status.mounted)
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
+    def test_status_disabled(self, run_mock):
+        layer = LuksLayer(LuksConfig(mode=LuksMode.DISABLED))
+        status = layer.status()
+        self.assertTrue(status.success)
+        self.assertFalse(status.mounted)
+        run_mock.assert_not_called()
+
+
+class LuksKeyStoreTests(unittest.TestCase):
+    def test_path_resolution(self):
+        ks = LuksKeyStore("/run/phasmid")
+        self.assertEqual(ks.key_path, "/run/phasmid/luks.key")
+
+    @mock.patch("phasmid.luks_key_store.os.urandom", return_value=b"a" * 32)
+    def test_generate_and_store(self, _urandom):
+        m = mock.mock_open()
+        with mock.patch("phasmid.luks_key_store.open", m), mock.patch(
+            "phasmid.luks_key_store.os.makedirs"
+        ), mock.patch("phasmid.luks_key_store.os.chmod"):
+            ks = LuksKeyStore("/run/phasmid")
+            key = ks.generate_and_store()
+        self.assertEqual(key, b"a" * 32)
+        m.assert_called_once_with("/run/phasmid/luks.key", "wb")
+
+    @mock.patch("phasmid.luks_key_store.os.path.exists", return_value=True)
+    def test_destroy(self, _exists):
+        with mock.patch("phasmid.luks_key_store.open", mock.mock_open()), mock.patch(
+            "phasmid.luks_key_store.os.path.getsize", return_value=16
+        ), mock.patch("phasmid.luks_key_store.os.urandom", return_value=b"b" * 32), mock.patch(
+            "phasmid.luks_key_store.os.remove"
+        ) as remove_mock:
+            ks = LuksKeyStore("/run/phasmid")
+            self.assertTrue(ks.destroy())
+        remove_mock.assert_called_once_with("/run/phasmid/luks.key")
+
+
+class ConfigConstantsTests(unittest.TestCase):
+    def test_luks_constants_present(self):
+        self.assertTrue(hasattr(config, "PHASMID_LUKS_MODE"))
+        self.assertTrue(hasattr(config, "PHASMID_LUKS_CONTAINER"))
+        self.assertTrue(hasattr(config, "PHASMID_LUKS_MOUNT_POINT"))
+        self.assertTrue(hasattr(config, "PHASMID_LUKS_ITER_TIME_MS"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -122,6 +122,8 @@ class TerminologyAuditTests(unittest.TestCase):
             "src/phasmid/object_model_gate.py",
             "src/phasmid/recognition_benchmark.py",
             "src/phasmid/crypto_params.py",
+            "src/phasmid/luks_layer.py",
+            "src/phasmid/luks_key_store.py",
         }
         self.assertEqual(all_modules, scanned | internal_allowlist)
 


### PR DESCRIPTION
## Summary
- add src/phasmid/luks_layer.py with LuksMode, LuksMountResult, LuksConfig, LuksLayer.is_available(), and non-privileged status()
- add src/phasmid/luks_key_store.py with generate_and_store() and destroy()
- add LUKS configuration constants to src/phasmid/config.py
- add tests/test_luks_layer.py (TDD-style unit coverage with subprocess/IO mocking)
- update terminology module-classification allowlist for new internal modules

## Validation
- python3 -m unittest tests/test_luks_layer.py
- python3 -m unittest discover -s tests

Closes #96
