### PR TITLE
docs: add Simple Operator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ What `./phasmid` does on first run:
 
 Success check:
 
-- you see the TUI Operator Console panel
-- press `c` to create a Vessel
+- you see the Simple Operator screen
+- press `n` to create protected storage
 - press `g` for a guided walkthrough
 
 If the TUI does not open, run `phasmid doctor`.
@@ -186,6 +186,7 @@ python3 -m unittest discover -s tests
 Primary entry points:
 
 - Documentation index (full map): [`docs/README_INDEX.md`](docs/README_INDEX.md)
+- WebUI normal-use manual: [`docs/WEBUI_OPERATOR_GUIDE.md`](docs/WEBUI_OPERATOR_GUIDE.md)
 - Threat model authority: [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md)
 - Behavioral specification: [`docs/SPECIFICATION.md`](docs/SPECIFICATION.md)
 - Architecture overview: [`docs/PHASMID_ARCHITECTURE.md`](docs/PHASMID_ARCHITECTURE.md)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -56,6 +56,11 @@ When a graphical interface is required, the operator may "expose" the WebUI. Bec
 2. **Operate**: Perform necessary tasks via `http://127.0.0.1:8000`.
 3. **Retract**: Press `w` again in the TUI. Confirm the shutdown of the WebUI process.
 
+For the normal Protect/Open workflow after the interface is available, use the
+[WebUI Operator Guide](WEBUI_OPERATOR_GUIDE.md). That guide is the operator
+manual for the Simple Operator dashboard; this document covers exposure
+management and local checks.
+
 ### Safety Mechanisms
 
 - **Inactivity Auto-Kill**: The TUI monitors operator input. If no keys are pressed for 10 minutes, the WebUI is automatically terminated.

--- a/docs/PHASMID_ARCHITECTURE.md
+++ b/docs/PHASMID_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Phasmid is a field-evaluation prototype for local-only coercion-aware storage and the reference implementation of the Janus Eidolon System.
 
-![Phasmid architecture overview](../images/architecture_v1.png)
+![Phasmid architecture overview](images/architecture_v1.png)
 
 Two-slot architecture overview: vessel structure, disclosure faces, local key material, and object-cue operating boundary.
 
@@ -67,7 +67,7 @@ See `docs/COERCION_SAFE_DELAYING.md` for full design documentation.
 
 ## Current Documentation Map
 
-- [docs/SPECIFICATION.md](docs/SPECIFICATION.md) defines implementation behavior and configuration.
-- [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) defines assumptions, residual risk, and safety boundaries.
-- [docs/JANUS_EIDOLON_SYSTEM.md](docs/JANUS_EIDOLON_SYSTEM.md) defines the formal two-slot architecture.
+- [SPECIFICATION.md](SPECIFICATION.md) defines implementation behavior and configuration.
+- [THREAT_MODEL.md](THREAT_MODEL.md) defines assumptions, residual risk, and safety boundaries.
+- [JANUS_EIDOLON_SYSTEM.md](JANUS_EIDOLON_SYSTEM.md) defines the formal two-slot architecture.
 - [README.md](../README.md) defines the user-facing tool summary and operational limits.

--- a/docs/README_INDEX.md
+++ b/docs/README_INDEX.md
@@ -23,6 +23,7 @@ Use this order when documents overlap:
 
 ## Operator interfaces
 
+- WebUI normal-use manual: [`WEBUI_OPERATOR_GUIDE.md`](WEBUI_OPERATOR_GUIDE.md)
 - TUI Operator Console: [`TUI_OPERATOR_CONSOLE.md`](TUI_OPERATOR_CONSOLE.md)
 - Operational workflow guide: [`OPERATIONS.md`](OPERATIONS.md)
 - Restricted actions policy and flow: [`RESTRICTED_ACTIONS.md`](RESTRICTED_ACTIONS.md)

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -188,12 +188,16 @@ The default bind address is `127.0.0.1:8000`.
 
 WebUI v2 is server-rendered with lightweight JavaScript. It preserves the internal two-slot model while presenting normal operations as protected-entry workflows.
 
