### PR TITLE
Generate structured Pi artifacts and operator report/docs (#94)

### DIFF
--- a/docs/PI_ZERO2W_FIELD_TEST.md
+++ b/docs/PI_ZERO2W_FIELD_TEST.md
@@ -152,6 +152,16 @@ Results are written to `release/pi-zero2w/` on the Mac after the run.
 Key fields to review:
 
 ```
+timestamp
+host_info
+target_info
+git_commit
+test_phase_results
+timings
+memory
+temperature
+failures
+warnings
 overall_status              "pass" or "fail"
 swap_enabled                true = warn; KDF measurements may be affected
 coercion_path_timing
@@ -162,6 +172,17 @@ vault_operations.roundtrip_ok  true = store → retrieve produced identical byte
 failures[]                  list of phases that failed with error messages
 warnings[]                  non-fatal issues (swap, temperature, etc.)
 ```
+
+### `perf-report.md`
+
+Human-readable summary generated automatically by the harness. It includes:
+
+- executive technical summary;
+- target hardware summary;
+- dependency installation references (`install.log`, `run.log`);
+- performance/viability phase table;
+- warnings and failures;
+- recommended next actions.
 
 ### Coercion-Path Timing Acceptance Gate
 

--- a/scripts/pi_zero2w/README.md
+++ b/scripts/pi_zero2w/README.md
@@ -58,6 +58,7 @@ The script will:
 | `release/pi-zero2w/install.log` | pip install output |
 | `release/pi-zero2w/sysinfo.txt` | Target hardware summary |
 | `release/pi-zero2w/perf-results.json` | Structured JSON results |
+| `release/pi-zero2w/perf-report.md` | Human-readable summary report |
 | `release/pi-zero2w/webui-probe.json` | WebUI timing results |
 
 ## Key result fields

--- a/scripts/pi_zero2w/run_local_perf.py
+++ b/scripts/pi_zero2w/run_local_perf.py
@@ -272,6 +272,7 @@ def measure_kdf(rounds: int = 3) -> dict:
 def measure_object_gate() -> dict:
     try:
         import numpy as np
+
         from phasmid.recognition_benchmark import RecognitionBenchmark
 
         rng = np.random.default_rng(42)
@@ -318,6 +319,7 @@ def measure_object_gate() -> dict:
 def measure_coercion_path_timing(n: int = 5) -> dict:
     try:
         import argon2
+
         from phasmid.observability_probe import ObservabilityProbe
 
         def _real_kdf(password: bytes, salt: bytes) -> bytes:

--- a/scripts/pi_zero2w/run_local_perf.py
+++ b/scripts/pi_zero2w/run_local_perf.py
@@ -84,6 +84,43 @@ def _git_commit() -> str:
         return "unknown"
 
 
+def _host_info() -> dict[str, object]:
+    return {
+        "controller": "macos-remote-harness",
+        "script": "scripts/pi_zero2w/run_local_perf.py",
+    }
+
+
+def _target_info() -> dict[str, object]:
+    out: dict[str, object] = {
+        "hostname": None,
+        "os": None,
+        "kernel": None,
+        "arch": None,
+        "python_version": sys.version.split()[0],
+    }
+    try:
+        out["hostname"] = subprocess.run(
+            ["hostname"], capture_output=True, text=True, check=False
+        ).stdout.strip() or None
+        out["kernel"] = subprocess.run(
+            ["uname", "-r"], capture_output=True, text=True, check=False
+        ).stdout.strip() or None
+        out["arch"] = subprocess.run(
+            ["uname", "-m"], capture_output=True, text=True, check=False
+        ).stdout.strip() or None
+    except Exception:
+        pass
+    try:
+        for line in Path("/etc/os-release").read_text().splitlines():
+            if line.startswith("PRETTY_NAME="):
+                out["os"] = line.split("=", 1)[1].strip().strip('"')
+                break
+    except OSError:
+        pass
+    return out
+
+
 # ── Phase D: Import-time baseline ─────────────────────────────────────────────
 
 def measure_imports() -> dict:
@@ -348,7 +385,12 @@ def main() -> None:
 
     output: dict = {
         "timestamp":               _utc_now(),
+        "host_info":               _host_info(),
+        "target_info":             _target_info(),
         "git_commit":              _git_commit(),
+        "timings":                 {},
+        "memory":                  {},
+        "temperature":             {},
         "swap_enabled":            _swap_enabled(),
         "temperature_before_c":    _temp_c(),
         "mem_available_before_kb": _mem_available_kb(),
@@ -376,19 +418,30 @@ def main() -> None:
     for phase_name, fn in phases:
         print(f"[run_local_perf] phase={phase_name} ...", flush=True)
         temp_before = _temp_c()
+        mem_before = _mem_available_kb()
+        phase_t0 = time.perf_counter()
         try:
             result = fn()
             output["test_phase_results"][phase_name] = "ok"
             output.update(result)
             temp_after = _temp_c()
+            mem_after = _mem_available_kb()
             if temp_before is not None:
-                output.setdefault("temperature", {})[f"{phase_name}_before_c"] = temp_before
+                output["temperature"][f"{phase_name}_before_c"] = temp_before
             if temp_after is not None:
-                output.setdefault("temperature", {})[f"{phase_name}_after_c"] = temp_after
+                output["temperature"][f"{phase_name}_after_c"] = temp_after
+            if mem_before is not None:
+                output["memory"][f"{phase_name}_before_kb"] = mem_before
+            if mem_after is not None:
+                output["memory"][f"{phase_name}_after_kb"] = mem_after
+            output["timings"][phase_name] = round(time.perf_counter() - phase_t0, 4)
             print(f"[run_local_perf] phase={phase_name} ok", flush=True)
         except Exception as exc:
             output["test_phase_results"][phase_name] = "fail"
             output["failures"].append({"phase": phase_name, "error": str(exc)})
+            output["timings"][phase_name] = round(time.perf_counter() - phase_t0, 4)
+            output["memory"][f"{phase_name}_before_kb"] = mem_before
+            output["temperature"][f"{phase_name}_before_c"] = temp_before
             print(f"[run_local_perf] phase={phase_name} FAILED: {exc}", file=sys.stderr, flush=True)
             traceback.print_exc(file=sys.stderr)
 

--- a/scripts/pi_zero2w/run_remote_perf.sh
+++ b/scripts/pi_zero2w/run_remote_perf.sh
@@ -88,12 +88,37 @@ log()  { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*" | tee -a "$RUN_LOG"; }
 warn() { log "WARNING: $*"; }
 fail() { log "ERROR: $*"; exit 1; }
 
-# Track phase results for summary
-declare -A PHASE_RESULTS
+# Track phase results (bash 3.2 compatible)
+PHASE_SSH_SANITY="not_run"
+PHASE_SYSTEM_INFO="not_run"
+PHASE_PREPARE_ENV="not_run"
+PHASE_PERF_TIMING="not_run"
+PHASE_WEBUI="not_run"
 
-phase_ok()   { PHASE_RESULTS["$1"]="ok";   log "  phase $1: ok"; }
-phase_fail() { PHASE_RESULTS["$1"]="fail"; warn "phase $1: failed"; }
-phase_skip() { PHASE_RESULTS["$1"]="skip"; log "  phase $1: skipped"; }
+set_phase_status() {
+    case "$1" in
+        ssh_sanity) PHASE_SSH_SANITY="$2" ;;
+        system_info) PHASE_SYSTEM_INFO="$2" ;;
+        prepare_env) PHASE_PREPARE_ENV="$2" ;;
+        perf_timing) PHASE_PERF_TIMING="$2" ;;
+        webui) PHASE_WEBUI="$2" ;;
+    esac
+}
+
+phase_status() {
+    case "$1" in
+        ssh_sanity) printf '%s' "$PHASE_SSH_SANITY" ;;
+        system_info) printf '%s' "$PHASE_SYSTEM_INFO" ;;
+        prepare_env) printf '%s' "$PHASE_PREPARE_ENV" ;;
+        perf_timing) printf '%s' "$PHASE_PERF_TIMING" ;;
+        webui) printf '%s' "$PHASE_WEBUI" ;;
+        *) printf '%s' "unknown" ;;
+    esac
+}
+
+phase_ok()   { set_phase_status "$1" "ok";   log "  phase $1: ok"; }
+phase_fail() { set_phase_status "$1" "fail"; warn "phase $1: failed"; }
+phase_skip() { set_phase_status "$1" "skip"; log "  phase $1: skipped"; }
 
 # ── Phase A: SSH sanity and architecture check ─────────────────────────────────
 
