### PR TITLE
docs: record UI refresh, document WebUI access, cut 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-26
+
+Version 0.1.5 was prepared and version-bumped but never tagged or published; its
+changes ship here as part of 0.2.0. The last published release before this one is
+0.1.4.
+
+> **Security notice for 0.1.4 users — upgrade.** In 0.1.4 the TUI `w` key bound
+> the WebUI to `0.0.0.0`, reachable from any attached network. The WebUI serves
+> page HTML, the embedded mutation token, and `/video_feed` without
+> authentication, and `_ui_unlocked()` returns `True` unconditionally, so that
+> wildcard bind made those weaknesses remotely reachable — including the
+> restricted-action confirmation phrases, which are public constants in this
+> repository. 0.2.0 restores the documented loopback default. If you must expose
+> the WebUI, use `PHASMID_WEBUI_EXPOSE_GADGET=1`, which binds the USB gadget
+> interface only.
+
+This release also changes the default operator surface. The TUI now opens the
+Simple Operator screen instead of the detailed console, and the WebUI home is
+reduced to two primary actions. Existing expert workflows remain available behind
+Expert controls (`e`) and the WebUI **Advanced tools** disclosure.
+
 ### Added
+
+- Simple Operator mode: `phasmid` with no arguments now opens a low-cognitive-load
+  TUI entry screen (`src/phasmid/tui/screens/simple_home.py`) listing protected
+  storage with `o` Open, `n` New, `g` Guided, `e` Expert, and `q` Quit. The
+  previous detailed console is reachable with `e`.
+- WebUI Simple Operator home: two primary actions, **Protect a File** and **Open
+  a Protected File**, a Guided Mode entry point, and an **Advanced tools**
+  disclosure holding maintenance, diagnostics, audit, and inspection.
+- WebUI protect flow is now a numbered three-step wizard (choose file, create
+  access password, set physical access object) whose submit control stays
+  disabled until all three are ready. The retrieve flow is reduced to two steps.
+- Beginner-first guided workflows (`quick_protect`, `quick_open`) in both the TUI
+  and the WebUI, written without Phasmid-specific terminology.
+- `docs/WEBUI_OPERATOR_GUIDE.md`: normal-use manual for the refreshed WebUI.
+- README section documenting WebUI bind behaviour and the USB gadget opt-in.
 
 - WebUI object-cue registration from a local image file: `/register_key` now accepts an optional `reference_image` upload, and the Local Entry Maintenance page provides a file picker next to the existing camera rebind flow. Registration from a file derives the same encrypted feature template as camera capture and keeps the size-limited upload handling used by other WebUI uploads.
 - `AIGate.register_reference_from_image_bytes` for camera-independent reference registration, with decoding guards, downscaling of large images toward the camera frame scale, and the existing cue-similarity checks.
@@ -16,6 +52,12 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ### Changed
 
+- `docs/TUI_OPERATOR_CONSOLE.md` rewritten for the Simple/Expert split, and now
+  documents that entering Expert controls is one-way for the session: no key
+  returns to the Simple Operator screen and `q` there quits the application.
+- `README.md`, `docs/OPERATIONS.md`, `docs/SPECIFICATION.md`,
+  `docs/PHASMID_ARCHITECTURE.md`, and `docs/README_INDEX.md` updated for the
+  refreshed operator surfaces.
 - WebUI bind address is now resolved in one place, `WebUIService.resolve_bind_host()`, used by every start path. Order: explicit `PHASMID_HOST`, then opt-in USB gadget exposure, then `127.0.0.1`.
 - `WebUIService.start()` takes `host=None`/`port=None` and resolves them from configuration, so `PHASMID_PORT` is now honoured on the TUI path as well.
 - `WebUIService.access_url()` reports the address actually bound instead of probing for a USB gadget address, and no longer returns `None`. The TUI start notification and exposure banner show that address.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Current implementation status and evidence paths are tracked in [`docs/IMPLEMENT
 | OS | Linux, macOS (development); Raspberry Pi OS Bookworm/Bullseye (deployment) |
 | Hardware | x86-64 laptop/desktop for development; Raspberry Pi Zero 2 W for field deployment |
 | Camera (optional) | Picamera2 / libcamera — required only for object-cue matching on Pi |
-| WebUI (optional) | Any modern browser; intended for localhost or USB gadget Ethernet access only |
+| WebUI (optional) | Any modern browser; binds `127.0.0.1` by default. USB gadget Ethernet access is opt-in — see [WebUI access](#webui-access) |
 | LUKS (optional) | Linux kernel with dm-crypt — required for the optional LUKS2 storage layer |
 
 For Raspberry Pi deployment, `python3-picamera2` and `python3-libcamera` must be installed via apt before running the bootstrap script.
@@ -142,6 +142,29 @@ Phasmid does not claim:
 - covert communication, censorship bypass, remote wipe, or remote unlock
 
 For complete claims and non-claims, see [`docs/CLAIMS.md`](docs/CLAIMS.md), [`docs/NON_CLAIMS.md`](docs/NON_CLAIMS.md), and [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
+
+## WebUI access
+
+The WebUI binds `127.0.0.1:8000` by default, so pressing `w` in the TUI keeps it
+reachable only from the device itself. Reaching it from another machine is an
+explicit opt-in:
+
+```bash
+# Reach the WebUI from a laptop over the USB Ethernet gadget link.
+# Binds the gadget interface address (usb0 / enx*) only — never all interfaces.
+PHASMID_WEBUI_EXPOSE_GADGET=1 phasmid
+```
+
+If you skip this, the WebUI starts successfully but a browser on the attached
+laptop cannot reach it. The TUI notification and exposure banner always show the
+address actually bound, so check there first when a browser cannot connect.
+
+`PHASMID_HOST` overrides the bind address directly and takes precedence over the
+gadget opt-in. Setting `PHASMID_HOST=0.0.0.0` exposes the WebUI on every
+interface; because WebUI pages, the embedded mutation token, and `/video_feed`
+are served without authentication, treat that as unsafe on any untrusted
+network. See [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) and
+[`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md).
 
 ## Install and run details
 

