### PR TITLE
Doctor: add dummy plausibility baseline evaluation (part of #104)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -32,6 +32,11 @@ All `PHASMID_*` reads are centralized in `src/phasmid/config.py`.
 | `PHASMID_STATE_SECRET` | string | unset | Local state encryption | Overrides local state key with environment-derived secret | `config.state_secret()` |
 | `PHASMID_DEBUG` | bool | `false` | Diagnostics | Enables debug-mode warning in doctor output | `config.debug_enabled()` |
 | `PHASMID_DOCTOR_RECENT_SECONDS` | int (>=1) | `86400` | Doctor | Window for “recent vault activity” warning | `config.doctor_recent_seconds()` |
+| `PHASMID_DUMMY_MIN_SIZE_MB` | int (>=0) | `50` | Doctor plausibility advisory | Minimum baseline size for local disclosure-face dataset | `config.dummy_min_size_mb()` |
+| `PHASMID_DUMMY_MIN_FILE_COUNT` | int (>=0) | `20` | Doctor plausibility advisory | Minimum baseline file count for local disclosure-face dataset | `config.dummy_min_file_count()` |
+| `PHASMID_DUMMY_OCCUPANCY_WARN` | float (>=0) | `0.10` | Doctor plausibility advisory | Warn when disclosure-face size ratio falls below threshold | `config.dummy_occupancy_warn()` |
+| `PHASMID_DUMMY_PROFILE_DIR` | path | `.state/dummy_profile` | Doctor plausibility advisory | Local path scanned for disclosure-face plausibility baseline | `config.dummy_profile_dir()` |
+| `PHASMID_DUMMY_CONTAINER_PATH` | path | `vault.bin` | Doctor plausibility advisory | Local container path used for occupancy ratio baseline | `config.dummy_container_path()` |
 | `PHASMID_ENABLE_DISPLAY` | bool | `false` | Bridge UI simulator | Enables OpenCV preview window for display simulator | `config.display_enabled()` |
 | `PHASMID_DARK` | bool | `false` | TUI theming | Optional dark theme selection flag | `config.tui_dark_enabled()` |
 | `PHASMID_LIGHT` | bool | `false` | TUI theming | Optional light theme selection flag | `config.tui_light_enabled()` |

--- a/src/phasmid/config.py
+++ b/src/phasmid/config.py
@@ -148,6 +148,33 @@ def doctor_recent_seconds() -> int:
     return env_int("PHASMID_DOCTOR_RECENT_SECONDS", 86400, minimum=1)
 
 
+def dummy_min_size_mb() -> int:
+    return env_int("PHASMID_DUMMY_MIN_SIZE_MB", 50, minimum=0)
+
+
+def dummy_min_file_count() -> int:
+    return env_int("PHASMID_DUMMY_MIN_FILE_COUNT", 20, minimum=0)
+
+
+def dummy_occupancy_warn() -> float:
+    raw = env_text("PHASMID_DUMMY_OCCUPANCY_WARN", "0.10")
+    try:
+        value = float(raw)
+    except ValueError:
+        value = 0.10
+    if value < 0.0:
+        return 0.0
+    return value
+
+
+def dummy_profile_dir() -> str:
+    return env_text("PHASMID_DUMMY_PROFILE_DIR", ".state/dummy_profile")
+
+
+def dummy_container_path() -> str:
+    return env_text("PHASMID_DUMMY_CONTAINER_PATH", "vault.bin")
+
+
 def display_enabled() -> bool:
     return env_flag("PHASMID_ENABLE_DISPLAY", default=False)
 

--- a/src/phasmid/dummy_profile_eval.py
+++ b/src/phasmid/dummy_profile_eval.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DummyProfileEvaluation:
+    container_size_bytes: int
+    dummy_size_bytes: int
+    file_count: int
+    occupancy_ratio: float
+    min_file_size: int
+    p50_file_size: int
+    max_file_size: int
+    warnings: list[str]
+
+
+def _percentile(sorted_values: list[int], percentile: float) -> int:
+    if not sorted_values:
+        return 0
+    idx = int((len(sorted_values) - 1) * percentile)
+    return sorted_values[idx]
+
+
+def _collect_file_sizes(path: Path) -> list[int]:
+    if not path.exists() or not path.is_dir():
+        return []
+    sizes: list[int] = []
+    for item in path.rglob("*"):
+        if item.is_file():
+            try:
+                sizes.append(item.stat().st_size)
+            except OSError:
+                continue
+    return sizes
+
+
+def evaluate_dummy_profile(
+    *,
+    dummy_profile_dir: str | Path,
+    container_path: str | Path,
+    min_size_mb: int,
+    min_file_count: int,
+    occupancy_warn_threshold: float,
+) -> DummyProfileEvaluation:
+    dummy_dir = Path(dummy_profile_dir)
+    container = Path(container_path)
+
+    file_sizes = sorted(_collect_file_sizes(dummy_dir))
+    file_count = len(file_sizes)
+    dummy_size_bytes = sum(file_sizes)
+    min_size_bytes = max(0, int(min_size_mb) * 1024 * 1024)
+
+    try:
+        container_size_bytes = container.stat().st_size
+    except OSError:
+        container_size_bytes = 0
+
+    occupancy_ratio = 0.0
+    if container_size_bytes > 0:
+        occupancy_ratio = dummy_size_bytes / float(container_size_bytes)
+
+    warnings: list[str] = []
+    if file_count < max(0, min_file_count):
+        warnings.append(
+            "dummy profile file count is below configured minimum"
+        )
+    if dummy_size_bytes < min_size_bytes:
+        warnings.append(
+            "dummy profile size is below configured minimum"
+        )
+    if container_size_bytes > 0 and occupancy_ratio < max(0.0, occupancy_warn_threshold):
+        warnings.append(
+            "dummy profile size is disproportionately small relative to the local container"
+        )
+
+    min_file_size = file_sizes[0] if file_sizes else 0
+    p50_file_size = _percentile(file_sizes, 0.5)
+    max_file_size = file_sizes[-1] if file_sizes else 0
+
+    return DummyProfileEvaluation(
+        container_size_bytes=container_size_bytes,
+        dummy_size_bytes=dummy_size_bytes,
+        file_count=file_count,
+        occupancy_ratio=occupancy_ratio,
+        min_file_size=min_file_size,
+        p50_file_size=p50_file_size,
+        max_file_size=max_file_size,
+        warnings=warnings,
+    )
+
+
+def human_bytes(value: int) -> str:
+    if value < 1024:
+        return f"{value} B"
+    size = float(value)
+    for unit in ("KiB", "MiB", "GiB", "TiB"):
+        size /= 1024.0
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
+    return f"{size:.1f} PiB"

--- a/src/phasmid/services/doctor_service.py
+++ b/src/phasmid/services/doctor_service.py
@@ -10,7 +10,17 @@ import tempfile
 import time
 from pathlib import Path
 
-from ..config import debug_enabled, doctor_recent_seconds, state_dir
+from ..config import (
+    debug_enabled,
+    doctor_recent_seconds,
+    dummy_container_path,
+    dummy_min_file_count,
+    dummy_min_size_mb,
+    dummy_occupancy_warn,
+    dummy_profile_dir,
+    state_dir,
+)
+from ..dummy_profile_eval import evaluate_dummy_profile, human_bytes
 from ..luks_layer import LuksConfig, LuksLayer, LuksMode
 from ..models.doctor import DoctorCheck, DoctorLevel, DoctorResult
 from ..process_hardening import hardening_status
@@ -637,6 +647,68 @@ def _check_luks_statuses() -> list[DoctorCheck]:
     return checks
 
 
+def _check_dummy_profile_plausibility() -> list[DoctorCheck]:
+    evaluation = evaluate_dummy_profile(
+        dummy_profile_dir=dummy_profile_dir(),
+        container_path=dummy_container_path(),
+        min_size_mb=dummy_min_size_mb(),
+        min_file_count=dummy_min_file_count(),
+        occupancy_warn_threshold=dummy_occupancy_warn(),
+    )
+    warning_level = DoctorLevel.WARN if evaluation.warnings else DoctorLevel.OK
+    ratio_pct = evaluation.occupancy_ratio * 100.0
+
+    checks = [
+        DoctorCheck(
+            name="Dummy Profile Size",
+            level=warning_level,
+            message=(
+                f"dummy profile size: {human_bytes(evaluation.dummy_size_bytes)}; "
+                f"container size: {human_bytes(evaluation.container_size_bytes)}"
+            ),
+        ),
+        DoctorCheck(
+            name="Dummy Profile File Count",
+            level=warning_level,
+            message=f"dummy profile file count: {evaluation.file_count}",
+        ),
+        DoctorCheck(
+            name="Dummy Profile Occupancy Ratio",
+            level=warning_level,
+            message=f"occupancy ratio: {ratio_pct:.2f}%",
+        ),
+        DoctorCheck(
+            name="Dummy Profile Size Distribution",
+            level=DoctorLevel.INFO,
+            message=(
+                "file size distribution: "
+                f"min={human_bytes(evaluation.min_file_size)}, "
+                f"p50={human_bytes(evaluation.p50_file_size)}, "
+                f"max={human_bytes(evaluation.max_file_size)}"
+            ),
+        ),
+    ]
+    if evaluation.warnings:
+        checks.append(
+            DoctorCheck(
+                name="Dummy Profile Plausibility",
+                level=DoctorLevel.WARN,
+                message="Dummy profile plausibility assessment: LOW",
+                detail="; ".join(evaluation.warnings),
+            )
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                name="Dummy Profile Plausibility",
+                level=DoctorLevel.OK,
+                message="Dummy profile plausibility assessment: baseline thresholds met",
+                detail="Operational plausibility is advisory, not a technical guarantee.",
+            )
+        )
+    return checks
+
+
 def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
     cfg = config_dir()
     vault_path = Path("vault.bin")
