### PR TITLE
Add LUKS TUI panel and restricted-clear wiring (Phase 17-C / #98)

### DIFF
--- a/src/phasmid/luks_layer.py
+++ b/src/phasmid/luks_layer.py
@@ -179,3 +179,19 @@ class LuksLayer:
         if config.env_text("PHASMID_STATE_DIR", "") == self.cfg.mount_point:
             os.environ.pop("PHASMID_STATE_DIR", None)
         return True
+
+    def restricted_clear(self) -> bool:
+        key_cleared = self.key_store.destroy()
+        proc = subprocess.run(
+            [
+                "sudo",
+                self.WRAPPER_PATH,
+                "brick",
+                self.cfg.container_path,
+                self.cfg.mount_point,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return key_cleared and proc.returncode == 0

--- a/src/phasmid/services/luks_service.py
+++ b/src/phasmid/services/luks_service.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from ..luks_layer import LuksLayer, LuksMode
+
+
+class LuksService:
+    """Service wrapper for operator-facing LUKS actions."""
+
+    def __init__(self):
+        self.layer = LuksLayer()
+
+    @property
+    def enabled(self) -> bool:
+        return self.layer.cfg.mode != LuksMode.DISABLED
+
+    def status(self):
+        return self.layer.status()
+
+    def mount(self, passphrase: str):
+        return self.layer.mount(passphrase)
+
+    def unmount(self) -> bool:
+        return self.layer.unmount()
+
+    def restricted_clear(self) -> bool:
+        return self.layer.restricted_clear()

--- a/src/phasmid/tui/app.py
+++ b/src/phasmid/tui/app.py
@@ -54,6 +54,7 @@ class PhasmidApp(App):
             "inspect": self._push_inspect,
             "create": self._push_create,
             "open": self._push_open,
+            "luks": self._push_luks,
             "about": self._push_about,
         }
         action = screen_map.get(self._initial_screen, self._push_home)
@@ -162,6 +163,12 @@ class PhasmidApp(App):
 
         self.push_screen(HomeScreen())
         self.push_screen(AboutScreen())
+
+    def _push_luks(self) -> None:
+        from .screens.luks_screen import LuksScreen
+
+        self.push_screen(HomeScreen())
+        self.push_screen(LuksScreen())
 
 
 def run_tui(

--- a/src/phasmid/tui/screens/home.py
+++ b/src/phasmid/tui/screens/home.py
@@ -7,6 +7,7 @@ from textual.binding import Binding
 from textual.css.query import NoMatches
 from textual.widgets import DataTable, Footer, Static
 
+from ...config import PHASMID_LUKS_MODE
 from ...models.vessel import VesselMeta
 from ...services.profile_service import load_profile
 from ...services.vessel_service import VesselService
@@ -31,6 +32,7 @@ class HomeScreen(OperatorScreen):
         Binding("a", "audit", "Audit"),
         Binding("d", "doctor", "Doctor"),
         Binding("s", "settings", "Settings"),
+        Binding("l", "luks_panel", "LUKS"),
         Binding("question_mark", "help", "Help"),
         Binding("q", "quit", "Quit"),
         Binding("r", "refresh_vessels", "Refresh", show=False),
@@ -221,6 +223,14 @@ class HomeScreen(OperatorScreen):
         self._refresh_vessels()
         self._run_startup_checks()
         self._log("Vessel list refreshed.")
+
+    def action_luks_panel(self) -> None:
+        if PHASMID_LUKS_MODE.strip().lower() == "disabled":
+            self.app.notify("LUKS layer is disabled.", severity="warning")
+            return
+        from .luks_screen import LuksScreen
+
+        self.app.push_screen(LuksScreen())
 
     def action_open_vessel(self) -> None:
         from .confirm_modal import ConfirmModal

--- a/src/phasmid/tui/screens/luks_screen.py
+++ b/src/phasmid/tui/screens/luks_screen.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.widgets import Button, Footer, Input, Label, Static
+
+from ...services.luks_service import LuksService
+from .base import OperatorScreen
+
+
+class LuksScreen(OperatorScreen):
+    BINDINGS = [Binding("escape", "dismiss", "Back")]
+
+    DEFAULT_CSS = """
+    LuksScreen {
+        background: $background;
+        padding: 1 4;
+    }
+    LuksScreen #title {
+        color: $primary;
+        text-style: bold;
+        text-align: center;
+        padding-bottom: 1;
+    }
+    LuksScreen .meta {
+        color: $text-muted;
+    }
+    LuksScreen #status {
+        padding: 1 0;
+        color: $text;
+    }
+    LuksScreen #result {
+        min-height: 1;
+        color: $success;
+        padding-top: 1;
+    }
+    LuksScreen .btn-row {
+        padding-top: 1;
+        height: auto;
+    }
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._svc = LuksService()
+
+    def compose(self) -> ComposeResult:
+        yield self.webui_warning_banner()
+        yield Static("LUKS OPERATOR PANEL", id="title")
+        yield Static("", id="mode", classes="meta")
+        yield Static("", id="container", classes="meta")
+        yield Static("", id="mount-point", classes="meta")
+        yield Static("", id="status")
+        yield Label("Passphrase (optional)", classes="meta")
+        yield Input(password=True, id="passphrase")
+        with Horizontal(classes="btn-row"):
+            yield Button("Open Local Container", id="mount-btn", variant="primary")
+            yield Button("Close Local Container", id="unmount-btn")
+            yield Button("Restricted Clear", id="clear-btn", variant="error")
+        yield Static("", id="result")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    def _refresh(self) -> None:
+        cfg = self._svc.layer.cfg
+        st = self._svc.status()
+        self.query_one("#mode", Static).update(f"Mode: {cfg.mode.value}")
+        self.query_one("#container", Static).update(f"Container: {cfg.container_path}")
+        self.query_one("#mount-point", Static).update(f"Mount point: {cfg.mount_point}")
+        mounted = "mounted" if st.mounted else "unmounted"
+        self.query_one("#status", Static).update(f"Local container status: {mounted}")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "mount-btn":
+            pw = self.query_one("#passphrase", Input).value
+            result = self._svc.mount(pw)
+            if result.success:
+                self.query_one("#result", Static).update("local container opened")
+            else:
+                self.query_one("#result", Static).update("operation failed")
+        elif event.button.id == "unmount-btn":
+            if self._svc.unmount():
+                self.query_one("#result", Static).update("local container closed")
+            else:
+                self.query_one("#result", Static).update("operation failed")
+        elif event.button.id == "clear-btn":
+            if self._svc.restricted_clear():
+                self.query_one("#result", Static).update(
+                    "local access path cleared (best-effort)"
+                )
+            else:
+                self.query_one("#result", Static).update("operation failed")
+        self._refresh()

--- a/tests/test_luks_layer.py
+++ b/tests/test_luks_layer.py
@@ -129,6 +129,20 @@ class LuksLayerTests(unittest.TestCase):
         self.assertFalse(layer.unmount())
 
     @mock.patch("phasmid.luks_layer.subprocess.run")
+    @mock.patch("phasmid.luks_layer.LuksKeyStore.destroy", return_value=True)
+    def test_restricted_clear_success(self, _destroy_mock, run_mock):
+        run_mock.return_value = mock.Mock(returncode=0)
+        layer = LuksLayer(LuksConfig(mode=LuksMode.FILE_CONTAINER))
+        self.assertTrue(layer.restricted_clear())
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
+    @mock.patch("phasmid.luks_layer.LuksKeyStore.destroy", return_value=False)
+    def test_restricted_clear_failure(self, _destroy_mock, run_mock):
+        run_mock.return_value = mock.Mock(returncode=0)
+        layer = LuksLayer(LuksConfig(mode=LuksMode.FILE_CONTAINER))
+        self.assertFalse(layer.restricted_clear())
+
+    @mock.patch("phasmid.luks_layer.subprocess.run")
     def test_status_disabled(self, run_mock):
         layer = LuksLayer(LuksConfig(mode=LuksMode.DISABLED))
         status = layer.status()


### PR DESCRIPTION
## Summary
- add `LuksLayer.restricted_clear()` to perform key-store wipe + wrapper `brick` action
- add `src/phasmid/services/luks_service.py` service-layer wrapper for status/mount/unmount/restricted_clear
- add `src/phasmid/tui/screens/luks_screen.py` operator panel with:
  - mode/container/mount status display
  - mount/unmount controls
  - restricted clear action
  - neutral capture-visible language
- wire LUKS operator access from Home screen (`l` binding), while showing a warning when LUKS mode is disabled
- add app-level screen routing support for `initial_screen="luks"`
- add `scripts/luks_mount.sh` privileged wrapper stub and `docs/LUKS_LAYER.md` sudoers stub
- extend tests with `restricted_clear()` coverage and mount/unmount behavior assertions

## Validation
- bash -n scripts/luks_mount.sh
- python3 -m ruff check src/phasmid/luks_layer.py src/phasmid/services/luks_service.py src/phasmid/tui/screens/luks_screen.py src/phasmid/tui/screens/home.py src/phasmid/tui/app.py tests/test_luks_layer.py
- python3 -m unittest tests/test_luks_layer.py
- python3 -m unittest discover -s tests

Closes #98
