### PR TITLE
fix(pi): unbreak bootstrap and environment validation on Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,31 @@ and this project follows SemVer-style release intent for documented interfaces.
   `/unlock`, and `curl -sf` treats that 303 as success, so the probe would time
   an empty redirect and report meaningless latency. It now requires HTTP 200 and
   fails with an explanation when it sees the unlock redirect.
+- `scripts/bootstrap_pi.sh` aborted before it created the virtualenv on
+  Raspberry Pi OS Trixie. The apt package list named `libatlas-base-dev`, which
+  Debian 13 dropped, and `set -e` turned that one missing candidate into a total
+  failure: no `.venv`, no editable install, no usable device, from a script whose
+  whole job is to produce one. The list now names `libopenblas-dev`, which the
+  supported releases ship and which `scripts/pi_zero2w/README.md` and
+  `docs/PI_ZERO2W_FIELD_TEST.md` already prescribed, so the repository no longer
+  contradicts itself about its own dependencies. Packages with no installation
+  candidate are reported and skipped instead of ending the run, because the BLAS
+  development headers only matter when no wheel is available and numpy has to be
+  built from source.
+- `scripts/validate_pi_environment.sh` recorded Stage A as failed on every run
+  under Python 3.13. The probe did `import importlib` and then called
+  `importlib.util.find_spec`; importing the parent package does not bind `util`
+  as an attribute, so the check raised `AttributeError` and was recorded as a
+  missing-import failure while picamera2, cv2 and numpy were in fact all
+  importable. It now imports `importlib.util` directly.
 
 ### Changed
 
