### PR TITLE
fix(tui): let Expert controls return to the Simple Operator screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ## [Unreleased]
 
+### Fixed
+
+- Expert controls are no longer a one-way trip. `escape` returns to the Simple
+  Operator screen, matching every other pushed screen in the TUI; previously the
+  only way out was `q`, which quits the application, so reaching Expert controls
+  ended the simple surface for the rest of the session. The protected storage
+  list is refreshed on return, so work done in Expert controls is reflected
+  immediately. `docs/TUI_OPERATOR_CONSOLE.md` documented the old behaviour as a
+  caveat and now documents the return path and the full Expert key table.
+
 ### Changed
 
 - `SECURITY.md` now states supported versions concretely rather than by

--- a/docs/TUI_OPERATOR_CONSOLE.md
+++ b/docs/TUI_OPERATOR_CONSOLE.md
@@ -190,12 +190,32 @@ actions: Close, Create, Inspect, Face management, Audit, Doctor, Settings,
 LUKS, and Help. Expert controls are for diagnostic and maintenance work, not
 the normal Protect/Open flow.
 
-> **Entering Expert controls is one-way for the rest of the session.** There is
-> no key that returns to the Simple Operator screen: `q` in Expert controls
-> quits the application rather than going back. Restart `phasmid` to get the
-> Simple Operator screen again. Plan work that must stay on the simple surface
-> — a scripted demonstration, or handing the device to a non-specialist —
-> before pressing `e`.
+Press `escape` to return to the Simple Operator screen. The protected storage
+list is refreshed on return, so anything created or closed in Expert controls is
+reflected immediately.
+
+`q` in Expert controls quits the application rather than going back, matching
+every other screen in the TUI. Use `escape` to go back.
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|---|---|
+| `escape` | Back to the Simple Operator screen |
+| `o` | Open Vessel |
+| `x` | Close Vessel |
+| `c` | Create Vessel |
+| `i` | Inspect Vessel |
+| `f` | Face management |
+| `g` | Guided Help |
+| `a` | Audit View |
+| `d` | Doctor View |
+| `s` | Settings |
+| `l` | LUKS panel |
+| `?` | Help |
+| `q` | Quit |
+| `r` | Refresh Vessel list (not shown in footer) |
+| `/` | About (not shown in footer) |
 
 ## WebUI Integration (Exposed Mode)
 

