### PR TITLE
docs(security): state supported versions concretely, prefer private reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ## [Unreleased]
 
+### Changed
+
+- `SECURITY.md` now states supported versions concretely rather than by
+  reference to "the latest release line", links the published advisories, and
+  names GitHub private vulnerability reporting as the preferred intake channel.
+  A Scope note points at the accepted residual risks in `docs/THREAT_MODEL.md`
+  and `docs/NON_CLAIMS.md` so documented limits are not re-reported as findings.
+
 ## [0.3.0] - 2026-07-26
 
 > **Upgrading from 0.2.0 changes how the WebUI is reached from another machine.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,17 +2,42 @@
 
 ## Supported Versions
 
-Phasmid is a prototype project. Security fixes are prioritized for the latest `main` branch and the latest tagged release line (if tags are present).
+Phasmid is a prototype project. Security fixes land on the latest `main` branch
+and the current release line. Fixes are not backported to earlier lines.
 
-Older snapshots may not receive backported fixes.
+| Version | Supported | Notes |
+| --- | --- | --- |
+| `0.3.x` | Yes | Current release line |
+| `0.2.0` | No | Affected by [GHSA-2gm6-2phc-wv26](https://github.com/01rabbit/Phasmid/security/advisories/GHSA-2gm6-2phc-wv26) — upgrade to 0.3.0 |
+| `0.1.4` | No | Affected by [GHSA-2gm6-2phc-wv26](https://github.com/01rabbit/Phasmid/security/advisories/GHSA-2gm6-2phc-wv26) — upgrade to 0.3.0 |
+| `< 0.1.4` | No | Unsupported prototype snapshots |
+
+0.1.5 was version-bumped but never tagged or published; its changes shipped in
+0.2.0.
+
+"Not supported" means no backported fix will be issued for that line. It does
+not mean the line is free of known issues; check the published advisories.
+
+## Published Advisories
+
+Resolved issues are published at
+[Security advisories](https://github.com/01rabbit/Phasmid/security/advisories).
+Each names the affected range and the release that fixes it.
 
 ## Reporting a Vulnerability
 
-Please report vulnerabilities privately to:
+**Preferred:** use GitHub's private vulnerability reporting —
+[Report a vulnerability](https://github.com/01rabbit/Phasmid/security/advisories/new).
+The report stays private, and it becomes the draft advisory directly, so no
+separate key exchange is needed.
+
+Alternatively, report privately by email:
 
 - Email: `appleseedj073@gmail.com`
 - PGP fingerprint: `3B25 D2EE 9084 FAF4 7525 86FA CA32 EA9B 9038 7A39`
 - Public key: `docs/keys/security@phasmid.asc`
+
+Please do not open a public issue for a suspected vulnerability.
 
 When possible, include:
 
@@ -20,6 +45,15 @@ When possible, include:
 - reproducible steps
 - impact assessment
 - whether exploitation requires local host compromise
+
+### Scope
+
+Phasmid documents several accepted residual risks — for example, a process
+running as the same user on the device can read WebUI access-token material.
+These are stated in [`docs/THREAT_MODEL.md`](docs/THREAT_MODEL.md) and in
+[`docs/NON_CLAIMS.md`](docs/NON_CLAIMS.md); they are known limits rather than
+unreported issues. Reports are still welcome if you believe a documented limit
+is stated incorrectly or is worse than described.
 
 ## Disclosure Process and Timeline
 


### PR DESCRIPTION
Follow-up tidy after GHSA-2gm6-2phc-wv26 and the 0.3.0 release. Documentation only.

## Supported versions were stated by reference, not by version

`SECURITY.md` said fixes go to "the latest `main` branch and the latest tagged release line". That does not answer the question a reader actually has now that the advisory names `>= 0.1.4, < 0.3.0` as affected: **is 0.2.x going to get a backported fix?**

The table now names the lines and marks the two the advisory covers, with a link to it. It also spells out that "not supported" means no backport will be issued — not that the line is free of known issues.

`0.1.5` is deliberately absent: it was version-bumped but never tagged or published (its changes shipped in 0.2.0), so listing it as a version would be misleading.

## Private vulnerability reporting is now the preferred intake

Private vulnerability reporting is enabled on the repository. It is named first because the report stays private and becomes the draft advisory directly, so a reporter does not need to exchange PGP keys with a single maintainer to get started. Email and PGP remain documented as the alternative.

Also adds an explicit "do not open a public issue" line, which the policy did not have.

## Scope note

Phasmid documents accepted residual risks — for example, a process running as the same user on the device can read WebUI access-token material. Without a pointer, those get re-reported as findings. The note sends readers to `docs/THREAT_MODEL.md` and `docs/NON_CLAIMS.md`, while explicitly inviting reports that a documented limit is stated incorrectly or is worse than described.

## Checks

Referenced paths verified to exist (`docs/keys/security@phasmid.asc`, `docs/THREAT_MODEL.md`, `docs/NON_CLAIMS.md`). `markdownlint-cli2` reports nothing for the changed files. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
