### PR TITLE
Implement LUKS mount/unmount wrapper path (Phase 17-B / #97)

### DIFF
--- a/docs/LUKS_LAYER.md
+++ b/docs/LUKS_LAYER.md
@@ -1,0 +1,23 @@
+# LUKS Layer (Stub)
+
+This document is a phase-B stub for LUKS wrapper integration.
+
+## Scope in This Phase
+
+- privileged wrapper path: `/usr/local/bin/phasmid-luks-mount`
+- wrapper script source: `scripts/luks_mount.sh`
+- mount/unmount/status/brick command stubs only
+
+## Sudoers (minimum privilege)
+
+```text
+phasmid ALL=(root) NOPASSWD: /usr/local/bin/phasmid-luks-mount
+```
+
+No wildcard sudo rules are required for this phase.
+
+## Notes
+
+- The wrapper script performs best-effort operations only.
+- Complete physical media sanitization is not guaranteed.
+- Full threat-model and operating procedure content is tracked for Phase 17-E.

--- a/scripts/luks_mount.sh
+++ b/scripts/luks_mount.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+CONTAINER="${2:-/opt/phasmid/luks.img}"
+MOUNT_POINT="${3:-/mnt/phasmid-vault}"
+MAPPER_NAME="phasmid-vault"
+KEY_FILE="/run/phasmid/luks.key"
+
+case "$ACTION" in
+    mount)
+        cryptsetup luksOpen --key-file "$KEY_FILE" "$CONTAINER" "$MAPPER_NAME"
+        mount "/dev/mapper/$MAPPER_NAME" "$MOUNT_POINT"
+        ;;
+    unmount)
+        umount "$MOUNT_POINT" || true
+        cryptsetup luksClose "$MAPPER_NAME" || true
+        ;;
+    status)
+        cryptsetup status "$MAPPER_NAME" 2>/dev/null | head -5 || true
+        ;;
+    brick)
+        # best-effort — complete erasure is not guaranteed
+        shred -n 3 "$KEY_FILE" 2>/dev/null || true
+        rm -f "$KEY_FILE"
+        cryptsetup luksErase "$CONTAINER" --batch-mode || true
+        ;;
+    *)
+        echo "usage: $0 {mount|unmount|status|brick} [container_path] [mount_point]" >&2
+        exit 2
+        ;;
+esac

--- a/src/phasmid/luks_layer.py
+++ b/src/phasmid/luks_layer.py
@@ -8,6 +8,9 @@ import subprocess
 from dataclasses import dataclass
 from enum import Enum
 
+from . import config
+from .luks_key_store import LuksKeyStore
+
 
 class LuksMode(str, Enum):
     FILE_CONTAINER = "file"
@@ -43,16 +46,25 @@ class LuksConfig:
     @classmethod
     def from_env(cls) -> "LuksConfig":
         return cls(
-            mode=LuksMode.from_text(os.getenv("PHASMID_LUKS_MODE", "disabled")),
-            container_path=os.getenv("PHASMID_LUKS_CONTAINER", "/opt/phasmid/luks.img"),
-            mount_point=os.getenv("PHASMID_LUKS_MOUNT_POINT", "/mnt/phasmid-vault"),
-            iter_time_ms=max(1, int(os.getenv("PHASMID_LUKS_ITER_TIME_MS", "2000"))),
+            mode=LuksMode.from_text(config.env_text("PHASMID_LUKS_MODE", "disabled")),
+            container_path=config.env_text(
+                "PHASMID_LUKS_CONTAINER", "/opt/phasmid/luks.img"
+            ),
+            mount_point=config.env_text(
+                "PHASMID_LUKS_MOUNT_POINT", "/mnt/phasmid-vault"
+            ),
+            iter_time_ms=max(
+                1, config.env_int("PHASMID_LUKS_ITER_TIME_MS", 2000, minimum=1)
+            ),
         )
 
 
 class LuksLayer:
+    WRAPPER_PATH = "/usr/local/bin/phasmid-luks-mount"
+
     def __init__(self, cfg: LuksConfig | None = None):
         self.cfg = cfg or LuksConfig.from_env()
+        self.key_store = LuksKeyStore()
 
     def is_available(self) -> bool:
         if self.cfg.mode == LuksMode.DISABLED:
@@ -89,3 +101,81 @@ class LuksLayer:
             mode=self.cfg.mode,
             mount_point=mount_point,
         )
