### PR TITLE
Refine web UI with fluid-interface design principles

### DIFF
--- a/src/phasmid/templates/base.html
+++ b/src/phasmid/templates/base.html
@@ -59,15 +59,20 @@
             --webui-warning: #ff5f5f;  /* exposure banner */
 
             /* Radius */
-            --r-sm:   2px;
-            --r-md:   4px;
-            --r-lg:   6px;
+            --r-sm:   4px;
+            --r-md:   6px;
+            --r-lg:   10px;
             --r-pill: 999px;
+
+            /* Easing curves */
+            --ease-out-soft: cubic-bezier(0.25, 1, 0.5, 1);
+            --ease-overshoot: cubic-bezier(0.34, 1.56, 0.64, 1);
 
             /* Transitions */
             --t-fast: 0.12s ease;
             --t-base: 0.18s ease;
             --t-slow: 0.28s ease;
+            --t-press: transform 180ms var(--ease-out-soft);
         }
 
         /* ── Reset ────────────────────────────────────────────── */
@@ -113,8 +118,20 @@
             justify-content: space-between;
             gap: 20px;
             margin-bottom: 28px;
-            padding-bottom: 20px;
-            border-bottom: 1px solid var(--border-soft);
+            padding-top: 16px;
+            padding-bottom: 18px;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background: rgba(13,13,13,0.72);
+            backdrop-filter: blur(20px) saturate(140%);
+            -webkit-backdrop-filter: blur(20px) saturate(140%);
+            border-top: 1px solid rgba(255,255,255,0.06);
+            border-bottom: 1px solid rgba(0,215,175,0.08);
+            box-shadow: 0 10px 24px -18px rgba(0,0,0,0.75);
+        }
+        body:has(#webui-warning-banner) .topbar {
+            top: 22px;
         }
         .brand {
             display: flex;
@@ -160,11 +177,15 @@
             letter-spacing: 0.03em;
             border-bottom: 2px solid transparent;
             border-radius: var(--r-md) var(--r-md) 0 0;
-            transition: color var(--t-fast), border-color var(--t-fast), background var(--t-fast);
+            transition: color var(--t-fast), border-color var(--t-fast), background var(--t-fast), var(--t-press);
         }
         .nav a:hover {
             color: var(--text-secondary);
             background: rgba(0,215,175,0.06);
+        }
+        .nav a:active {
+            transform: scale(0.97);
+            transition: transform 100ms ease-out;
         }
         .nav a.active {
             color: var(--accent-bright);
@@ -209,6 +230,7 @@
             flex-direction: column;
             gap: 8px;
             min-height: 94px;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.30);
         }
         .status-card__head {
             display: flex;
@@ -243,6 +265,21 @@
             50%      { opacity: 0.5; }
         }
 
