### PR TITLE
Publish LUKS layer docs and README section (Phase 17-E / #100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ Phasmid is not approved classified-data handling infrastructure. It does not rep
 
 Use of Phasmid in government or organizational environments must follow applicable law, policy, records-retention requirements, and classification rules. Phasmid is intended for local field-evaluation and harm-reduction workflows, not as a substitute for approved systems of record.
 
+## Storage Encryption (LUKS Layer)
+
+Phasmid supports an optional LUKS2 storage layer for local container and state paths.
+This layer can reduce offline filesystem exposure by encrypting the underlying block
+storage until mapped and mounted. It does not replace Phasmid's local-only posture,
+and it does not provide protection against compromised hosts, live memory capture,
+or keylogging. Erase-related actions in this layer remain best-effort.
+
+See [`docs/LUKS_LAYER.md`](docs/LUKS_LAYER.md) for threat-model limits, operating
+procedure, and deployment notes. This layer is not a replacement for full-disk
+encryption on a trusted platform.
+
 ## Reviewer Notes and Known Limits
 
 Phasmid is intentionally narrow.

--- a/docs/LUKS_LAYER.md
+++ b/docs/LUKS_LAYER.md
@@ -1,23 +1,105 @@
-# LUKS Layer (Stub)
+# LUKS Layer
 
-This document is a phase-B stub for LUKS wrapper integration.
+## Overview
 
-## Scope in This Phase
+Phasmid can operate on top of an optional LUKS2-backed storage layer.
+This layer is intended to reduce offline filesystem exposure of the local container
+and local state paths by encrypting the underlying block storage.
+It does not replace Phasmid's application-layer controls, and it does not replace
+full-disk encryption or trusted-platform controls.
+LUKS is an additional storage boundary, not a complete host-compromise defense.
 
-- privileged wrapper path: `/usr/local/bin/phasmid-luks-mount`
-- wrapper script source: `scripts/luks_mount.sh`
-- mount/unmount/status/brick command stubs only
+## Threat Model Delta
 
-## Sudoers (minimum privilege)
+| Threat Surface | Without LUKS Layer | With LUKS Layer |
+|---|---|---|
+| Offline image of medium | `vault.bin` and local state paths are visible as files | Underlying contents are encrypted until mapped and mounted |
+| Access-key residue risk | Depends on state location and host posture | Still depends on host posture; encrypted-at-rest block layer adds friction |
+| Brick / restricted clear effect | Key-path invalidation + best-effort overwrite | Key-path invalidation + optional LUKS key-slot erase path (best-effort) |
+| Host compromise while running | Out of scope | Out of scope (unchanged) |
+
+## Known Limits
+
+- Live memory capture while the container is mounted bypasses LUKS protection.
+- The LUKS header proves that encrypted storage was used. This differs from VeraCrypt hidden volumes; LUKS does not provide plausible deniability about the container's existence.
+- Restricted clear (`luksErase`) is best-effort. Physical recovery of erased NAND cells is outside the scope of this software.
+- Disabling swap reduces residue risk but does not eliminate it from RAM while the system is running.
+- This layer has not been independently audited.
+
+Additional operational limits:
+
+- Malware, keyloggers, and compromised kernels are not mitigated by this layer.
+- Storage-controller behavior, snapshots, and wear leveling can preserve older blocks.
+- Results are hardware-specific; validation on one Pi setup does not generalize automatically.
+
+## Deployment Modes
+
+### Mode A: File Container
+
+- LUKS device stored as a regular file (for example `luks.img`).
+- Suitable for prototype and evaluation workflows where repartitioning is undesirable.
+- Additional loopback overhead may affect throughput and startup timing.
+
+### Mode B: Partition
+
+- LUKS mapped directly on a dedicated block partition.
+- Better fit for appliance-style deployment with clearer storage boundaries.
+- Requires partition planning and provisioning discipline.
+
+## Setup Procedure
+
+Reference setup script: `scripts/setup_luks_appliance.sh` (when provided in deployment workflow).
+
+Minimum setup expectations:
+
+1. provision LUKS device or partition;
+2. configure wrapper path and mount point;
+3. configure restricted sudoers entry;
+4. validate mount/unmount status path before operator use;
+5. run Pi field-test harness and record artifacts.
+
+## Sudoers Configuration
+
+Minimum-privilege sudoers entry:
 
 ```text
 phasmid ALL=(root) NOPASSWD: /usr/local/bin/phasmid-luks-mount
 ```
 
-No wildcard sudo rules are required for this phase.
+Do not use wildcard sudo rules for this path.
 
-## Notes
+## Operating Procedure
 
-- The wrapper script performs best-effort operations only.
-- Complete physical media sanitization is not guaranteed.
-- Full threat-model and operating procedure content is tracked for Phase 17-E.
+### Mount
+
+1. prepare key material in `/run/phasmid/luks.key` (tmpfs-backed path preferred);
+2. invoke wrapper mount command via restricted sudo path;
+3. verify mapped device and mount point;
+4. set runtime state path to the mounted location for operator flows.
+
+User-facing status should remain neutral:
+- `local container opened`
+
+### Unmount
+
+1. terminate dependent operations;
+2. unmount filesystem and close mapper;
+3. clear runtime state path overrides where applicable.
+
+User-facing status:
+- `local container closed`
+
+### Restricted Clear
+
+1. wipe local key-store artifact (best-effort);
+2. invoke wrapper `brick` path to trigger LUKS erase behavior (best-effort);
+3. report only neutral local-access-path language.
+
+User-facing status:
+- `local access path cleared (best-effort)`
+
+## Iter-Time Calibration
+
+`PHASMID_LUKS_ITER_TIME_MS=2000` is a Pi Zero 2 W target value for evaluation,
+not a universal default guarantee. Field calibration on target hardware is required
+before freezing deployment recommendations.


### PR DESCRIPTION
## Summary
- replace `docs/LUKS_LAYER.md` stub with full phase-E operator documentation
- include required sections:
  - overview
  - threat-model delta table
  - known limits
  - deployment modes (file container / partition)
  - setup procedure reference
  - sudoers configuration
  - operating procedure (mount / unmount / restricted clear)
  - iter-time calibration guidance
- add `## Storage Encryption (LUKS Layer)` section to README with link to `docs/LUKS_LAYER.md`
- keep language conservative and hardware-specific, including best-effort erase limits

## Validation
- python3 -m unittest discover -s tests
- markdown links and terminology sanity checked in modified docs

Closes #100
