### PR TITLE
Add safe sync and remote env preparation safeguards (#91)

### DIFF
--- a/scripts/pi_zero2w/README.md
+++ b/scripts/pi_zero2w/README.md
@@ -7,7 +7,7 @@ Run from macOS. All test phases execute on the Raspberry Pi via SSH.
 **On macOS (host):**
 
 - Git repository checked out
-- `ssh` and `rsync` available
+- `ssh` available (`rsync` is preferred; fallback exists if missing)
 - SSH key configured for the Pi (or ssh-agent running)
 
 **On the Raspberry Pi:**
@@ -83,6 +83,12 @@ The script will:
 If `coercion_path_timing.gate_passed` is `false`, the timing delta between
 the FAILED and RESTRICTED code paths exceeds 5% of Argon2id wall time.
 This is a significant finding that must be documented before field use.
+
+## Sync Fallback
+
+If `rsync` is unavailable on the macOS host, the harness falls back to a
+bounded `tar` stream over SSH with the same exclude rules (`.git`, `.venv`,
+`.state`, `vault.bin`, `release/`, caches, and `_pi_field_test/`).
 
 ## Cleanup (remote test artifacts only)
 

--- a/scripts/pi_zero2w/prepare_remote_env.sh
+++ b/scripts/pi_zero2w/prepare_remote_env.sh
@@ -5,8 +5,7 @@
 # virtual environment. Called by run_remote_perf.sh; reads the same env vars.
 #
 # Key constraints:
-#   - Uses "pip install -e ." (not requirements.txt) so the phasmid CLI
-#     entry point is created.
+#   - Installs requirements first, then local package entry point.
 #   - Verifies that "phasmid --help" succeeds after install.
 #   - Does NOT set PHASMID_TMPFS_STATE on the remote side.
 #   - Excludes local runtime artifacts from sync (vault.bin, .state, etc.).
@@ -36,6 +35,10 @@ pi_ssh() {
         ssh "${SSH_OPTS[@]}" "$PHASMID_PI_USER@$PHASMID_PI_HOST" "$@"
 }
 
+has_local_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
 # ── Step 1: Create remote directory ──────────────────────────────────────────
 
 printf '[prepare] Creating remote directory %s ...\n' "$PHASMID_PI_REMOTE_DIR"
@@ -47,24 +50,44 @@ pi_ssh "mkdir -p '$PHASMID_PI_REMOTE_DIR'"
 
 printf '[prepare] Syncing repository to %s:%s ...\n' "$PHASMID_PI_HOST" "$PHASMID_PI_REMOTE_DIR"
 
-rsync -av \
-    -e "ssh $(printf '%q ' "${SSH_OPTS[@]}")" \
-    --no-delete \
-    --exclude='.git/' \
-    --exclude='.venv/' \
-    --exclude='__pycache__/' \
-    --exclude='*.pyc' \
-    --exclude='*.pyo' \
-    --exclude='.state/' \
-    --exclude='vault.bin' \
-    --exclude='release/' \
-    --exclude='.hypothesis/' \
-    --exclude='.mypy_cache/' \
-    --exclude='.ruff_cache/' \
-    --exclude='.pytest_cache/' \
-    --exclude='_pi_field_test/' \
-    "$REPO_ROOT/" \
-    "$PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR/"
+if has_local_cmd rsync; then
+    rsync -av \
+        -e "ssh $(printf '%q ' "${SSH_OPTS[@]}")" \
+        --no-delete \
+        --exclude='.git/' \
+        --exclude='.venv/' \
+        --exclude='__pycache__/' \
+        --exclude='*.pyc' \
+        --exclude='*.pyo' \
+        --exclude='.state/' \
+        --exclude='vault.bin' \
+        --exclude='release/' \
+        --exclude='.hypothesis/' \
+        --exclude='.mypy_cache/' \
+        --exclude='.ruff_cache/' \
+        --exclude='.pytest_cache/' \
+        --exclude='_pi_field_test/' \
+        "$REPO_ROOT/" \
+        "$PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR/"
+else
+    printf '[prepare] rsync not found on macOS host; using tar-over-SSH fallback.\n'
+    tar \
+        --exclude='.git' \
+        --exclude='.venv' \
+        --exclude='__pycache__' \
+        --exclude='*.pyc' \
+        --exclude='*.pyo' \
+        --exclude='.state' \
+        --exclude='vault.bin' \
+        --exclude='release' \
+        --exclude='.hypothesis' \
+        --exclude='.mypy_cache' \
+        --exclude='.ruff_cache' \
+        --exclude='.pytest_cache' \
+        --exclude='_pi_field_test' \
+        -C "$REPO_ROOT" -cf - . \
+        | pi_ssh "tar -xf - -C '$PHASMID_PI_REMOTE_DIR'"
+fi
 
 printf '[prepare] Sync complete.\n'
 
@@ -72,9 +95,34 @@ printf '[prepare] Sync complete.\n'
 
 pi_ssh "mkdir -p '$PHASMID_PI_REMOTE_DIR/_pi_field_test/results'"
 
-# ── Step 4: Create or reuse .venv and install ─────────────────────────────────
-# Uses "pip install -e ." so the "phasmid" CLI entry point is registered.
-# "pip install -r requirements.txt" alone does NOT create the entry point.
+# ── Step 4: Validate remote Python and disk before install ───────────────────
+
+printf '[prepare] Validating remote Python and virtualenv support ...\n'
+pi_ssh "
+set -uo pipefail
+if ! command -v python3 >/dev/null 2>&1; then
+    printf 'ERROR: python3 is not installed on the target Pi.\n' >&2
+    exit 11
+fi
+if ! python3 -m venv --help >/dev/null 2>&1; then
+    printf 'ERROR: python3-venv support is missing. Install python3-venv and retry.\n' >&2
+    exit 12
+fi
+"
+
+printf '[prepare] Checking remote free disk space ...\n'
+REMOTE_FREE_KB="$(pi_ssh "df -Pk '$PHASMID_PI_REMOTE_DIR' | awk 'NR==2 {print \\$4}'" 2>/dev/null || true)"
+if [[ -z "$REMOTE_FREE_KB" ]]; then
+    printf 'WARNING: Could not determine remote free disk space.\n'
+else
+    printf '[prepare] Remote free space: %s KB\n' "$REMOTE_FREE_KB"
+    if [[ "$REMOTE_FREE_KB" -lt 1048576 ]]; then
+        printf 'ERROR: Insufficient disk space (< 1GB free) for dependency installation.\n' >&2
+        exit 13
+    fi
+fi
+
+# ── Step 5: Create or reuse .venv and install ─────────────────────────────────
 
 printf '[prepare] Preparing Python virtual environment ...\n'
 INSTALL_START="$(date -u +%s)"
@@ -91,10 +139,13 @@ else
 fi
 
 printf '[prepare] Upgrading pip ...\n'
-.venv/bin/pip install --upgrade pip --quiet
+.venv/bin/python -m pip --version
 
-printf '[prepare] Running: pip install -e . ...\n'
-.venv/bin/pip install -e . 2>&1
+printf '[prepare] Running: pip install -r requirements.txt ...\n'
+.venv/bin/pip install -r requirements.txt 2>&1 | tee '$PHASMID_PI_REMOTE_DIR/_pi_field_test/results/install-remote.log'
+
+printf '[prepare] Running: pip install -e . --no-deps ...\n'
+.venv/bin/pip install -e . --no-deps 2>&1 | tee -a '$PHASMID_PI_REMOTE_DIR/_pi_field_test/results/install-remote.log'
 
 printf '[prepare] Installed packages:\n'
 .venv/bin/pip list --format=columns 2>&1 | head -30
@@ -104,7 +155,19 @@ INSTALL_END="$(date -u +%s)"
 INSTALL_ELAPSED=$(( INSTALL_END - INSTALL_START ))
 printf '[prepare] Install completed in %ds.\n' "$INSTALL_ELAPSED"
 
-# ── Step 5: Verify CLI entry point ────────────────────────────────────────────
+printf '[prepare] Checking for likely native source builds of heavy dependencies ...\n'
+if pi_ssh "
+set -uo pipefail
+LOG='$PHASMID_PI_REMOTE_DIR/_pi_field_test/results/install-remote.log'
+if [[ -f \"\$LOG\" ]] && grep -E 'Building wheel for (numpy|opencv-python-headless)|Running setup.py' \"\$LOG\" >/dev/null 2>&1; then
+    printf 'WARNING: Heavy dependency source-build indicators found in install log.\n'
+    printf '         Review wheel availability and Python/OS architecture compatibility.\n'
+fi
+"; then
+    :
+fi
+
+# ── Step 6: Verify CLI entry point ────────────────────────────────────────────
 
 printf '[prepare] Verifying phasmid CLI entry point ...\n'
 if pi_ssh "
@@ -119,7 +182,7 @@ else
     exit 1
 fi
 
-# ── Step 6: Write install timing record ──────────────────────────────────────
+# ── Step 7: Write install timing record ──────────────────────────────────────
 
 pi_ssh "
     mkdir -p '$PHASMID_PI_REMOTE_DIR/_pi_field_test/results'

--- a/scripts/pi_zero2w/run_local_perf.py
+++ b/scripts/pi_zero2w/run_local_perf.py
@@ -235,6 +235,7 @@ def measure_kdf(rounds: int = 3) -> dict:
 def measure_object_gate() -> dict:
     try:
         import numpy as np
+
         from phasmid.recognition_benchmark import RecognitionBenchmark
 
         rng = np.random.default_rng(42)
@@ -281,6 +282,7 @@ def measure_object_gate() -> dict:
 def measure_coercion_path_timing(n: int = 5) -> dict:
     try:
         import argon2
+
         from phasmid.observability_probe import ObservabilityProbe
 
         def _real_kdf(password: bytes, salt: bytes) -> bytes:


### PR DESCRIPTION
## Summary
- extend `prepare_remote_env.sh` with rsync fallback to bounded tar-over-SSH when rsync is unavailable on macOS host
- keep sync bounded and non-destructive with explicit excludes and no remote delete behavior
- add remote viability checks before install: python3 presence, venv support, and disk-space threshold
- install dependencies conservatively (`requirements.txt`, then `pip install -e . --no-deps`) with remote install log capture
- add heavy native-build indicator warnings for numpy/opencv source-build patterns
- document the rsync fallback path in `scripts/pi_zero2w/README.md`

## Validation
- bash -n scripts/pi_zero2w/prepare_remote_env.sh
- python3 -m unittest discover -s tests

Closes #91