-Normal navigation:
+Normal navigation presents a Simple Operator surface:
 
 - Home
-- Store
-- Retrieve
-- Maintenance
+- Protect a File
+- Open a Protected File
+- Guided Mode
+
+Maintenance, diagnostics, audit, and inspection are available through
+Advanced tools for experienced operators. Normal flows do not expose those
+controls by default.
 
 The restricted action view is available only by direct route and is not shown in normal navigation. A direct `GET /emergency` renders only a restricted confirmation screen until the browser has a fresh restricted confirmation session. After confirmation, the page presents a short stepwise emergency flow with exact-phrase prompts and a visible restricted-confirmation lifetime. Hidden route concealment is not a security boundary.
 
@@ -258,11 +262,14 @@ Phasmid must prefer simple, low-choice flows under stress.
 
 Normal operation should remain:
 
-1. Store
-2. Retrieve
-3. Maintenance
+1. Protect a File
+2. Open a Protected File
+3. Guided Mode when help is needed
 
-Restricted actions must remain separated. Field Mode should reduce diagnostic noise. The UI should avoid forcing the user to reason about internal slots, trial order, recovery side effects, or disclosure structure during stressful conditions.
+Advanced and restricted actions must remain separated. Field Mode should reduce
+diagnostic noise. The UI should avoid forcing the user to reason about internal
+slots, trial order, recovery side effects, or disclosure structure during
+stressful conditions.
 
 ## 10. Metadata and Data Minimization
 

--- a/docs/TUI_OPERATOR_CONSOLE.md
+++ b/docs/TUI_OPERATOR_CONSOLE.md
@@ -4,10 +4,10 @@
 
 Phasmid provides a terminal user interface as its primary operator console.
 
-Running `phasmid` with no arguments opens the Main Operator Console. Long
-command-line argument chains are not required for normal operation. Complex
-workflows are accessible through the TUI, guided workflows, and configuration
-files.
+Running `phasmid` with no arguments opens the Simple Operator screen. Long
+command-line argument chains are not required for normal operation. The
+default screen provides only Open, New, Guided, Expert, and Quit. Detailed
+operator screens remain available through Expert.
 
 Phasmid is a research-grade prototype for studying and operating deniable
 storage under coerced disclosure scenarios. The TUI reflects that position: it
@@ -87,7 +87,8 @@ src/phasmid/
     theme.py                phasmid-dark and phasmid-light themes
 
     screens/
-      home.py               Main Operator Console
+      simple_home.py        Simple Operator screen (default)
+      home.py               Expert operator console
       about.py              About / splash screen with full banner
       audit.py              Audit View
       doctor.py             Doctor View