--- a/docs/TUI_OPERATOR_CONSOLE.md
+++ b/docs/TUI_OPERATOR_CONSOLE.md
@@ -190,6 +190,13 @@ actions: Close, Create, Inspect, Face management, Audit, Doctor, Settings,
 LUKS, and Help. Expert controls are for diagnostic and maintenance work, not
 the normal Protect/Open flow.
 
+> **Entering Expert controls is one-way for the rest of the session.** There is
+> no key that returns to the Simple Operator screen: `q` in Expert controls
+> quits the application rather than going back. Restart `phasmid` to get the
+> Simple Operator screen again. Plan work that must stay on the simple surface
+> — a scripted demonstration, or handing the device to a non-specialist —
+> before pressing `e`.
+
 ## WebUI Integration (Exposed Mode)
 
 Phasmid provides a local WebUI for operators who require a graphical interface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phasmid"
-version = "0.1.5"
+version = "0.2.0"
 description = "Phasmid local-only coercion-aware storage prototype"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Why

The Simple Operator UI overhaul (#142) and its documentation pass (#143) were never recorded in `CHANGELOG.md` — searching it for `Simple Operator`, `#142`, `#143`, or `Expert` returns nothing. The largest user-facing change of this cycle was undocumented. Two smaller gaps surfaced alongside it, and the release needed a version decision.

## What changed

**CHANGELOG** — Records the Simple Operator TUI entry screen (with its key assignments), the reduced WebUI home, the three-step protect wizard, the two-step retrieve flow, the beginner-first guided workflows, and the #143 documentation work. `[Unreleased]` becomes `[0.2.0]`, with a note that 0.1.5 was version-bumped but never tagged or published, so its changes ship inside 0.2.0.

It also adds an upgrade notice for 0.1.4 users. In 0.1.4 the TUI `w` key bound the WebUI to `0.0.0.0`, which made the unauthenticated page HTML, the embedded mutation token, and `/video_feed` reachable from any attached network — along with the restricted-action confirmation phrases, which are public constants in this repository. 0.1.4 is the currently published Latest release, so this is called out rather than fixed quietly.

**README** — Adds a `## WebUI access` section. Since #144 the WebUI binds loopback by default, so a browser on an attached laptop cannot reach it until `PHASMID_WEBUI_EXPOSE_GADGET=1` is set. Nothing in the README said so, and the failure is silent: the WebUI starts fine and the browser simply cannot connect. The requirements table row is corrected to match.

**docs/TUI_OPERATOR_CONSOLE.md** — Records that entering Expert controls is one-way for the session: no key returns to the Simple Operator screen, and `q` there quits the application rather than going back.

## Version: 0.2.0, not 0.1.6

Two reasons this is more than a patch. The WebUI bind default change breaks existing USB gadget setups until the new opt-in is set, and the default TUI entry screen changed. Under the project's SemVer-style intent for documented interfaces, that is the minor lane.

## Verification

- `pytest tests/` — 611 passed, 5 skipped
- `ruff check src tests` — clean
- Confirmed the newly linked references exist: `PHASMID_WEBUI_EXPOSE_GADGET` in `docs/CONFIGURATION.md:23` and the resolution order in `docs/THREAT_MODEL.md:128`
- No remaining `0.1.5` references outside the changelog history

## Follow-ups not in this PR

- Tagging `v0.2.0` and publishing the GitHub release
- A GitHub Security Advisory for the 0.1.4 bind exposure — the changelog notice works as a draft
- The Expert one-way behaviour is documented here, not fixed; adding a return key to the Simple Operator screen is a separate UX change

🤖 Generated with [Claude Code](https://claude.com/claude-code)