+- `README.md` named Bookworm and Bullseye as the deployment targets. Bullseye
+  ships Python 3.9 and cannot satisfy the Python 3.10 requirement stated two rows
+  above it in the same table. The row now names Trixie and Bookworm and states
+  the 64-bit requirement the install path already depended on; a note below the
+  table records why 32-bit and Bullseye are excluded.
 - `SECURITY.md` now states supported versions concretely rather than by
   reference to "the latest release line", links the published advisories, and
   names GitHub private vulnerability reporting as the preferred intake channel.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,18 @@ Current implementation status and evidence paths are tracked in [`docs/IMPLEMENT
 | Requirement | Detail |
 |---|---|
 | Python | 3.10 or later |
-| OS | Linux, macOS (development); Raspberry Pi OS Bookworm/Bullseye (deployment) |
+| OS | Linux, macOS (development); Raspberry Pi OS Trixie or Bookworm, 64-bit (deployment) |
 | Hardware | x86-64 laptop/desktop for development; Raspberry Pi Zero 2 W for field deployment |
 | Camera (optional) | Picamera2 / libcamera — required only for object-cue matching on Pi |
 | WebUI (optional) | Any modern browser; binds `127.0.0.1` by default. USB gadget Ethernet access is opt-in — see [WebUI access](#webui-access) |
 | LUKS (optional) | Linux kernel with dm-crypt — required for the optional LUKS2 storage layer |
 
 For Raspberry Pi deployment, `python3-picamera2` and `python3-libcamera` must be installed via apt before running the bootstrap script.
+
+Deployment is verified on 64-bit Raspberry Pi OS. A 32-bit (`armv7l`) userland
+is not supported: the aarch64 wheels the install path depends on do not exist
+for it. Bullseye is excluded because it ships Python 3.9, below the Python
+requirement above.
 
 ## Hardware Snapshot
 

--- a/scripts/bootstrap_pi.sh
+++ b/scripts/bootstrap_pi.sh
@@ -36,7 +36,7 @@ apt_install() {
     python3-dev
     build-essential
     pkg-config
-    libatlas-base-dev
+    libopenblas-dev
   )
 
   local -a sudo_prefix=()
@@ -46,7 +46,37 @@ apt_install() {
 
   log "Installing apt dependencies..."
   "${sudo_prefix[@]}" apt-get update
-  "${sudo_prefix[@]}" apt-get install -y "${packages[@]}"
+
+  # A package that a newer Debian release has dropped must not abort the
+  # whole bootstrap under `set -e`. libatlas-base-dev did exactly that on
+  # trixie: it has no installation candidate there, so apt-get exited
+  # non-zero and the virtualenv was never created. Install what this
+  # release actually ships and report the rest -- the BLAS development
+  # headers only matter when no wheel is available and numpy has to be
+  # built from source.
+  local -a available=() unavailable=()
+  local pkg candidate
+  for pkg in "${packages[@]}"; do
+    candidate="$(apt-cache policy "$pkg" 2>/dev/null \
+      | awk '/Candidate:/ { print $2 }')"
+    if [[ -n "$candidate" && "$candidate" != "(none)" ]]; then
+      available+=("$pkg")
+    else
+      unavailable+=("$pkg")
+    fi
+  done
+
+  if [[ ${#unavailable[@]} -gt 0 ]]; then
+    warn "No installation candidate on this release: ${unavailable[*]}"
+    warn "Continuing without them. Revisit if a later stage fails."
+  fi
+
+  if [[ ${#available[@]} -eq 0 ]]; then
+    warn "No apt dependencies resolved. Check the apt sources."
+    return 1
+  fi
+
+  "${sudo_prefix[@]}" apt-get install -y "${available[@]}"
 }
 
 prepare_venv() {

--- a/scripts/validate_pi_environment.sh
+++ b/scripts/validate_pi_environment.sh
@@ -50,7 +50,7 @@ activate_venv_if_present() {
 stage_a_imports() {
   log "Stage A: Python imports"
   if python - <<'PY'
-import importlib
+import importlib.util
 mods = ["picamera2", "cv2", "numpy"]
 missing = [m for m in mods if importlib.util.find_spec(m) is None]
 if missing:


### PR DESCRIPTION
## Summary

A fresh Raspberry Pi deployment fails on Raspberry Pi OS Trixie, the current
release. Two defects are responsible; a third inconsistency in `README.md` is
corrected alongside them.

All three were found while deploying to a Pi Zero 2 W running Debian 13
(aarch64, Python 3.13.5), and every fix is verified on that device.

## Defects

**`scripts/bootstrap_pi.sh` never creates the virtualenv.** The apt package
list named `libatlas-base-dev`, which Debian 13 dropped. Under `set -e` a
single package with no installation candidate ends the run before `.venv`
exists, so the script produces nothing at all. `scripts/pi_zero2w/README.md`
and `docs/PI_ZERO2W_FIELD_TEST.md` already prescribed `libopenblas-dev`, so
the repository was contradicting itself about its own dependencies.

**`scripts/validate_pi_environment.sh` fails Stage A on every run under Python
3.13.** The probe does `import importlib` and then calls
`importlib.util.find_spec`. Importing the parent package does not bind `util`
as an attribute, so the check raises `AttributeError` and is recorded as a
missing-import failure while picamera2, cv2 and numpy are in fact all
importable. The reported failure was never real.

**`README.md` claims Bullseye support.** Bullseye ships Python 3.9 and cannot
satisfy the "Python 3.10 or later" requirement stated two rows above it in the
same table.

## Changes

- `bootstrap_pi.sh`: `libatlas-base-dev` -> `libopenblas-dev`.
- `bootstrap_pi.sh`: packages with no installation candidate are reported and
  skipped rather than aborting the run. Renaming the package alone would leave
  the same failure waiting for the next Debian release, and the BLAS
  development headers only matter when no wheel is available and numpy has to
  be built from source.
- `validate_pi_environment.sh`: import `importlib.util` directly.
- `README.md`: deployment targets are Trixie and Bookworm, 64-bit; a note
  records why 32-bit and Bullseye are excluded.
- `CHANGELOG.md`: entries under Unreleased.

## Verification

On a Pi Zero 2 W, Raspberry Pi OS Trixie, aarch64, Python 3.13.5:

| Check | Result |
|---|---|
| `bash -n` on both scripts | ok |
| `bootstrap_pi.sh` end to end | completes, no warnings (previously aborted at apt) |
| Skip guard, with two unresolvable packages injected | both reported, run completes, exit 0 |
| `validate_pi_environment.sh` | 7 pass, 0 fail (Stage A previously failed on every run) |
| `scripts/pi_zero2w/run_demo_smoke_test.sh` | 11 passed, 0 failed |
| markdownlint | no new findings |
| black / ruff / mypy | no Python files changed |