+        @keyframes surface-in {
+            from { opacity: 0; transform: translateY(6px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+        .panel, .status-card {
+            animation: surface-in 0.4s var(--ease-out-soft) both;
+        }
+        .status-grid .status-card:nth-child(2) { animation-delay: 0.03s; }
+        .status-grid .status-card:nth-child(3) { animation-delay: 0.06s; }
+        .status-grid .status-card:nth-child(4) { animation-delay: 0.09s; }
+        .grid > *:nth-child(2),
+        .split-grid > *:nth-child(2),
+        .panel-grid > *:nth-child(2) { animation-delay: 0.06s; }
+        .panel-grid > *:nth-child(3) { animation-delay: 0.09s; }
+
         /* ── Section Label ────────────────────────────────────── */
         .section-label {
             font-size: 11px;
@@ -259,7 +296,7 @@
             background: linear-gradient(180deg, rgba(255,255,255,0.025), transparent 48%), var(--bg-surface);
             border-radius: var(--r-md);
             padding: 20px;
-            box-shadow: 0 8px 24px rgba(0,0,0,0.28);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.40), 0 12px 32px rgba(0,0,0,0.35);
         }
         .panel--danger {
             border-left-color: var(--status-alert);
@@ -359,7 +396,7 @@
         }
 
         /* ── Typography ───────────────────────────────────────── */
-        h2 { font-size: 15px; font-weight: 700; margin: 0; letter-spacing: 0.02em; }
+        h2 { font-size: 1.0625rem; font-weight: 700; margin: 0; letter-spacing: -0.005em; line-height: 1.2; }
         h3 {
             font-size: 11px;
             font-weight: 600;
@@ -473,7 +510,7 @@
             padding: 9px 15px;
             border-radius: var(--r-lg);
             border: 1px solid;
-            transition: background var(--t-fast), box-shadow var(--t-fast), border-color var(--t-fast), color var(--t-fast);
+            transition: background var(--t-fast), box-shadow var(--t-fast), border-color var(--t-fast), color var(--t-fast), var(--t-press);
             /* Primary */
             color: #0a1008;
             background: var(--accent);
@@ -482,6 +519,10 @@
         button:hover, .button:hover {
             background: var(--accent-bright);
             box-shadow: 0 0 14px var(--glow-accent);
+        }
+        button:active, .button:active {
+            transform: scale(0.97);
+            transition: transform 100ms ease-out;
         }
         button.secondary, .button.secondary {
             color: var(--text-secondary);
@@ -534,12 +575,12 @@
             background: var(--bg-raised);
             color: var(--text);
             padding: 10px 12px;
-            transition: border-color var(--t-fast), box-shadow var(--t-fast);
+            transition: border-color 150ms var(--ease-out-soft), box-shadow 150ms var(--ease-out-soft);
         }
         input:focus, select:focus {
             outline: none;
             border-color: var(--border-focus);
-            box-shadow: 0 0 0 3px rgba(74,112,56,.18);
+            box-shadow: 0 0 0 1px var(--border-focus), 0 0 0 4px rgba(0,215,175,0.14);
         }
         input::placeholder { color: var(--text-muted); }
 
@@ -557,6 +598,8 @@
             font-size: 13px;
             letter-spacing: 0.02em;
             user-select: none;
+            border-radius: var(--r-sm);
+            transition: color var(--t-fast);
         }
         summary:hover { color: var(--text-secondary); }
         details[open] summary { margin-bottom: 12px; color: var(--text-secondary); }
@@ -603,19 +646,25 @@
             max-width: 400px;
             padding: 13px 16px;
             border-radius: var(--r-md);
-            background: var(--bg-overlay);
+            background: rgba(20,20,20,0.82);
+            backdrop-filter: blur(16px) saturate(140%);
+            -webkit-backdrop-filter: blur(16px) saturate(140%);
             border: 1px solid var(--border);
             border-left: 3px solid var(--accent);
             color: var(--text);
             font-size: 13px;
-            box-shadow: 0 12px 28px rgba(0,0,0,.40);
+            box-shadow: 0 1px 2px rgba(0,0,0,.5), 0 18px 44px rgba(0,0,0,.5);
             opacity: 0;
-            transform: translateY(10px);
-            transition: opacity var(--t-base), transform var(--t-base);
+            transform: translateY(16px);
+            transition: opacity 0.22s var(--ease-out-soft), transform 0.22s var(--ease-out-soft);
             pointer-events: none;
             z-index: 1000;
         }
-        .toast.show { opacity: 1; transform: translateY(0); }
+        .toast.show {
+            opacity: 1;
+            transform: translateY(0);
+            transition: opacity 0.28s var(--ease-out-soft), transform 0.42s var(--ease-overshoot);
+        }
         .toast.toast--success { border-left-color: var(--status-ready); }
         .toast.toast--error   { border-left-color: var(--status-alert); }
         .toast.toast--caution { border-left-color: var(--status-caution); }
@@ -801,6 +850,64 @@
         .hidden { display: none !important; }
         .camera-panel { padding-bottom: 0; }
         .camera-panel .panel-head { padding-bottom: 14px; }
+
+        button:focus-visible,
+        .button:focus-visible,
+        a:focus-visible,
+        input:focus-visible,
+        select:focus-visible,
+        summary:focus-visible {
+            outline: 2px solid var(--border-focus);
+            outline-offset: 2px;
+        }
+
+        * { scrollbar-width: thin; scrollbar-color: #333 transparent; }
+        ::-webkit-scrollbar { width: 10px; height: 10px; }
+        ::-webkit-scrollbar-track { background: transparent; }
+        ::-webkit-scrollbar-thumb {
+            background: #2e2e2e;
+            border-radius: var(--r-pill);
+            border: 2px solid transparent;
+            background-clip: padding-box;
+        }
+        ::-webkit-scrollbar-thumb:hover { background: #3c3c3c; background-clip: padding-box; }
+
+        @media (prefers-reduced-motion: reduce) {
+            .panel, .status-card { animation: none; }
+            .led--active { animation: none; }
+            .camera-frame.matched { animation: none; }
+            button:active, .button:active, .nav a:active { transform: none; }
+            .toast {
+                transform: none;
+                transition: opacity 200ms ease;
+            }
+            .toast.show { transform: none; transition: opacity 200ms ease; }
+        }
+        @media (prefers-reduced-transparency: reduce) {
+            .topbar {
+                background: rgba(13,13,13,0.98);
+                backdrop-filter: none;
+                -webkit-backdrop-filter: none;
+            }
+            .toast {
+                background: rgba(20,20,20,0.98);
+                backdrop-filter: none;
+                -webkit-backdrop-filter: none;
+            }
+        }
+        @media (prefers-contrast: more) {
+            :root { --text-secondary: #b4b4b4; }
+            .topbar {
+                background: var(--bg-base);
+                backdrop-filter: none;
+                -webkit-backdrop-filter: none;
+                border-bottom: 1px solid var(--border);
+            }
+            .panel, .status-card, .toast {
+                background: var(--bg-surface);
+                border-color: var(--text-secondary);
+            }
+        }
 
         /* ── Responsive ───────────────────────────────────────── */
         @media (max-width: 900px) {


### PR DESCRIPTION
## Summary

Experimental UI refinement applying Apple-style fluid-interface and craft principles (WWDC "Designing Fluid Interfaces" et al.) to the web UI, while fully preserving the existing JES Neon-Ops dark HUD identity. All changes are confined to a single file — `src/phasmid/templates/base.html` (+123/−16) — so this is trivially revertible if not adopted.

## Changes

**Response & press feedback**
- Buttons and nav links respond instantly on pointer-down (`:active` scale 0.97, ~100ms) with a softer settle on release; only `transform`/`opacity` are animated for motion.

**Motion**
- New easing tokens (`--ease-out-soft`, `--ease-overshoot`).
- Toast now enters and exits along the same path (slide + fade, mirrored easing), with a subtle overshoot only on arrival; exit is animated instead of abrupt.
- Restrained one-time staggered entrance (opacity + 6px rise, no overshoot) for panels and status cards.

**Materials & depth**
- Topbar is now a sticky translucent material bar (`backdrop-filter: blur(20px) saturate(140%)`) with content scrolling underneath, a faint bright top edge, and a soft scroll-edge in place of the hard 1px border. Offsets correctly below the fixed exposure warning banner.
- Toast gets matching material treatment; panels/cards use layered depth shadows (bigger surfaces read thicker).

**Accessibility (previously absent)**
- `prefers-reduced-motion: reduce` — entrance/pulse/flash animations and press-scale disabled; toast becomes a 200ms fade.
- `prefers-reduced-transparency: reduce` — topbar/toast go solid, blur dropped.
- `prefers-contrast: more` — solid surfaces with defined contrasting borders.
- `:focus-visible` outlines (2px accent, 2px offset) for buttons, links, inputs, selects, and summaries.

**Craft & typography**
- Radius scale softened via tokens (2/4/6 → 4/6/10px), applied consistently.
- Two-layer input focus ring using the cyan accent (replaces the old off-palette greenish glow).
- `h2` bumped to 17px with tighter leading and slight negative tracking for clearer hierarchy.
- Subtle dark scrollbar styling.

## Constraints preserved

- No DOM ids/classes renamed (all JS hooks like `deviceState`, `toast`, `storeForm` etc. untouched).
- Primary `<nav>` unchanged; no `/emergency` link; no HTML comments introduced.
- No Jinja variables, blocks, or test-asserted copy touched.
- Inline-only assets, CSP-compatible, no external fonts/CDNs/libraries, no build step.

## Testing

```
python -m pytest tests/test_terminology.py tests/webui/test_source_leakage.py \
  tests/test_docs_and_templates.py tests/scenarios/test_field_mode_visibility.py -q
29 passed in 0.55s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvtXzJMwWEskGHpkbWLV8z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvtXzJMwWEskGHpkbWLV8z)_