--- a/src/phasmid/tui/screens/home.py
+++ b/src/phasmid/tui/screens/home.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 class HomeScreen(OperatorScreen):
     BINDINGS = [
+        Binding("escape", "dismiss", "Back"),
         Binding("o", "open_vessel", "Open"),
         Binding("x", "close_vessel", "Close"),
         Binding("c", "create_vessel", "Create"),

--- a/src/phasmid/tui/screens/simple_home.py
+++ b/src/phasmid/tui/screens/simple_home.py
@@ -166,7 +166,8 @@ class SimpleHomeScreen(OperatorScreen):
         from .home import HomeScreen
 
         self.app.push_screen(
-            HomeScreen(initial_vessel_path=self._selected_path() or None)
+            HomeScreen(initial_vessel_path=self._selected_path() or None),
+            lambda _: self._refresh_table(),
         )
 
     def action_help(self) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1528,3 +1528,51 @@ def test_vessel_meta_defaults_name_from_path():
 
     v = VesselMeta(path=Path("/tmp/travel.vessel"))
     assert v.name == "travel.vessel"
+
+
+# ---------------------------------------------------------------------------
+# Simple Operator <-> Expert navigation
+# ---------------------------------------------------------------------------
+
+
+def test_expert_controls_have_back_binding():
+    """Expert controls must offer a way back, not only Quit.
+
+    Every other pushed screen binds `escape` to `dismiss`; the Expert console
+    was the one exception, which made entering it one-way for the session.
+    """
+    from phasmid.tui.screens.home import HomeScreen
+
+    bindings = {(b.key, b.action) for b in HomeScreen.BINDINGS}
+    assert ("escape", "dismiss") in bindings
+    # `q` still quits, matching the rest of the TUI.
+    assert ("q", "quit") in bindings
+
+
+def test_expert_entry_refreshes_simple_home_on_return(monkeypatch):
+    """Returning from Expert controls refreshes the protected storage list."""
+    from phasmid.tui.screens.home import HomeScreen
+    from phasmid.tui.screens.simple_home import SimpleHomeScreen
+
+    screen = SimpleHomeScreen.__new__(SimpleHomeScreen)
+    refreshed: list[bool] = []
+    monkeypatch.setattr(SimpleHomeScreen, "_selected_path", lambda self: "")
+    monkeypatch.setattr(
+        SimpleHomeScreen, "_refresh_table", lambda self: refreshed.append(True)
+    )
+
+    pushed: dict = {}
+
+    class FakeApp:
+        def push_screen(self, screen_obj, callback=None):
+            pushed["screen"] = screen_obj
+            pushed["callback"] = callback
+
+    monkeypatch.setattr(SimpleHomeScreen, "app", property(lambda self: FakeApp()))
+
+    screen.action_expert()
+
+    assert isinstance(pushed["screen"], HomeScreen)
+    assert pushed["callback"] is not None, "no return callback: list would go stale"
+    pushed["callback"](None)
+    assert refreshed == [True]


### PR DESCRIPTION
## Problem

Expert controls are pushed from the Simple Operator screen but bound no way back. `q` there calls `app.exit()`, so the only way out was quitting Phasmid entirely — reaching Expert controls ended the simple surface for the rest of the session.

Every other pushed screen in the TUI already binds `escape` to `dismiss` — `about`, `audit`, `doctor`, `context_profile_selector`, `create_vessel`, `face_manager`, `inspect_vessel`, `open_vessel`, `guided`. The Expert console was the single exception.

This is a trap for anyone who opens Expert controls to check one thing, and a real hazard when staying on the simple surface is the point: a scripted demonstration, or handing the device to a non-specialist. It was previously documented as a caveat in `docs/TUI_OPERATOR_CONSOLE.md`; this fixes the behaviour instead.

## Changes

`src/phasmid/tui/screens/home.py` — add `Binding("escape", "dismiss", "Back")`, following the existing convention. `q` still quits, consistent with the other screens.

`src/phasmid/tui/screens/simple_home.py` — push Expert controls with a callback that refreshes the protected storage list on return, so a Vessel created or closed in Expert controls is reflected immediately rather than leaving stale rows. Every other `push_screen` call on that screen already passes this callback.

`docs/TUI_OPERATOR_CONSOLE.md` — replace the caveat with the return path, and add the full Expert key table, which was missing.

## Tests

Two regression tests in `tests/test_tui.py`, in the existing direct-instantiation style:

- `test_expert_controls_have_back_binding` — asserts `escape` → `dismiss` is present and that `q` still quits.
- `test_expert_entry_refreshes_simple_home_on_return` — asserts Expert controls are pushed with a return callback, and that invoking it refreshes the storage list.

## Verification

- `pytest tests/` — 651 passed, 5 skipped
- `ruff check src tests` — clean
- `mypy src` — no issues in 90 source files
- `bandit -r src --severity-level medium --confidence-level high` — clean
- `black --check` on the three changed files: my added lines are already conformant

Scope note: `black --check` does report pre-existing violations elsewhere in these files (`home.py` around lines 246/318, `simple_home.py` around line 119, `test_tui.py` around lines 1213-1363). None are on lines this PR touches, so they are left alone rather than mixed into this diff. They survive because the CI formatting gate does not actually run — see below.

## Unrelated issue found while verifying

`[tool.black] include` in `pyproject.toml` is `'\\.pyi?$'`, which parses as a regex matching nothing. The CI steps `python -m black src tests scripts` and `python -m black --check src tests scripts` therefore print "No Python files are present to be formatted" and exit 0 — the formatting gate has been a no-op. Filed separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)