+
+    def mount(self, passphrase: str) -> LuksMountResult:
+        if self.cfg.mode == LuksMode.DISABLED:
+            return LuksMountResult(
+                success=False,
+                mounted=False,
+                mode=self.cfg.mode,
+                mount_point=self.cfg.mount_point,
+                error_message="luks mode disabled",
+            )
+        if not self.is_available():
+            return LuksMountResult(
+                success=False,
+                mounted=False,
+                mode=self.cfg.mode,
+                mount_point=self.cfg.mount_point,
+                error_message="cryptsetup not available",
+            )
+        try:
+            if passphrase:
+                os.makedirs(self.key_store.base_dir, mode=0o700, exist_ok=True)
+                with open(self.key_store.key_path, "wb") as handle:
+                    handle.write(passphrase.encode("utf-8"))
+            else:
+                self.key_store.generate_and_store()
+
+            cmd = [
+                "sudo",
+                self.WRAPPER_PATH,
+                "mount",
+                self.cfg.container_path,
+                self.cfg.mount_point,
+            ]
+            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if proc.returncode != 0:
+                return LuksMountResult(
+                    success=False,
+                    mounted=False,
+                    mode=self.cfg.mode,
+                    mount_point=self.cfg.mount_point,
+                    error_message="mount wrapper failed",
+                )
+            os.environ["PHASMID_STATE_DIR"] = self.cfg.mount_point
+            return LuksMountResult(
+                success=True,
+                mounted=True,
+                mode=self.cfg.mode,
+                mount_point=self.cfg.mount_point,
+            )
+        except OSError:
+            return LuksMountResult(
+                success=False,
+                mounted=False,
+                mode=self.cfg.mode,
+                mount_point=self.cfg.mount_point,
+                error_message="mount operation failed",
+            )
+
+    def unmount(self) -> bool:
+        if self.cfg.mode == LuksMode.DISABLED:
+            return True
+        proc = subprocess.run(
+            [
+                "sudo",
+                self.WRAPPER_PATH,
+                "unmount",
+                self.cfg.container_path,
+                self.cfg.mount_point,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return False
+        if config.env_text("PHASMID_STATE_DIR", "") == self.cfg.mount_point:
+            os.environ.pop("PHASMID_STATE_DIR", None)
+        return True

--- a/tests/test_luks_layer.py
+++ b/tests/test_luks_layer.py
@@ -79,6 +79,56 @@ class LuksLayerTests(unittest.TestCase):
         self.assertFalse(status.mounted)
 
     @mock.patch("phasmid.luks_layer.subprocess.run")
+    @mock.patch("phasmid.luks_layer.shutil.which", return_value="/usr/sbin/cryptsetup")
+    @mock.patch("phasmid.luks_layer.open", new_callable=mock.mock_open)
+    @mock.patch("phasmid.luks_layer.os.makedirs")
+    def test_mount_success_sets_state_dir(
+        self, _makedirs, _open_mock, _which_mock, run_mock
+    ):
+        run_mock.return_value = mock.Mock(returncode=0)
+        layer = LuksLayer(
+            LuksConfig(
+                mode=LuksMode.FILE_CONTAINER,
+                container_path="/opt/phasmid/luks.img",
+                mount_point="/mnt/phasmid-vault",
+            )
+        )
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = layer.mount("passphrase")
+            self.assertTrue(result.success)
+            self.assertTrue(result.mounted)
+            self.assertEqual(os.environ.get("PHASMID_STATE_DIR"), "/mnt/phasmid-vault")
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
+    @mock.patch("phasmid.luks_layer.shutil.which", return_value="/usr/sbin/cryptsetup")
+    @mock.patch("phasmid.luks_layer.open", new_callable=mock.mock_open)
+    @mock.patch("phasmid.luks_layer.os.makedirs")
+    def test_mount_failure(self, _makedirs, _open_mock, _which_mock, run_mock):
+        run_mock.return_value = mock.Mock(returncode=1)
+        layer = LuksLayer(LuksConfig(mode=LuksMode.FILE_CONTAINER))
+        result = layer.mount("passphrase")
+        self.assertFalse(result.success)
+        self.assertIn("failed", result.error_message)
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
+    def test_unmount_success_unsets_state_dir(self, run_mock):
+        run_mock.return_value = mock.Mock(returncode=0)
+        layer = LuksLayer(
+            LuksConfig(mode=LuksMode.FILE_CONTAINER, mount_point="/mnt/phasmid-vault")
+        )
+        with mock.patch.dict(
+            os.environ, {"PHASMID_STATE_DIR": "/mnt/phasmid-vault"}, clear=True
+        ):
+            self.assertTrue(layer.unmount())
+            self.assertNotIn("PHASMID_STATE_DIR", os.environ)
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
+    def test_unmount_failure(self, run_mock):
+        run_mock.return_value = mock.Mock(returncode=1)
+        layer = LuksLayer(LuksConfig(mode=LuksMode.FILE_CONTAINER))
+        self.assertFalse(layer.unmount())
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
     def test_status_disabled(self, run_mock):
         layer = LuksLayer(LuksConfig(mode=LuksMode.DISABLED))
         status = layer.status()


### PR DESCRIPTION
## Summary
- extend `LuksLayer` with privileged wrapper integration:
  - `mount(passphrase)` invoking `sudo /usr/local/bin/phasmid-luks-mount mount ...`
  - `unmount()` invoking `sudo /usr/local/bin/phasmid-luks-mount unmount ...`
- set `PHASMID_STATE_DIR` to LUKS mount point after successful mount, and clear it on successful unmount
- keep capture-visible mount failure messages generic (no key-path disclosure)
- add executable wrapper script `scripts/luks_mount.sh` with `mount|unmount|status|brick` stubs and required best-effort erase note
- add `docs/LUKS_LAYER.md` phase-B sudoers stub
- extend `tests/test_luks_layer.py` with mount/unmount and state-dir redirection coverage

## Validation
- bash -n scripts/luks_mount.sh
- python3 -m ruff check src/phasmid/luks_layer.py src/phasmid/luks_key_store.py tests/test_luks_layer.py
- python3 -m unittest tests/test_luks_layer.py tests/test_config.py
- python3 -m unittest discover -s tests

Closes #97
