### PR TITLE
Add LUKS status checks to Doctor View (Phase 17-D / #99)

### DIFF
--- a/src/phasmid/services/doctor_service.py
+++ b/src/phasmid/services/doctor_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import resource
+import shutil
 import stat
 import subprocess
 import sys
@@ -10,6 +11,7 @@ import time
 from pathlib import Path
 
 from ..config import debug_enabled, doctor_recent_seconds, state_dir
+from ..luks_layer import LuksConfig, LuksLayer, LuksMode
 from ..models.doctor import DoctorCheck, DoctorLevel, DoctorResult
 from ..process_hardening import hardening_status
 from ..volatile_state import check_volatile_state, volatile_state_path
@@ -492,6 +494,149 @@ def _check_vault_size_record(vault_path: Path) -> DoctorCheck:
     )
 
 
+def _check_luks_statuses() -> list[DoctorCheck]:
+    cfg = LuksConfig.from_env()
+    mode_value = cfg.mode.value
+    checks: list[DoctorCheck] = []
+    if cfg.mode == LuksMode.DISABLED:
+        checks.append(
+            DoctorCheck(
+                name="LUKS Mode",
+                level=DoctorLevel.INFO,
+                message="[DISABLED] LUKS mode is disabled",
+            )
+        )
+        checks.append(
+            DoctorCheck(
+                name="LUKS cryptsetup",
+                level=DoctorLevel.INFO,
+                message="[DISABLED] skipped because LUKS mode is disabled",
+            )
+        )
+        checks.append(
+            DoctorCheck(
+                name="Local container path",
+                level=DoctorLevel.INFO,
+                message="[DISABLED] skipped because LUKS mode is disabled",
+            )
+        )
+        checks.append(
+            DoctorCheck(
+                name="Local container mount state",
+                level=DoctorLevel.INFO,
+                message="[DISABLED] skipped because LUKS mode is disabled",
+            )
+        )
+        checks.append(
+            DoctorCheck(
+                name="LUKS key-store tmpfs",
+                level=DoctorLevel.INFO,
+                message="[DISABLED] skipped because LUKS mode is disabled",
+            )
+        )
+        return checks
+
+    if mode_value in {LuksMode.FILE_CONTAINER.value, LuksMode.PARTITION.value}:
+        checks.append(
+            DoctorCheck(
+                name="LUKS Mode",
+                level=DoctorLevel.OK,
+                message=f"LUKS mode configured: {mode_value}",
+            )
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                name="LUKS Mode",
+                level=DoctorLevel.FAIL,
+                message=f"Invalid LUKS mode value: {mode_value}",
+            )
+        )
+
+    if shutil.which("cryptsetup"):
+        checks.append(
+            DoctorCheck(
+                name="LUKS cryptsetup",
+                level=DoctorLevel.OK,
+                message="cryptsetup is available",
+            )
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                name="LUKS cryptsetup",
+                level=DoctorLevel.WARN,
+                message="cryptsetup is not available",
+            )
+        )
+
+    if cfg.mode == LuksMode.FILE_CONTAINER:
+        exists = Path(cfg.container_path).exists()
+        checks.append(
+            DoctorCheck(
+                name="Local container path",
+                level=DoctorLevel.OK if exists else DoctorLevel.WARN,
+                message=(
+                    "local container file is reachable"
+                    if exists
+                    else "local container file is not reachable"
+                ),
+            )
+        )
+    else:
+        exists = Path(cfg.container_path).exists()
+        checks.append(
+            DoctorCheck(
+                name="Local container path",
+                level=DoctorLevel.OK if exists else DoctorLevel.WARN,
+                message=(
+                    "local container partition path is reachable"
+                    if exists
+                    else "local container partition path is not reachable"
+                ),
+            )
+        )
+
+    status = LuksLayer(cfg).status()
+    checks.append(
+        DoctorCheck(
+            name="Local container mount state",
+            level=DoctorLevel.OK,
+            message=(
+                "local container is mounted"
+                if status.mounted
+                else "local container is unmounted"
+            ),
+        )
+    )
+
+    tmpfs_ok = False
+    if sys.platform == "linux":
+        try:
+            probe = subprocess.run(
+                ["findmnt", "-n", "-o", "FSTYPE", "/run/phasmid"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            tmpfs_ok = probe.returncode == 0 and probe.stdout.strip() == "tmpfs"
+        except Exception:
+            tmpfs_ok = False
+    checks.append(
+        DoctorCheck(
+            name="LUKS key-store tmpfs",
+            level=DoctorLevel.OK if tmpfs_ok else DoctorLevel.WARN,
+            message=(
+                "LUKS key-store path is tmpfs-backed"
+                if tmpfs_ok
+                else "LUKS key-store path is not confirmed as tmpfs-backed"
+            ),
+        )
+    )
+    return checks
+
+
 def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
     cfg = config_dir()
     vault_path = Path("vault.bin")
@@ -509,6 +654,11 @@ def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
     checks += [
         _check_secure_random(),
         _check_volatile_state(),
+    ]
+
+    checks += _check_luks_statuses()
+
+    checks += [
         _check_process_hardening(),
         _check_recent_documents_cache(),
         _check_thumbnail_cache(),

--- a/tests/test_doctor_m4.py
+++ b/tests/test_doctor_m4.py
@@ -24,8 +24,23 @@ class DoctorM4Checks(unittest.TestCase):
             "Core Dumps",
             "Compressed Swap",
             "Shell History",
+            "LUKS Mode",
+            "LUKS cryptsetup",
+            "Local container path",
+            "Local container mount state",
+            "LUKS key-store tmpfs",
         }
         self.assertTrue(expected.issubset(names))
+
+    def test_luks_checks_show_disabled_state(self):
+        with mock.patch.dict(os.environ, {"PHASMID_LUKS_MODE": "disabled"}, clear=False):
+            result = run_doctor_checks()
+        checks = {c.name: c for c in result.checks}
+        self.assertIn("[DISABLED]", checks["LUKS Mode"].message)
+        self.assertIn("[DISABLED]", checks["LUKS cryptsetup"].message)
+        self.assertIn("[DISABLED]", checks["Local container path"].message)
+        self.assertIn("[DISABLED]", checks["Local container mount state"].message)
+        self.assertIn("[DISABLED]", checks["LUKS key-store tmpfs"].message)
 
     def test_shell_history_warns_when_histfile_contains_phasmid_usage(self):
         with mock.patch.dict(


### PR DESCRIPTION
## Summary
- extend Doctor checks with a LUKS status section in `src/phasmid/services/doctor_service.py`
- add checks for:
  - LUKS mode validity
  - cryptsetup availability
  - local container path reachability
  - local container mount state
  - LUKS key-store tmpfs reachability
- implement graceful disabled behavior: each LUKS check reports `[DISABLED]` when `PHASMID_LUKS_MODE=disabled`
- preserve all existing doctor checks and ordering behavior
- add tests in `tests/test_doctor_m4.py` to verify LUKS check presence and disabled-state messaging

## Validation
- python3 -m ruff check src/phasmid/services/doctor_service.py tests/test_doctor_m4.py
- python3 -m unittest tests/test_doctor_m4.py
- python3 -m unittest discover -s tests

Closes #99