@@ -149,7 +174,7 @@ fi
 
 # ── Phase D–N: Performance and timing measurements ────────────────────────────
 
-if [[ "${PHASE_RESULTS[prepare_env]:-}" != "fail" ]]; then
+if [[ "$PHASE_PREPARE_ENV" != "fail" ]]; then
     log ""
     log "--- Phase D–N: Performance and timing measurements ---"
 
@@ -177,7 +202,7 @@ fi
 
 # ── Phase I: WebUI viability ─────────────────────────────────────────────────
 
-if [[ "${PHASE_RESULTS[prepare_env]:-}" != "fail" ]]; then
+if [[ "$PHASE_PREPARE_ENV" != "fail" ]]; then
     log ""
     log "--- Phase I: WebUI viability ---"
 
@@ -224,7 +249,7 @@ log ""
 log "=== Phase summary ==="
 OVERALL="ok"
 for phase in ssh_sanity system_info prepare_env perf_timing webui; do
-    status="${PHASE_RESULTS[$phase]:-unknown}"
+    status="$(phase_status "$phase")"
     log "  $phase: $status"
     [[ "$status" == "fail" ]] && OVERALL="fail"
 done
@@ -233,6 +258,68 @@ log ""
 log "Overall status : $OVERALL"
 log "Timestamp      : $TIMESTAMP"
 log "Results dir    : $RESULTS_DIR"
