### PR TITLE
fix(build): make the CI formatting gate actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,8 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-dev.txt
 
-      - name: Run formatting with black
-        run: python -m black src tests scripts
-
-      - name: Verify formatting with black
-        run: python -m black --check src tests scripts
+      - name: Check formatting with black
+        run: python -m black --check --diff src tests scripts
 
       - name: Lint with ruff
         run: python -m ruff check src tests scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project follows SemVer-style release intent for documented interfaces.
   names GitHub private vulnerability reporting as the preferred intake channel.
   A Scope note points at the accepted residual risks in `docs/THREAT_MODEL.md`
   and `docs/NON_CLAIMS.md` so documented limits are not re-reported as findings.
+- The CI formatting gate now inspects files. `[tool.black] include` in
+  `pyproject.toml` was `'\\.pyi?$'`, a regex matching no real path, so every
+  black invocation reported "No Python files are present to be formatted" and
+  exited 0. The workflow also ran an in-place `black` before `black --check`,
+  which reformatted whatever the check would have caught, so the check could
+  not fail even once the pattern was repaired. The pattern is corrected, the
+  mutating step is replaced by a single `black --check --diff`, and the 16
+  files that drifted behind the dead gate are reformatted.
 
 ## [0.3.0] - 2026-07-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ ignore = [
 [tool.black]
 line-length = 88
 target-version = ['py310']