@@ -133,7 +134,7 @@ The TUI does not implement cryptographic operations directly.
 ## Commands
 
 ```bash
-phasmid                    Open the Main Operator Console
+phasmid                    Open the Simple Operator screen
 phasmid open <vessel>      Open a Vessel in the TUI
 phasmid open <vessel> --no-tui --face face_a
                            Mark a Vessel open directly from the CLI
@@ -164,62 +165,37 @@ phasmid about              Open the About screen
 Legacy commands (`init`, `brick`, `verify-state`, `verify-audit-log`,
 `export-redacted-log`) remain available for compatibility and advanced use.
 
-## Main Operator Console
+## Simple Operator Screen
 
-The Main Operator Console is the default TUI entry point.
-
-![TUI Home screen](../images/TUI_HOME.png)
-Home screen with vessel list, vessel summary panel, event log, and operator shortcuts.
+The Simple Operator screen is the default TUI entry point. It shows protected
+storage and keeps normal actions short and visible. The current profile's
+default Vessel directory and selected Vessel context are preserved.
 
 ### Keyboard Shortcuts
 
 | Key | Action |
 |---|---|
 | `o` | Open selected Vessel |
-| `x` | Close selected Vessel |
-| `c` | Create new Vessel |
-| `i` | Inspect selected Vessel |
-| `f` | Manage Faces |
-| `g` | Guided Workflows |
-| `a` | Audit View |
-| `d` | Doctor |
-| `w` | Toggle WebUI Start/Stop |
-| `s` | Settings |
-| `?` | Help / About |
+| `n` | Create protected storage |
+| `g` | Guided Help |
+| `e` | Open Expert controls |
 | `q` | Quit |
 | `r` | Refresh Vessel list (not shown in footer) |
 
-## Screen Gallery (Operator Reference)
+## Expert Controls
 
-To reduce unnecessary exposure, keep public-facing screenshot use minimal.
-The Home screen above should be the default reference image.
-The following screenshots are optional operator-reference views.
-
-### Audit View
-
-![TUI Audit screen](../images/TUI_AUDIT.png)
-
-### Doctor View
-
-![TUI Doctor screen](../images/TUI_DOCTOR.png)
-
-### Inspect Vessel View
-
-![TUI Inspect screen](../images/TUI_INSPECT.png)
-
-### Disclosure Face Manager
-
-![TUI Face Manager screen](../images/TUI_FACE.png)
-
-The Face Manager uses the shared Vessel workflow backend. It creates or updates
-local Face records and displays face id, label, status, file count, occupancy,
-and most recent access time.
+Press `e` from the Simple Operator screen to open the detailed operator
+console. It retains the selected Vessel and provides the previous detailed
+actions: Close, Create, Inspect, Face management, Audit, Doctor, Settings,
+LUKS, and Help. Expert controls are for diagnostic and maintenance work, not
+the normal Protect/Open flow.
 
 ## WebUI Integration (Exposed Mode)
 
 Phasmid provides a local WebUI for operators who require a graphical interface
 for certain tasks. This interface is considered "exposed" as it opens a network
-port (default `0.0.0.0:8000` for USB gadget-connected operation).
+port. The default bind address is `127.0.0.1:8000`; deployment configuration
+may set a different host only when the access path is otherwise protected.
 
 ### WebUI Control
 
@@ -375,10 +351,12 @@ government-adjacent evaluators, and institutional reviewers.
 Guided Workflows are step-by-step interactive explanations built into the same
 operator console. They are not a separate demo mode.
 
-Available workflows:
+The first two workflows support normal use:
 
 | ID | Title |
 |---|---|
+| `quick_protect` | Protect a File |
+| `quick_open` | Open a Protected File |
 | `coerced_disclosure` | Coerced Disclosure Walkthrough |
 | `headerless_inspection` | Headerless Vessel Inspection |
 | `multiple_faces` | Multiple Disclosure Faces |

--- a/docs/WEBUI_OPERATOR_GUIDE.md
+++ b/docs/WEBUI_OPERATOR_GUIDE.md
@@ -1,0 +1,90 @@
+# WebUI Operator Guide
+
+This guide describes the standard local WebUI flow. It is for normal
+Protect/Open use; diagnostics, audit information, inspection, and restricted
+local updates remain advanced operator tasks.
+
+Phasmid is research software. The WebUI is local-only by default and is not a
+substitute for host integrity, full-disk encryption, or a complete response to
+compelled disclosure.
+
+## Before You Start
+
+1. Start the WebUI from the TUI with `w`, or run
+   `python3 -m phasmid.web_server` for a local development session.
+2. Open the address shown by the TUI or use `http://127.0.0.1:8000` when the
+   default host and port are in use.
+3. Check the visible WebUI-active warning before continuing. Do not expose the
+   interface to an untrusted network.
+
+When the TUI manages the WebUI, it stops the server after ten minutes without
+operator input. Stop it with `w` when the graphical task is complete.
+
+## Home
+
+The normal home screen has three entry points:
+
+- **Protect a File** starts a new protection operation.
+- **Open a Protected File** opens a file that was protected earlier.
+- **Guided Mode** presents the same normal flows as step-by-step help.
+
+**Advanced tools** contains maintenance, diagnostics, audit, and inspection.
+Use those controls only when the normal flow does not meet the task. Hidden
+routes are not an access-control boundary.
+
+## Protect a File
+
+The Protect screen keeps the action disabled until all three requirements are
+ready.
+
+1. **Choose the file.** Select one local file within the configured upload
+   limit.
+2. **Create the access password.** Use a distinct, memorable passphrase that
+   meets the local policy. Do not reuse it for the optional restricted recovery
+   password.
+3. **Set the physical access object.** Present an object clearly to the local
+   camera, then select **Capture access object**. Use an object that can be
+   presented consistently later.
+4. Review the readiness summary. When File, Password, and Access object are
+   all ready, select **Protect file**.
+
+The object cue is an operational access cue. It is not cryptographic key
+material, and a camera match is not proof of identity.
+
+### Optional advanced security controls
+
+Expand **Advanced security options** only when needed:
+
+- Set an optional restricted recovery password. It must differ from the access
+  password.
+- Check metadata risk before protection, or download a best-effort
+  metadata-reduced copy for supported formats. Reduction is not complete
+  sanitization and never replaces the original automatically.
+- Add a local note only when it does not reveal sensitive identifying context.
+
+If local space must be replaced, the interface requires restricted
+confirmation and typed replacement confirmation. Review the prompt carefully:
+replacement is a restricted local update and can remove an existing entry.
+
+## Open a Protected File
+
+1. **Show the access object.** Hold the same object in the camera view until a
+   stable match is reported.
+2. **Enter the access password.** Select **Open protected file**.
+3. When **File ready** appears, select **Download file**.
+4. Select **Finish and clear** when you no longer need the result. This clears
+   the browser session state; it does not guarantee deletion of downloaded
+   copies or browser/operating-system artifacts.
+
+If access is not granted, verify the object, camera view, and password. The
+interface intentionally provides limited failure detail.
+
+## After Use
+
+1. Download only the file needed for the task.
+2. Clear the local browser session.
+3. Return to the TUI and stop the WebUI with `w` when it is no longer needed.
+
+For deployment posture and limits, read the
+[Threat Model](THREAT_MODEL.md). For restricted actions, read
+[Restricted Actions](RESTRICTED_ACTIONS.md).