+
+REPORT_MD="$RESULTS_DIR/perf-report.md"
+python3 - "$RESULTS_DIR" "$TIMESTAMP" "$OVERALL" "$INSTALL_LOG" "$RUN_LOG" "$REPORT_MD" <<'PY'
+import json, pathlib, sys
+results_dir = pathlib.Path(sys.argv[1])
+timestamp = sys.argv[2]
+overall = sys.argv[3]
+install_log = sys.argv[4]
+run_log = sys.argv[5]
+report_md = pathlib.Path(sys.argv[6])
+perf_path = results_dir / "perf-results.json"
+data = {}
+if perf_path.exists():
+    try:
+        data = json.loads(perf_path.read_text())
+    except Exception:
+        data = {}
+
+target = data.get("target_info", {})
+phases = data.get("test_phase_results", {})
+warnings = data.get("warnings", [])
+failures = data.get("failures", [])
+timings = data.get("timings", {})
+with report_md.open("w", encoding="utf-8") as f:
+    f.write("# Pi Zero 2 W Field-Test Report\n\n")
+    f.write("## Executive Technical Summary\n")
+    f.write(f"- Timestamp: `{timestamp}`\n")
+    f.write(f"- Overall status: `{overall}`\n")
+    f.write("- This report reflects one hardware run and does not prove security properties.\n")
+    f.write("- Findings are viability measurements only.\n\n")
+    f.write("## Target Hardware Summary\n")
+    f.write(f"- Hostname: `{target.get('hostname')}`\n")
+    f.write(f"- OS: `{target.get('os')}`\n")
+    f.write(f"- Kernel: `{target.get('kernel')}`\n")
+    f.write(f"- Arch: `{target.get('arch')}`\n")
+    f.write(f"- Python: `{target.get('python_version')}`\n\n")
+    f.write("## Dependency Installation\n")
+    f.write(f"- Install log: `{install_log}`\n")
+    f.write(f"- Run log: `{run_log}`\n\n")
+    f.write("## Performance / Viability Table\n")
+    f.write("| Phase | Status | Duration (s) |\n")
+    f.write("|---|---|---|\n")
+    for phase in ["imports","cli_baseline","vault_operations","kdf_timing","object_gate","coercion_path_timing"]:
+        f.write(f"| {phase} | {phases.get(phase, 'not_run')} | {timings.get(phase, 'n/a')} |\n")
+    f.write("\n## Warnings\n")
+    if warnings:
+        for w in warnings:
+            f.write(f"- {w}\n")
+    else:
+        f.write("- none\n")
+    f.write("\n## Failures\n")
+    if failures:
+        for item in failures:
+            f.write(f"- {item.get('phase')}: {item.get('error')}\n")
+    else:
+        f.write("- none\n")
+    f.write("\n## Recommended Next Actions\n")
+    f.write("1. Re-run on the same unit after resolving any install or probe failures.\n")
+    f.write("2. Compare with at least one additional Pi Zero 2 W unit and SD card.\n")
+    f.write("3. Perform manual field procedure checks before making deployment claims.\n")
+PY
+log "Generated report: $REPORT_MD"
 
 if [[ "$OVERALL" == "fail" ]]; then
     log "One or more phases failed. Review $RUN_LOG and partial results in $RESULTS_DIR."


### PR DESCRIPTION
## Summary
- update `run_local_perf.py` so `perf-results.json` includes required stable top-level fields: `timestamp`, `host_info`, `target_info`, `git_commit`, `test_phase_results`, `timings`, `memory`, `temperature`, `failures`, `warnings`, `overall_status`
- preserve partial results and explicit missing values while keeping phase-by-phase failure recording
- update `run_remote_perf.sh` to generate `release/pi-zero2w/perf-report.md` automatically from run artifacts
- include report sections required by #94: executive summary, hardware summary, dependency-install references, phase table, warnings/failures, next actions, and explicit non-proof language
- make remote harness phase-state handling bash 3.2 compatible while preserving existing phase flow
- update operator docs (`scripts/pi_zero2w/README.md`, `docs/PI_ZERO2W_FIELD_TEST.md`) to reference and interpret `perf-report.md` and required JSON schema

## Validation
- bash -n scripts/pi_zero2w/run_remote_perf.sh
- bash -n scripts/pi_zero2w/run_webui_probe.sh
- bash -n scripts/pi_zero2w/prepare_remote_env.sh
- python3 -m py_compile scripts/pi_zero2w/run_local_perf.py
- python3 -m unittest discover -s tests

Closes #94
