### PR TITLE
chore: ignore the Pi field-test output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dump.txt
 *.bin
 models/object_gate/
 release/
+_pi_field_test/
 report.json
 refactor-instructions.md
 phasmid-autotest/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project follows SemVer-style release intent for documented interfaces.
   as an attribute, so the check raised `AttributeError` and was recorded as a
   missing-import failure while picamera2, cv2 and numpy were in fact all
   importable. It now imports `importlib.util` directly.
+- `.gitignore` did not cover `_pi_field_test/`, the directory that
+  `scripts/pi_zero2w/run_remote_perf.sh` and
+  `scripts/pi_zero2w/run_demo_smoke_test.sh` write their results into.
+  Running either left the working tree dirty for good, so every device that
+  had been field tested reported untracked output on each `git status` and a
+  real untracked change was easy to lose among it. Parts of the contents were
+  already covered by the `vault.bin`, `*.bin` and `.state/` patterns; the
+  directory itself was not.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

`scripts/pi_zero2w/run_remote_perf.sh` and
`scripts/pi_zero2w/run_demo_smoke_test.sh` write their results into
`_pi_field_test/`, which `.gitignore` did not cover.

Running either left the working tree dirty for good. Every device that had
been field tested reported untracked output on each `git status`, which is
noise on its own and, worse, a place for a real untracked change to hide.

Parts of the contents were already caught by the `vault.bin`, `*.bin` and
`.state/` patterns, which is likely why this went unnoticed. The directory
itself was not.

## Verification

- No tracked file lives under `_pi_field_test/` (`git ls-files` returns zero
  matches), so nothing is removed from the index.
- With the entry in place, both `_pi_field_test/` and
  `_pi_field_test/results/demo-smoke-test.json` are reported as ignored, and
  `git status` after a smoke-test run is clean.
- markdownlint reports no findings on `CHANGELOG.md`.

Split out from #152 rather than folded into it: that PR is about Debian 13
compatibility, and this is unrelated repository hygiene.