--- a/tests/test_docs_and_templates.py
+++ b/tests/test_docs_and_templates.py
@@ -28,6 +28,17 @@ class DocsAndTemplateTests(unittest.TestCase):
         self.assertIn("docs/PHASMID_ARCHITECTURE.md", readme)
         self.assertIn("docs/THREAT_MODEL.md", readme)
         self.assertIn("docs/SPECIFICATION.md", readme)
+        self.assertIn("docs/WEBUI_OPERATOR_GUIDE.md", readme)
+
+    def test_webui_operator_guide_covers_normal_simple_operator_flow(self):
+        guide = read_text("docs/WEBUI_OPERATOR_GUIDE.md")
+        self.assertIn("Protect a File", guide)
+        self.assertIn("Open a Protected File", guide)
+        self.assertIn("Guided Mode", guide)
+        self.assertIn("Advanced tools", guide)
+        self.assertIn("Finish and clear", guide)
+        self.assertIn("never replaces the original automatically", guide)
+        self.assertIn("not an access-control boundary", guide)
 
     def test_readme_addresses_reviewer_and_use_boundaries(self):
         readme = read_text("README.md")


### PR DESCRIPTION
## Summary

- add a normal-use WebUI operator guide for the Simple Operator dashboard
- align README, documentation index, operations, specification, and TUI guide with current Simple Operator flows
- remove obsolete TUI screenshot references and repair architecture-document links
- cover the new guide from the documentation tests

## Why

The WebUI and TUI now start from simplified operator surfaces, while the documentation still described the former detailed default console and lacked a normal-use WebUI manual.

## Validation

- `python3 -m unittest discover -s tests`
- `python3 -m ruff check src tests`
- `python3 -m mypy src`
- Markdown local-link check
- `git diff --check`