@@ -657,6 +729,7 @@ def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
     ]
 
     checks += _check_luks_statuses()
+    checks += _check_dummy_profile_plausibility()
 
     checks += [
         _check_process_hardening(),

--- a/tests/test_doctor_m4.py
+++ b/tests/test_doctor_m4.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
@@ -29,8 +30,38 @@ class DoctorM4Checks(unittest.TestCase):
             "Local container path",
             "Local container mount state",
             "LUKS key-store tmpfs",
+            "Dummy Profile Size",
+            "Dummy Profile File Count",
+            "Dummy Profile Occupancy Ratio",
+            "Dummy Profile Size Distribution",
+            "Dummy Profile Plausibility",
         }
         self.assertTrue(expected.issubset(names))
+
+    def test_dummy_profile_plausibility_warns_for_small_ratio(self):
+        with tempfile.TemporaryDirectory() as td:
+            dummy_dir = os.path.join(td, "dummy")
+            os.makedirs(dummy_dir, exist_ok=True)
+            with open(os.path.join(dummy_dir, "a.bin"), "wb") as handle:
+                handle.write(b"a" * 64)
+            container = os.path.join(td, "vault.bin")
+            with open(container, "wb") as handle:
+                handle.write(b"b" * (10 * 1024 * 1024))
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "PHASMID_DUMMY_PROFILE_DIR": dummy_dir,
+                    "PHASMID_DUMMY_CONTAINER_PATH": container,
+                    "PHASMID_DUMMY_MIN_SIZE_MB": "1",
+                    "PHASMID_DUMMY_MIN_FILE_COUNT": "2",
+                    "PHASMID_DUMMY_OCCUPANCY_WARN": "0.10",
+                },
+                clear=False,
+            ):
+                result = run_doctor_checks()
+
+        check = next(c for c in result.checks if c.name == "Dummy Profile Plausibility")
+        self.assertEqual("WARN", check.level.value)
 
     def test_luks_checks_show_disabled_state(self):
         with mock.patch.dict(os.environ, {"PHASMID_LUKS_MODE": "disabled"}, clear=False):