-include = '\\.pyi?$'
+include = '\.pyi?$'
 exclude = '''
 /(
     \.eggs

--- a/scripts/pi_zero2w/luks_eval.py
+++ b/scripts/pi_zero2w/luks_eval.py
@@ -139,9 +139,10 @@ def recommend_iter(
     if not open_ok:
         return None, "no candidate achieved successful open"
     closest = min(open_ok, key=lambda m: abs(float(m["luks_format_ms"]) - 4000.0))
-    return int(
-        closest["iter_time_ms"]
-    ), "closest format time to upper acceptance bound with successful open"
+    return (
+        int(closest["iter_time_ms"]),
+        "closest format time to upper acceptance bound with successful open",
+    )
 
 
 def evaluate_status(
@@ -254,9 +255,9 @@ def main() -> int:
         "device_tier": tier,
         "iter_time_ms_requested": args.requested_iter,
         "recommended_iter_time_ms": recommended_iter,
-        "selected_iter_for_evaluation_ms": int(recommended_iter)
-        if recommended_iter is not None
-        else None,
+        "selected_iter_for_evaluation_ms": (
+            int(recommended_iter) if recommended_iter is not None else None
+        ),
         "recommendation_basis": basis,
         "cipher": args.cipher,
         "key_size": args.key_size,
@@ -292,36 +293,36 @@ def main() -> int:
             ),
             "requested_iter": {
                 "iter_time_ms": int(requested["iter_time_ms"]) if requested else None,
-                "luks_format_in_range": bool(requested["luks_format_in_range"])
-                if requested
-                else False,
-                "luks_open_in_range": bool(requested["luks_open_in_range"])
-                if requested
-                else False,
-                "luks_format_ok": bool(requested["luks_format_ok"])
-                if requested
-                else False,
+                "luks_format_in_range": (
+                    bool(requested["luks_format_in_range"]) if requested else False
+                ),
+                "luks_open_in_range": (
+                    bool(requested["luks_open_in_range"]) if requested else False
+                ),
+                "luks_format_ok": (
+                    bool(requested["luks_format_ok"]) if requested else False
+                ),
                 "luks_open_ok": bool(requested["luks_open_ok"]) if requested else False,
             },
             "selected_iter": {
                 "iter_time_ms": int(selected["iter_time_ms"]) if selected else None,
-                "luks_format_in_range": bool(selected["luks_format_in_range"])
-                if selected
-                else False,
-                "luks_open_in_range": bool(selected["luks_open_in_range"])
-                if selected
-                else False,
-                "luks_format_ok": bool(selected["luks_format_ok"])
-                if selected
-                else False,
+                "luks_format_in_range": (
+                    bool(selected["luks_format_in_range"]) if selected else False
+                ),
+                "luks_open_in_range": (
+                    bool(selected["luks_open_in_range"]) if selected else False
+                ),
+                "luks_format_ok": (
+                    bool(selected["luks_format_ok"]) if selected else False
+                ),
                 "luks_open_ok": bool(selected["luks_open_ok"]) if selected else False,
             },
-            "luks_format_in_range": bool(requested["luks_format_in_range"])
-            if requested
-            else False,
-            "luks_open_in_range": bool(requested["luks_open_in_range"])
-            if requested
-            else False,
+            "luks_format_in_range": (
+                bool(requested["luks_format_in_range"]) if requested else False
+            ),
+            "luks_open_in_range": (
+                bool(requested["luks_open_in_range"]) if requested else False
+            ),
             "aes_required_met": aes_status in {"confirmed", "inferred"},
             "dm_crypt_required_met": args.dm_crypt_loadable == "true",
         },

--- a/src/phasmid/ai_gate.py
+++ b/src/phasmid/ai_gate.py
@@ -115,7 +115,9 @@ class AIGate:
             raise ValueError("unsupported local entry")
 
     def _reference_state_from_image(self, image: Any) -> dict[str, Any] | None:
-        return cast(dict[str, Any] | None, self.matcher.reference_state_from_image(image))
+        return cast(
+            dict[str, Any] | None, self.matcher.reference_state_from_image(image)
+        )
 
     def _to_gray(self, image: Any) -> Any:
         return self.matcher.to_gray(image)
@@ -251,9 +253,7 @@ class AIGate:
         self.object_detected = True
         self.match_states = {mode: mode == matched_mode for mode in self.MODES}
 
-    def _update_match_result_from_gate_results(
-        self, results: dict[str, Any]
-    ) -> None:
+    def _update_match_result_from_gate_results(self, results: dict[str, Any]) -> None:
         if any(result.state == "ambiguous" for result in results.values()):
             self.latest_gate_results = results
             self.last_match_mode = self.MATCH_AMBIGUOUS

--- a/src/phasmid/cli.py
+++ b/src/phasmid/cli.py
@@ -310,9 +310,7 @@ def _print_operation_report(report):
     status_style = (
         "green"
         if report["status"] in ok_statuses
-        else "yellow"
-        if report["status"] == "attention"
-        else "red"
+        else "yellow" if report["status"] == "attention" else "red"
     )
     console.print(
         Panel(
@@ -516,7 +514,9 @@ def _build_tui_parser() -> argparse.ArgumentParser:
         "destroy-vessel", help="Destroy the entire Vessel explicitly"
     )
     emergency_vessel_p.add_argument("vessel", help="Path to Vessel file")
-    emergency_vessel_p.add_argument("--face", default="face_a", help="Authorizing face id")
+    emergency_vessel_p.add_argument(
+        "--face", default="face_a", help="Authorizing face id"
+    )
     emergency_vessel_p.add_argument("--emergency-passphrase-file")
     emergency_vessel_p.add_argument("--confirm", required=True)
     _add_object_source_flags(emergency_vessel_p)
@@ -554,11 +554,11 @@ def _build_tui_parser() -> argparse.ArgumentParser:
     plausibility_clear_p.add_argument("--restricted-passphrase-file")
 
     store_p = subparsers.add_parser("store", help="Store a local file in a Vessel")
-    store_p.add_argument("vessel", nargs="?", default="vault.bin", help="Path to Vessel file")
-    store_p.add_argument("--entry", choices=["a", "b"], default="a")
     store_p.add_argument(
-        "--" + "prof" + "ile", choices=["a", "b"], dest="legacy_entry"
+        "vessel", nargs="?", default="vault.bin", help="Path to Vessel file"
     )
+    store_p.add_argument("--entry", choices=["a", "b"], default="a")
+    store_p.add_argument("--" + "prof" + "ile", choices=["a", "b"], dest="legacy_entry")
     store_p.add_argument("--mode", dest="legacy_entry_mode")
     store_p.add_argument("--input", "--file", dest="file")
     store_p.add_argument(
@@ -595,7 +595,13 @@ def _build_tui_parser() -> argparse.ArgumentParser:
 
 
 def _add_legacy_subparser(subparsers) -> None:
-    for action in ["init", "brick", "verify-state", "verify-audit-log", "export-redacted-log"]:
+    for action in [
+        "init",
+        "brick",
+        "verify-state",
+        "verify-audit-log",
+        "export-redacted-log",
+    ]:
         p = subparsers.add_parser(action, help=f"Legacy: {action}")
         if action == "export-redacted-log":
             p.add_argument("--out")
@@ -880,10 +886,10 @@ def _run_emergency_command(args) -> int:
 def _print_plausibility_result(result) -> None:
     summary = object.__getattribute__(result, "pro" + "file")
     type_distribution = summary.file_type_distribution
-    distribution = ", ".join(
-        f"{ext}:{count}"
-        for ext, count in sorted(type_distribution.items())
-    ) or "-"
+    distribution = (
+        ", ".join(f"{ext}:{count}" for ext, count in sorted(type_distribution.items()))
+        or "-"
+    )
     info(
         "Plausibility summary: "
         f"files={summary.dummy_file_count}, "
@@ -1021,12 +1027,16 @@ def _run_file_add_command(args) -> int:
                 no_object_binding=getattr(args, "no_object_binding", False),
                 emergency_password=emergency_pw,
             )
-        except (FileNotFoundError, PermissionError, RuntimeError, ValueError, OSError) as exc:
+        except (
+            FileNotFoundError,
+            PermissionError,
+            RuntimeError,
+            ValueError,
+            OSError,
+        ) as exc:
             error(str(exc))
             return 1
-        success(
-            f"File added to selected face: [bold]{result.input_path.name}[/bold]"
-        )
+        success(f"File added to selected face: [bold]{result.input_path.name}[/bold]")
         return 0
     finally:
         panic_monitor.stop()
@@ -1172,12 +1182,16 @@ def _run_emergency_destroy_face_command(args) -> int:
                 camera_object=getattr(args, "camera_object", False),
                 confirmation=args.confirm,
             )
-        except (FileNotFoundError, PermissionError, RuntimeError, ValueError, OSError) as exc:
+        except (
+            FileNotFoundError,
+            PermissionError,
+            RuntimeError,
+            ValueError,
+            OSError,
+        ) as exc:
             error(str(exc))
             return 1
-        success(
-            f"Face destroyed explicitly: [bold]{result.face_id}[/bold]"
-        )
+        success(f"Face destroyed explicitly: [bold]{result.face_id}[/bold]")
         return 0
     finally:
         panic_monitor.stop()
@@ -1208,12 +1222,16 @@ def _run_emergency_destroy_vessel_command(args) -> int:
                 camera_object=getattr(args, "camera_object", False),
                 confirmation=args.confirm,
             )
-        except (FileNotFoundError, PermissionError, RuntimeError, ValueError, OSError) as exc:
+        except (
+            FileNotFoundError,
+            PermissionError,
+            RuntimeError,
+            ValueError,
+            OSError,
+        ) as exc:
             error(str(exc))
             return 1
-        success(
-            f"Vessel destroyed explicitly: [bold]{result.vessel_path}[/bold]"
-        )
+        success(f"Vessel destroyed explicitly: [bold]{result.vessel_path}[/bold]")
         return 0
     finally:
         panic_monitor.stop()
@@ -1353,7 +1371,9 @@ def _run_retrieve_command(args) -> int:
         console.print()
         console.print(Rule("Object Verification", style="dim cyan"))
         if getattr(args, "passphrase_file", None):
-            info("Position the bound object in view. Verification will begin automatically.")
+            info(
+                "Position the bound object in view. Verification will begin automatically."
+            )
             user_gesture_seq = svc.collect_auth_sequence()
         else:
             user_gesture_seq = _collect_auth_sequence()

--- a/src/phasmid/services/object_binding_service.py
+++ b/src/phasmid/services/object_binding_service.py
@@ -84,9 +84,7 @@ class ObjectBindingService:
         ).encode("utf-8")
         fingerprint_id = hashlib.sha256(fingerprint_bytes).hexdigest()
         threshold = (
-            self._CAMERA_THRESHOLD
-            if source_type == "camera"
-            else self._IMAGE_THRESHOLD
+            self._CAMERA_THRESHOLD if source_type == "camera" else self._IMAGE_THRESHOLD
         )
         return ObjectBindingProfile(
             source_type=source_type,
@@ -229,9 +227,7 @@ class ObjectBindingService:
         )
         return 1.0 - (mismatches / float(len(left)))
 
-    def _histogram_similarity(
-        self, left: list[float], right: list[float]
-    ) -> float:
+    def _histogram_similarity(self, left: list[float], right: list[float]) -> float:
         if not left or not right or len(left) != len(right):
             return 0.0
         return float(sum(min(a, b) for a, b in zip(left, right, strict=True)))

--- a/src/phasmid/services/vessel_service.py
+++ b/src/phasmid/services/vessel_service.py
@@ -135,8 +135,12 @@ def _aggregate_dummy_profile(
     level_rank = {"LOW": 0, "MEDIUM": 1, "HIGH": 2}
     for face in faces:
         profile = _normalize_dummy_profile_record(face.get("dummy_profile", {}))
-        aggregate["dummy_file_count"] = _int_value(aggregate["dummy_file_count"]) + _int_value(profile["dummy_file_count"])
-        aggregate["dummy_total_size"] = _int_value(aggregate["dummy_total_size"]) + _int_value(profile["dummy_total_size"])
+        aggregate["dummy_file_count"] = _int_value(
+            aggregate["dummy_file_count"]
+        ) + _int_value(profile["dummy_file_count"])
+        aggregate["dummy_total_size"] = _int_value(
+            aggregate["dummy_total_size"]
+        ) + _int_value(profile["dummy_total_size"])
         total_ratio += _float_value(profile["occupancy_ratio"])
         highest_score = max(highest_score, _int_value(profile["plausibility_score"]))
         level = str(profile["plausibility_level"]).upper()
@@ -391,7 +395,9 @@ def update_face_access(
 ) -> dict[str, object]:
     record = _update_registry_record(path)
     faces = _normalize_faces(record.get("faces", []))
-    face = next((item for item in faces if str(item.get("face_id", "")) == face_id), None)
+    face = next(
+        (item for item in faces if str(item.get("face_id", "")) == face_id), None
+    )
     if face is None:
         raise ValueError(f"unsupported face id: {face_id}")
 
@@ -424,9 +430,7 @@ def update_face_access(
         return record
     if closed:
         face["status"] = (
-            "occupied"
-            if _int_value(face.get("file_count", 0)) > 0
-            else "available"
+            "occupied" if _int_value(face.get("file_count", 0)) > 0 else "available"
         )
         record = _update_registry_record(
             path,

--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -210,9 +210,13 @@ class VesselWorkflowService:
         if not vessel_path.exists():
             raise FileNotFoundError(f"vessel file not found: {vessel_path}")
         resolved_face_id = self.resolve_face_id(face_id)
-        default_label = "Disclosure Face 1" if resolved_face_id == "face_a" else "Disclosure Face 2"
+        default_label = (
+            "Disclosure Face 1" if resolved_face_id == "face_a" else "Disclosure Face 2"
+        )
         selector = "a" if resolved_face_id == "face_a" else "b"
-        self._vessels.create_face(vessel_path, resolved_face_id, label or default_label, selector)
+        self._vessels.create_face(
+            vessel_path, resolved_face_id, label or default_label, selector
+        )
         vessel = self._get_meta(vessel_path)
         face = self._get_face(vessel, resolved_face_id)
         return FaceResult(vessel=vessel, face=face)
@@ -410,7 +414,9 @@ class VesselWorkflowService:
             if isinstance(candidate, dict):
                 self._set_face_binding_record(vessel_path, face_id, candidate)
             else:
-                self._set_face_binding_record(vessel_path, face_id, candidate.to_record())
+                self._set_face_binding_record(
+                    vessel_path, face_id, candidate.to_record()
+                )
             return cast(
                 list[str],
                 self._access_cue.sequence_for_mode(self.resolve_mode(selector)),
@@ -558,9 +564,18 @@ class VesselWorkflowService:
             return []
 
         specs = [
-            ("field_notes_01.txt", self._text_payload("Field Notes", max(256, target_bytes // 10))),
-            ("briefing_01.md", self._text_payload("# Briefing", max(320, target_bytes // 12))),
-            ("report_01.pdf", self._pdf_payload("Operational Report", max(768, target_bytes // 8))),
+            (
+                "field_notes_01.txt",
+                self._text_payload("Field Notes", max(256, target_bytes // 10)),
+            ),
+            (
+                "briefing_01.md",
+                self._text_payload("# Briefing", max(320, target_bytes // 12)),
+            ),
+            (
+                "report_01.pdf",
+                self._pdf_payload("Operational Report", max(768, target_bytes // 8)),
+            ),
             ("logsheet_01.csv", self._csv_payload(max(256, target_bytes // 12))),
             ("site_photo_01.jpg", self._jpg_payload(max(512, target_bytes // 10))),
         ]
@@ -676,7 +691,9 @@ class VesselWorkflowService:
         if profile.plausibility_level == "HIGH":
             return "Baseline profile is credible. Periodically refresh file mix."
         if profile.plausibility_level == "MEDIUM":
-            return "Add more size variation or increase occupancy for a stronger baseline."
+            return (
+                "Add more size variation or increase occupancy for a stronger baseline."
+            )
         return "Generate a broader local baseline before field use."
 
     def _read_face_namespace(
@@ -1042,7 +1059,10 @@ class VesselWorkflowService:
 
         for name in list(files):
             item = files.get(name)
-            if isinstance(item, dict) and str(item.get("origin", "")) == _GENERATED_PLAUSIBILITY_ORIGIN:
+            if (
+                isinstance(item, dict)
+                and str(item.get("origin", "")) == _GENERATED_PLAUSIBILITY_ORIGIN
+            ):
                 del files[name]
 
         vessel_size = vessel.stat().st_size
@@ -1069,7 +1089,9 @@ class VesselWorkflowService:
             and str(item.get("origin", "")) == _GENERATED_PLAUSIBILITY_ORIGIN
             for item in files.values()
         ):
-            raise ValueError("target size does not fit within the selected face capacity")
+            raise ValueError(
+                "target size does not fit within the selected face capacity"
+            )
 
         self._write_face_namespace(
             vessel,
@@ -1091,7 +1113,9 @@ class VesselWorkflowService:
     ) -> DummyProfileResult:
         vessel = Path(vessel_path).expanduser().resolve()
         if cue_sequence is None:
-            cue_sequence = self._access_cue.sequence_for_mode(self.resolve_mode(selector))
+            cue_sequence = self._access_cue.sequence_for_mode(
+                self.resolve_mode(selector)
+            )
         cue_sequence = cast(list[str], cue_sequence)
         namespace, _filename = self._read_face_namespace(
             vessel, open_passphrase, selector, cue_sequence
@@ -1101,7 +1125,10 @@ class VesselWorkflowService:
             raise ValueError("face namespace is invalid")
         for name in list(files):
             item = files.get(name)
-            if isinstance(item, dict) and str(item.get("origin", "")) == _GENERATED_PLAUSIBILITY_ORIGIN:
+            if (
+                isinstance(item, dict)
+                and str(item.get("origin", "")) == _GENERATED_PLAUSIBILITY_ORIGIN
+            ):
                 del files[name]
         self._write_face_namespace(
             vessel,
@@ -1134,12 +1161,12 @@ class VesselWorkflowService:
             object_image_path=object_image_path,
             camera_object=camera_object,
         )
-        if not self._verify_face_emergency_password(vessel, face_id, emergency_password):
+        if not self._verify_face_emergency_password(
+            vessel, face_id, emergency_password
+        ):
             raise ValueError("emergency password mismatch")
         mode = self.resolve_mode(selector)
-        vault = PhasmidVault(
-            str(vessel), size_mb=vessel.stat().st_size / (1024 * 1024)
-        )
+        vault = PhasmidVault(str(vessel), size_mb=vessel.stat().st_size / (1024 * 1024))
         vault.purge_mode(mode)
         self._vessels.touch_face(
             vessel,
@@ -1188,11 +1215,11 @@ class VesselWorkflowService:
             object_image_path=object_image_path,
             camera_object=camera_object,
         )
-        if not self._verify_face_emergency_password(vessel, face_id, emergency_password):
+        if not self._verify_face_emergency_password(
+            vessel, face_id, emergency_password
+        ):
             raise ValueError("emergency password mismatch")
-        vault = PhasmidVault(
-            str(vessel), size_mb=vessel.stat().st_size / (1024 * 1024)
-        )
+        vault = PhasmidVault(str(vessel), size_mb=vessel.stat().st_size / (1024 * 1024))
         vault.silent_brick()
         self._vessels.unregister(vessel)
         return EmergencyDestroyResult(
@@ -1259,7 +1286,9 @@ class VesselWorkflowService:
         namespace = None
         accessed_selector = None
         for candidate in candidate_selectors:
-            if not self._credentials_initialized(vessel, self.resolve_face_id(str(candidate))):
+            if not self._credentials_initialized(
+                vessel, self.resolve_face_id(str(candidate))
+            ):
                 continue
             try:
                 active_cue_sequence = cue_sequence
@@ -1300,7 +1329,12 @@ class VesselWorkflowService:
                 accessed_selector = str(candidate)
                 break
             except ValueError:
-                if selector is not None or object_image_path or camera_object or no_object_binding:
+                if (
+                    selector is not None
+                    or object_image_path
+                    or camera_object
+                    or no_object_binding
+                ):
                     raise
                 continue
 

--- a/src/phasmid/tui/screens/face_manager.py
+++ b/src/phasmid/tui/screens/face_manager.py
@@ -88,7 +88,9 @@ class FaceManagerScreen(OperatorScreen):
 
     def on_mount(self) -> None:
         table = self.query_one(DataTable)
-        table.add_columns("Face", "Label", "Status", "Files", "Occupancy", "Last Accessed")
+        table.add_columns(
+            "Face", "Label", "Status", "Files", "Occupancy", "Last Accessed"
+        )
         self._refresh_table()
 
     def _refresh_table(self) -> None:
@@ -118,15 +120,20 @@ class FaceManagerScreen(OperatorScreen):
             summary.update("No Vessel selected.")
             return
         face_id = self._selected_face_id()
-        face = next((item for item in self._vessel.faces if item.face_id == face_id), None)
+        face = next(
+            (item for item in self._vessel.faces if item.face_id == face_id), None
+        )
         if face is None:
             summary.update("No Face metadata recorded.")
             return
         profile = face.dummy_profile
-        distribution = ", ".join(
-            f"{ext}:{count}"
-            for ext, count in sorted(profile.file_type_distribution.items())
-        ) or "-"
+        distribution = (
+            ", ".join(
+                f"{ext}:{count}"
+                for ext, count in sorted(profile.file_type_distribution.items())
+            )
+            or "-"
+        )
         summary.update(
             "Plausibility Profile\n"
             f"Level: {profile.plausibility_level}  "

--- a/src/phasmid/tui/screens/guided.py
+++ b/src/phasmid/tui/screens/guided.py
@@ -19,7 +19,9 @@ def _quick_start_workflows() -> list[GuidedWorkflow]:
                 GuidedStep(2, "Choose the file you need to protect."),
                 GuidedStep(3, "Set the access password."),
                 GuidedStep(4, "Present and bind the physical access object."),
-                GuidedStep(5, "Confirm the result and close the storage when finished."),
+                GuidedStep(
+                    5, "Confirm the result and close the storage when finished."
+                ),
             ],
         ),
         GuidedWorkflow(
@@ -28,7 +30,9 @@ def _quick_start_workflows() -> list[GuidedWorkflow]:
             description="Normal-use steps for opening content that was protected earlier.",
             steps=[
                 GuidedStep(1, "Select the protected storage you need."),
-                GuidedStep(2, "Present the physical access object and wait for a stable match."),
+                GuidedStep(
+                    2, "Present the physical access object and wait for a stable match."
+                ),
                 GuidedStep(3, "Enter the access password."),
                 GuidedStep(4, "Retrieve only the file you need."),
                 GuidedStep(5, "Close the storage when finished."),

--- a/src/phasmid/tui/screens/home.py
+++ b/src/phasmid/tui/screens/home.py
@@ -247,7 +247,8 @@ class HomeScreen(OperatorScreen):
         def _on_confirm(result: bool | None) -> None:
             if result:
                 self.app.push_screen(
-                    OpenVesselScreen(vessel_path=path), lambda _result: self._refresh_vessels()
+                    OpenVesselScreen(vessel_path=path),
+                    lambda _result: self._refresh_vessels(),
                 )
 
         self.app.push_screen(
@@ -319,7 +320,9 @@ class HomeScreen(OperatorScreen):
 
         table = self.query_one(VesselTable)
         vessel = table.selected_vessel
-        self.app.push_screen(FaceManagerScreen(vessel=vessel), lambda _result: self._refresh_vessels())
+        self.app.push_screen(
+            FaceManagerScreen(vessel=vessel), lambda _result: self._refresh_vessels()
+        )
 
     def action_guided(self) -> None:
         from .guided import GuidedScreen

--- a/src/phasmid/tui/screens/open_vessel.py
+++ b/src/phasmid/tui/screens/open_vessel.py
@@ -138,7 +138,9 @@ class OpenVesselScreen(OperatorScreen):
                 )
             elif operation == "list":
                 if not passphrase:
-                    self.app.notify("Passphrase is required for listing.", severity="error")
+                    self.app.notify(
+                        "Passphrase is required for listing.", severity="error"
+                    )
                     return
                 listing = self._workflow.list_files(
                     path,
@@ -146,7 +148,9 @@ class OpenVesselScreen(OperatorScreen):
                     selector=str(face),
                     use_attempt_limiter=True,
                 )
-                names = ", ".join(file.name for file in listing.files) or "No files stored."
+                names = (
+                    ", ".join(file.name for file in listing.files) or "No files stored."
+                )
                 self.app.notify(
                     names,
                     title="Open Vessel",
@@ -155,7 +159,9 @@ class OpenVesselScreen(OperatorScreen):
                 )
             else:
                 if not passphrase:
-                    self.app.notify("Passphrase is required for recovery.", severity="error")
+                    self.app.notify(
+                        "Passphrase is required for recovery.", severity="error"
+                    )
                     return
                 if operation == "retrieve" and not output_file:
                     self.app.notify(

--- a/src/phasmid/tui/screens/simple_home.py
+++ b/src/phasmid/tui/screens/simple_home.py
@@ -121,7 +121,10 @@ class SimpleHomeScreen(OperatorScreen):
                 vessel.size_human,
                 str(file_count),
             )
-            if self._initial_vessel_path and str(vessel.path) == self._initial_vessel_path:
+            if (
+                self._initial_vessel_path
+                and str(vessel.path) == self._initial_vessel_path
+            ):
                 initial_row = index
         if initial_row is not None:
             table.move_cursor(row=initial_row)

--- a/tests/scenarios/known_magics.py
+++ b/tests/scenarios/known_magics.py
@@ -74,6 +74,6 @@ KNOWN_SIGNATURES: list[tuple[str, int, bytes]] = [
     ("JSON object", 0, b"{"),
 ]
 
-assert len(KNOWN_SIGNATURES) >= 20, (
-    f"known_magics.py must define at least 20 signatures, got {len(KNOWN_SIGNATURES)}"
-)
+assert (
+    len(KNOWN_SIGNATURES) >= 20
+), f"known_magics.py must define at least 20 signatures, got {len(KNOWN_SIGNATURES)}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,9 +172,15 @@ class CLITests(unittest.TestCase):
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
-            unittest.mock.patch.object(sys, "argv", ["phasmid", "open", "travel.vessel", "--no-tui", "--face", "face_b"]),
+            unittest.mock.patch.object(
+                sys,
+                "argv",
+                ["phasmid", "open", "travel.vessel", "--no-tui", "--face", "face_b"],
+            ),
             unittest.mock.patch.object(
                 cli, "VesselWorkflowService", return_value=FakeWorkflowService()
             ),
@@ -192,15 +198,21 @@ class CLITests(unittest.TestCase):
         class FakeWorkflowService:
             def close_vessel(self, path):
                 events.append(("close", path))
-                return type("Result", (), {"vessel": type("Vessel", (), {"path": path})()})()
+                return type(
+                    "Result", (), {"vessel": type("Vessel", (), {"path": path})()}
+                )()
 
         with (
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
-            unittest.mock.patch.object(sys, "argv", ["phasmid", "close", "travel.vessel"]),
+            unittest.mock.patch.object(
+                sys, "argv", ["phasmid", "close", "travel.vessel"]
+            ),
             unittest.mock.patch.object(
                 cli, "VesselWorkflowService", return_value=FakeWorkflowService()
             ),
@@ -231,12 +243,23 @@ class CLITests(unittest.TestCase):
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
             unittest.mock.patch.object(
                 sys,
                 "argv",
-                ["phasmid", "face", "create", "travel.vessel", "--face", "face_b", "--label", "travel"],
+                [
+                    "phasmid",
+                    "face",
+                    "create",
+                    "travel.vessel",
+                    "--face",
+                    "face_b",
+                    "--label",
+                    "travel",
+                ],
             ),
             unittest.mock.patch.object(
                 cli, "VesselWorkflowService", return_value=FakeWorkflowService()
@@ -282,12 +305,21 @@ class CLITests(unittest.TestCase):
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
             unittest.mock.patch.object(
                 sys,
                 "argv",
-                ["phasmid", command_name, "inspect", "travel.vessel", "--face", "face_b"],
+                [
+                    "phasmid",
+                    command_name,
+                    "inspect",
+                    "travel.vessel",
+                    "--face",
+                    "face_b",
+                ],
             ),
             unittest.mock.patch.object(
                 cli, "VesselWorkflowService", return_value=FakeWorkflowService()
@@ -338,20 +370,39 @@ class CLITests(unittest.TestCase):
                     )
                 )
                 return type(
-                    "Result", (), {"input_path": Path(input_path), "vessel_path": Path(vessel)}
+                    "Result",
+                    (),
+                    {"input_path": Path(input_path), "vessel_path": Path(vessel)},
                 )()
 
         with (
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
             unittest.mock.patch.object(
                 cli, "_resolve_access_password", return_value="pw"
             ),
-            unittest.mock.patch.object(sys, "argv", ["phasmid", "file", "add", "travel.vessel", "--face", "face_b", "--input", "note.txt"]),
-            unittest.mock.patch.object(cli, "VesselWorkflowService", return_value=FakeWorkflowService()),
+            unittest.mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "phasmid",
+                    "file",
+                    "add",
+                    "travel.vessel",
+                    "--face",
+                    "face_b",
+                    "--input",
+                    "note.txt",
+                ],
+            ),
+            unittest.mock.patch.object(
+                cli, "VesselWorkflowService", return_value=FakeWorkflowService()
+            ),
             unittest.mock.patch.object(cli.gate, "start"),
             unittest.mock.patch.object(cli.gate, "close"),
             unittest.mock.patch.object(cli.EmergencyDaemon, "start"),
@@ -360,7 +411,20 @@ class CLITests(unittest.TestCase):
         ):
             cli.main()
 
-        self.assertIn(("file_add", "travel.vessel", "note.txt", "pw", None, "face_b", True, None, None), events)
+        self.assertIn(
+            (
+                "file_add",
+                "travel.vessel",
+                "note.txt",
+                "pw",
+                None,
+                "face_b",
+                True,
+                None,
+                None,
+            ),
+            events,
+        )
         self.assertIn("File added to selected face", output.getvalue())
 
     def test_cli_file_add_with_object_image_skips_camera(self):
@@ -399,14 +463,18 @@ class CLITests(unittest.TestCase):
                     )
                 )
                 return type(
-                    "Result", (), {"input_path": Path(input_path), "vessel_path": Path(vessel)}
+                    "Result",
+                    (),
+                    {"input_path": Path(input_path), "vessel_path": Path(vessel)},
                 )()
 
         with (
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
             unittest.mock.patch.object(
                 cli, "_resolve_access_password", return_value="pw"
@@ -486,17 +554,23 @@ class CLITests(unittest.TestCase):
                     )
                 )
                 return type(
-                    "Result", (), {"input_path": Path(input_path), "vessel_path": Path(vessel)}
+                    "Result",
+                    (),
+                    {"input_path": Path(input_path), "vessel_path": Path(vessel)},
                 )()
 
         with (
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
             unittest.mock.patch.object(
-                cli, "_resolve_first_add_passwords", return_value=("access", "emergency")
+                cli,
+                "_resolve_first_add_passwords",
+                return_value=("access", "emergency"),
             ),
             unittest.mock.patch.object(
                 sys,
@@ -560,7 +634,9 @@ class CLITests(unittest.TestCase):
             unittest.mock.patch.object(
                 cli, "apply_process_hardening", return_value=None
             ),
-            unittest.mock.patch.object(cli, "require_volatile_state", return_value=None),
+            unittest.mock.patch.object(
+                cli, "require_volatile_state", return_value=None
+            ),
             unittest.mock.patch.object(cli, "_run_startup_checks", return_value=True),
             unittest.mock.patch.object(
                 cli, "_resolve_required_emergency_password", return_value="burn"
@@ -594,7 +670,14 @@ class CLITests(unittest.TestCase):
 
         gate_start.assert_not_called()
         self.assertIn(
-            ("destroy_face", "travel.vessel", "burn", "face_b", "object.png", "DESTROY FACE"),
+            (
+                "destroy_face",
+                "travel.vessel",
+                "burn",
+                "face_b",
+                "object.png",
+                "DESTROY FACE",
+            ),
             events,
         )
         self.assertIn("Face destroyed explicitly", output.getvalue())

--- a/tests/test_container_format_constants.py
+++ b/tests/test_container_format_constants.py
@@ -49,7 +49,9 @@ class ContainerFormatConstantsTests(unittest.TestCase):
     def test_container_layout_capacity_uses_record_overhead(self):
         with tempfile.NamedTemporaryFile(delete=False) as handle:
             container_path = handle.name
-        self.addCleanup(lambda: os.path.exists(container_path) and os.unlink(container_path))
+        self.addCleanup(
+            lambda: os.path.exists(container_path) and os.unlink(container_path)
+        )
 
         container_size = 4096
         layout = ContainerLayout(container_path, container_size)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1215,7 +1215,9 @@ def test_create_vessel_screen_uses_shared_workflow(monkeypatch):
             )
         ),
     )
-    monkeypatch.setattr(screen, "dismiss", lambda: created.setdefault("dismissed", True))
+    monkeypatch.setattr(
+        screen, "dismiss", lambda: created.setdefault("dismissed", True)
+    )
     monkeypatch.setattr(
         screen,
         "query_one",
@@ -1248,7 +1250,12 @@ def test_open_vessel_screen_marks_vessel_open(monkeypatch):
             events.append(("open", path, face_id))
 
         def retrieve_file(
-            self, path, passphrase, output_path=None, selector=None, use_attempt_limiter=False
+            self,
+            path,
+            passphrase,
+            output_path=None,
+            selector=None,
+            use_attempt_limiter=False,
         ):
             events.append(("retrieve", path, passphrase, output_path, selector))
             return SimpleNamespace(bytes_retrieved=4, output_path=Path("/tmp/out.bin"))
@@ -1296,7 +1303,9 @@ def test_face_manager_screen_uses_shared_workflow(monkeypatch):
 
     from phasmid.tui.screens.face_manager import FaceManagerScreen
 
-    vessel = SimpleNamespace(path=Path("/tmp/travel.vessel"), name="travel.vessel", faces=[])
+    vessel = SimpleNamespace(
+        path=Path("/tmp/travel.vessel"), name="travel.vessel", faces=[]
+    )
     screen = FaceManagerScreen(vessel=vessel)
     events = []
 
@@ -1356,20 +1365,29 @@ def test_face_manager_screen_uses_shared_workflow(monkeypatch):
         ),
     )
 
-    table = SimpleNamespace(clear=lambda: events.append(("clear",)), add_row=lambda *args: events.append(("row", args)))
+    table = SimpleNamespace(
+        clear=lambda: events.append(("clear",)),
+        add_row=lambda *args: events.append(("row", args)),
+    )
     monkeypatch.setattr(
         screen,
         "query_one",
         lambda selector, _type=None: {
             "#face-id": SimpleNamespace(value="face_b"),
             "#new-label": SimpleNamespace(value="travel"),
-            "#plausibility-summary": SimpleNamespace(update=lambda value: events.append(("summary", value))),
+            "#plausibility-summary": SimpleNamespace(
+                update=lambda value: events.append(("summary", value))
+            ),
             DataTable: table,
         }[selector],
     )
 
-    screen.on_button_pressed(SimpleNamespace(button=SimpleNamespace(id="add-label-btn")))
-    screen.on_button_pressed(SimpleNamespace(button=SimpleNamespace(id="inspect-plausibility-btn")))
+    screen.on_button_pressed(
+        SimpleNamespace(button=SimpleNamespace(id="add-label-btn"))
+    )
+    screen.on_button_pressed(
+        SimpleNamespace(button=SimpleNamespace(id="inspect-plausibility-btn"))
+    )
 
     assert ("create_face", Path("/tmp/travel.vessel"), "face_b", "travel") in events
     assert ("inspect_plausibility", Path("/tmp/travel.vessel"), "face_b") in events

--- a/tests/test_vessel_workflow_service.py
+++ b/tests/test_vessel_workflow_service.py
@@ -37,11 +37,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             output_path = Path(tmpdir) / "recovered.txt"
             input_path.write_text("field note", encoding="utf-8")
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 created = svc.create_vessel(vessel_path, "8M")
                 self.assertTrue(created.vessel_path.exists())
@@ -75,11 +78,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             input_path.write_text("field note", encoding="utf-8")
             self._write_object_image(image_path, (20, 120, 220))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 stored = svc.add_file(
@@ -93,7 +99,10 @@ class VesselWorkflowServiceTests(unittest.TestCase):
                 self.assertEqual(stored.bytes_stored, len(b"field note"))
                 inspection = InspectionService().inspect(vessel_path)
                 labels = {field.label: field.value for field in inspection.fields}
-                self.assertIn("face_a:credentials=ready:object=ready", labels["Face Credential State"])
+                self.assertIn(
+                    "face_a:credentials=ready:object=ready",
+                    labels["Face Credential State"],
+                )
 
     def test_first_add_initializes_face_b_credentials(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -104,11 +113,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             input_path.write_text("field note", encoding="utf-8")
             self._write_object_image(image_path, (220, 40, 40))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 stored = svc.add_file(
@@ -133,11 +145,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             state_dir = Path(tmpdir) / "state"
             vessel_path = Path(tmpdir) / "travel.vessel"
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 with self.assertRaises(FileExistsError):
@@ -148,11 +163,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             state_dir = Path(tmpdir) / "state"
             vessel_path = Path(tmpdir) / "travel.vessel"
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
 
@@ -167,11 +185,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             state_dir = Path(tmpdir) / "state"
             vessel_path = Path(tmpdir) / "travel.vessel"
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M", label="travel")
 
@@ -191,7 +212,9 @@ class VesselWorkflowServiceTests(unittest.TestCase):
                 self.assertTrue(reopened.vessel.is_open)
                 self.assertEqual(reopened.vessel.open_count, 2)
                 self.assertEqual(reopened.vessel.label, "travel")
-                self.assertEqual(reopened.vessel.last_closed_at, closed.vessel.last_closed_at)
+                self.assertEqual(
+                    reopened.vessel.last_closed_at, closed.vessel.last_closed_at
+                )
 
                 inspection = InspectionService().inspect(vessel_path)
                 self.assertTrue(inspection.ok)
@@ -204,11 +227,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             output_path = Path(tmpdir) / "recovered.txt"
             input_path.write_text("field note", encoding="utf-8")
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 face = svc.create_face(vessel_path, "face_b", label="travel")
@@ -217,7 +243,9 @@ class VesselWorkflowServiceTests(unittest.TestCase):
                 self.assertTrue(face.face.created_at)
 
                 opened = svc.open_vessel(vessel_path, face_id="face_b")
-                opened_face = next(face for face in opened.vessel.faces if face.face_id == "face_b")
+                opened_face = next(
+                    face for face in opened.vessel.faces if face.face_id == "face_b"
+                )
                 self.assertEqual(opened_face.status, "open")
                 self.assertTrue(opened_face.last_accessed)
 
@@ -233,13 +261,17 @@ class VesselWorkflowServiceTests(unittest.TestCase):
                 self.assertEqual(stored.mode, "secret")
 
                 closed = svc.close_vessel(vessel_path)
-                closed_face = next(face for face in closed.vessel.faces if face.face_id == "face_b")
+                closed_face = next(
+                    face for face in closed.vessel.faces if face.face_id == "face_b"
+                )
                 self.assertEqual(closed_face.status, "occupied")
                 self.assertEqual(closed_face.occupancy, len(b"field note"))
                 self.assertEqual(closed_face.file_count, 1)
 
                 reopened = svc.open_vessel(vessel_path, face_id="face_b")
-                reopened_face = next(face for face in reopened.vessel.faces if face.face_id == "face_b")
+                reopened_face = next(
+                    face for face in reopened.vessel.faces if face.face_id == "face_b"
+                )
                 self.assertEqual(reopened_face.label, "travel")
                 self.assertEqual(reopened_face.occupancy, len(b"field note"))
 
@@ -269,11 +301,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             file_x.write_text("alpha", encoding="utf-8")
             file_y.write_text("bravo", encoding="utf-8")
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 cue_a = ["reference_dummy_matched"]
@@ -376,11 +411,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             state_dir = Path(tmpdir) / "state"
             vessel_path = Path(tmpdir) / "travel.vessel"
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
 
@@ -423,11 +461,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             note_path = Path(tmpdir) / "note.txt"
             note_path.write_text("field note", encoding="utf-8")
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 cue_sequence = ["reference_dummy_matched"]
@@ -475,11 +516,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             self._write_object_image(first_image, (20, 120, 220))
             self._write_object_image(second_image, (220, 40, 40))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 svc.add_file(
@@ -520,7 +564,9 @@ class VesselWorkflowServiceTests(unittest.TestCase):
                     selector="face_a",
                     object_image_path=str(first_image),
                 )
-                self.assertEqual([item.name for item in listing_after.files], ["note.txt"])
+                self.assertEqual(
+                    [item.name for item in listing_after.files], ["note.txt"]
+                )
 
     def test_second_add_wrong_access_password_fails(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -533,11 +579,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             second_file.write_text("bravo", encoding="utf-8")
             self._write_object_image(image_path, (20, 120, 220))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 svc.add_file(
@@ -569,11 +618,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             second_file.write_text("bravo", encoding="utf-8")
             self._write_object_image(image_path, (20, 120, 220))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 svc.add_file(
@@ -610,11 +662,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             note_path.write_text("field note", encoding="utf-8")
             self._write_object_image(image_path, (20, 120, 220))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 svc.add_file(
@@ -650,7 +705,9 @@ class VesselWorkflowServiceTests(unittest.TestCase):
                         object_image_path=str(image_path),
                     )
 
-    def test_emergency_destroy_face_requires_correct_object_password_and_confirmation(self):
+    def test_emergency_destroy_face_requires_correct_object_password_and_confirmation(
+        self,
+    ):
         with tempfile.TemporaryDirectory() as tmpdir:
             state_dir = Path(tmpdir) / "state"
             vessel_path = Path(tmpdir) / "travel.vessel"
@@ -663,11 +720,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             self._write_object_image(image_a, (20, 120, 220))
             self._write_object_image(image_b, (220, 40, 40))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 svc.add_file(
@@ -734,11 +794,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             image_a = Path(tmpdir) / "object-a.png"
             self._write_object_image(image_a, (20, 120, 220))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 with self.assertRaisesRegex(ValueError, "credentials not initialized"):
@@ -763,11 +826,14 @@ class VesselWorkflowServiceTests(unittest.TestCase):
             self._write_object_image(image_a, (20, 120, 220))
             self._write_object_image(image_b, (220, 40, 40))
 
-            with mock.patch.dict(
-                os.environ,
-                {"PHASMID_STATE_DIR": str(state_dir)},
-                clear=False,
-            ), self._patch_registry_dir(tmpdir):
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
                 svc = VesselWorkflowService()
                 svc.create_vessel(vessel_path, "8M")
                 svc.add_file(


### PR DESCRIPTION
## Problem

The CI formatting gate has never inspected a file. Two independent defects, either of which alone disables it.

**1. `[tool.black] include` matches nothing.** `pyproject.toml` set:

```toml
include = '\\.pyi?$'
```

A TOML literal (single-quoted) string does not process escapes, so black receives the regex `\\.pyi?$` — a literal backslash, any character, then `.py`/`.pyi`. No real path matches. Confirmed through black's own config loader rather than by inspection:

```
include: '\\\\.pyi?$'   re.search(include, 'src/phasmid/tui/app.py') -> None
```

Both CI steps therefore printed `No Python files are present to be formatted. Nothing to do` and exited 0.

**2. The workflow reformatted before checking.** Even with the pattern repaired, the gate still could not fail:

```yaml
- name: Run formatting with black
  run: python -m black src tests scripts      # rewrites the checkout
- name: Verify formatting with black
  run: python -m black --check src tests scripts
```

The first step reformats whatever the second would have caught, and the rewrite is discarded with the runner. Verified by dropping a deliberately misformatted file in and running the two steps in order: black reformatted it, `--check` passed, exit 0. Misformatted code would have been silently fixed in CI and reported green.

This is the issue filed from #149's verification notes.

## Changes

Three separate commits, so the mechanical reformat stays readable.

- `pyproject.toml` — `include` corrected to black's intended `\.pyi?$`. `--check` now walks 146 files instead of 0.
- `src`, `tests`, `scripts` — the 16 files that drifted behind the dead gate, reformatted in one pass. Line-wrapping and spacing only.
- `.github/workflows/ci.yml` — the mutating step dropped; one `black --check --diff` remains, so drift fails the build and the log shows exactly what to reformat.

Scope note: the repo also configures `[tool.ruff]`, and `ruff format` disagrees with black on some files. CI runs `ruff check` (lint) and `black` (format), so black is left as the formatter of record; nothing here switches formatters.

## Verification

Gate behaviour, with the workflow's exact command:

| | exit |
|---|---|
| deliberately misformatted file present | **1** — build fails |
| clean tree, 146 files | **0** — build passes |

The probe file was removed; the tree is clean.

The reformat is behaviour-preserving:

- `unittest discover -s tests` — 542 tests, OK, 5 skipped
- `ruff check src tests scripts` — clean
- `mypy src` — no issues in 90 source files
- `bandit -r src --severity-level medium --confidence-level high` — clean
- `compileall -q src tests scripts` — clean

## Interaction with the open PRs

Checked rather than assumed, since a repo-wide reformat is the kind of change that breaks everything in flight.

- **#150** touches only `.md` and `.sh` files — no overlap with the reformat.
- **#149** touches `home.py`, `simple_home.py` and `test_tui.py`, all three in the reformatted set. It still merges cleanly, and its added lines survive the merge intact.
- Merging this branch with either PR produces a tree that is **already black-clean** (`--check` exits 0 over 146 files), so neither PR needs reformatting work to satisfy the revived gate.

The `CHANGELOG.md` entry here is deliberately appended to the end of the existing `### Changed` list rather than at the top of `[Unreleased]`, because both open PRs insert at that top anchor. Merges with both were re-verified clean after adding it.

Unrelated to this branch, but worth flagging: **#149 and #150 conflict with each other** on `CHANGELOG.md` — both insert at the same anchor. Whichever merges first will require the other to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)