--- a/tests/test_dummy_profile_eval.py
+++ b/tests/test_dummy_profile_eval.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import unittest
+
+from phasmid.dummy_profile_eval import evaluate_dummy_profile
+
+
+class DummyProfileEvalTests(unittest.TestCase):
+    def test_warns_on_small_footprint(self):
+        with self.subTest("small footprint"):
+            import tempfile
+            from pathlib import Path
+
+            with tempfile.TemporaryDirectory() as td:
+                base = Path(td)
+                dummy_dir = base / "dummy"
+                dummy_dir.mkdir()
+                (dummy_dir / "a.txt").write_bytes(b"a" * 128)
+
+                container = base / "vault.bin"
+                container.write_bytes(b"x" * (10 * 1024 * 1024))
+
+                result = evaluate_dummy_profile(
+                    dummy_profile_dir=dummy_dir,
+                    container_path=container,
+                    min_size_mb=1,
+                    min_file_count=3,
+                    occupancy_warn_threshold=0.10,
+                )
+
+                self.assertEqual(result.file_count, 1)
+                self.assertEqual(result.container_size_bytes, 10 * 1024 * 1024)
+                self.assertLess(result.occupancy_ratio, 0.10)
+                self.assertTrue(result.warnings)
+
+    def test_ok_when_thresholds_met(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            dummy_dir = base / "dummy"
+            dummy_dir.mkdir()
+            for i in range(4):
+                (dummy_dir / f"f{i}.bin").write_bytes(b"a" * (300 * 1024))
+
+            container = base / "vault.bin"
+            container.write_bytes(b"x" * (8 * 1024 * 1024))
+
+            result = evaluate_dummy_profile(
+                dummy_profile_dir=dummy_dir,
+                container_path=container,
+                min_size_mb=1,
+                min_file_count=4,
+                occupancy_warn_threshold=0.10,
+            )
+
+            self.assertEqual(result.file_count, 4)
+            self.assertGreaterEqual(result.dummy_size_bytes, 1024 * 1024)
+            self.assertGreaterEqual(result.occupancy_ratio, 0.10)
+            self.assertEqual(result.warnings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -124,6 +124,7 @@ class TerminologyAuditTests(unittest.TestCase):
             "src/phasmid/crypto_params.py",
             "src/phasmid/luks_layer.py",
             "src/phasmid/luks_key_store.py",
+            "src/phasmid/dummy_profile_eval.py",
         }
         self.assertEqual(all_modules, scanned | internal_allowlist)
 


### PR DESCRIPTION
## Summary\n- add configurable baseline thresholds for local dummy dataset plausibility checks\n- add doctor checks for size, file count, occupancy ratio, and size distribution\n- add unit tests for threshold warnings and occupancy calculation\n- document new environment variables in docs/CONFIGURATION.md\n\n## Notes\n- This is a partial implementation for #104 focused on local evaluation and warnings.\n- It does not implement dummy dataset generation/import workflows yet.\n\n## Validation\n- python3 -m unittest discover -s tests\n- ruff check src tests\n- mypy --strict src (repository baseline currently has pre-existing strict typing errors outside this PR scope)