### PR TITLE
fix(tui): key-name markup stripping + Silent Standby crash-on-push

### DIFF
--- a/src/phasmid/tui/screens/base.py
+++ b/src/phasmid/tui/screens/base.py
@@ -25,7 +25,7 @@ class OperatorScreen(Screen):
     }
     """
 
-    _WEBUI_WARNING_FALLBACK = "WEBUI ACTIVE - PRESS [w] TO RETRACT"
+    _WEBUI_WARNING_FALLBACK = "WEBUI ACTIVE - PRESS \\[w] TO RETRACT"
 
     def webui_warning_banner(self) -> Static:
         return Static(
@@ -38,7 +38,7 @@ class OperatorScreen(Screen):
         app = cast("PhasmidApp", self.app)
         access_url = app.webui_svc.access_url()
         if access_url:
-            return f"WEBUI ACTIVE AT {access_url} - PRESS [w] TO RETRACT"
+            return f"WEBUI ACTIVE AT {access_url} - PRESS \\[w] TO RETRACT"
         return self._WEBUI_WARNING_FALLBACK
 
     def refresh_webui_status(self) -> None:

--- a/src/phasmid/tui/screens/context_profile_selector.py
+++ b/src/phasmid/tui/screens/context_profile_selector.py
@@ -46,7 +46,7 @@ class ContextProfileSelectorScreen(OperatorScreen):
     }
     ContextProfileSelectorScreen #detail-panel {
         height: 8;
-        border: solid $text-muted;
+        border: solid $foreground-muted;
         padding: 0 1;
         margin: 0 0 1 0;
         color: $text;

--- a/src/phasmid/tui/screens/home.py
+++ b/src/phasmid/tui/screens/home.py
@@ -137,7 +137,7 @@ class HomeScreen(OperatorScreen):
         app = cast("PhasmidApp", self.app)
         is_running = app.webui_svc.is_running()
         warning.update_message(
-            self.webui_running_message().replace(" - PRESS [w] TO RETRACT", "")
+            self.webui_running_message().replace(" - PRESS \\[w] TO RETRACT", "")
         )
         warning.display = is_running
 
@@ -204,12 +204,12 @@ class HomeScreen(OperatorScreen):
             badge.update(
                 f"[bold red]✗ SYSTEM: {fail_count} FAIL"
                 + (f", {warn_count} WARN" if warn_count else "")
-                + " — press [d] to review[/bold red]"
+                + " — press \\[d] to review[/bold red]"
             )
             badge.display = True
         elif warn_count:
             badge.update(
-                f"[yellow]! SYSTEM: {warn_count} WARN — press [d] to review[/yellow]"
+                f"[yellow]! SYSTEM: {warn_count} WARN — press \\[d] to review[/yellow]"
             )
             badge.display = True
         else:

--- a/src/phasmid/tui/screens/simple_home.py
+++ b/src/phasmid/tui/screens/simple_home.py
@@ -82,15 +82,15 @@ class SimpleHomeScreen(OperatorScreen):
             id="simple-subtitle",
         )
         yield Static(
-            "Normal controls are ready. Press [e] Expert for diagnostics and technical detail.",
+            "Normal controls are ready. Press \\[e] Expert for diagnostics and technical detail.",
             id="health",
             markup=True,
         )
         yield Static("PROTECTED STORAGE", id="storage-label")
         yield DataTable(id="storage-table", cursor_type="row", zebra_stripes=True)
         yield Static(
-            "[bold]Choose an action:[/bold]  [o] Open selected   [n] New protected storage   "
-            "[g] Guided help\n[dim]Advanced diagnostics and forensic detail are available under [e] Expert.[/dim]",
+            "[bold]Choose an action:[/bold]  \\[o] Open selected   \\[n] New protected storage   "
+            "\\[g] Guided help\n[dim]Advanced diagnostics and forensic detail are available under \\[e] Expert.[/dim]",
             id="next-step",
             markup=True,
         )
@@ -131,7 +131,7 @@ class SimpleHomeScreen(OperatorScreen):
         if not self._vessels:
             self.query_one("#next-step", Static).update(
                 "[bold]No protected storage found.[/bold]\n"
-                "Press [n] to create one, or [g] for guided help."
+                "Press \\[n] to create one, or \\[g] for guided help."
             )
 
     def _selected_path(self) -> str:

--- a/src/phasmid/tui/screens/standby.py
+++ b/src/phasmid/tui/screens/standby.py
@@ -73,7 +73,7 @@ class StandbyScreen(OperatorScreen):
     }
     StandbyScreen #maintenance-panel {
         height: 10;
-        border: solid $text-muted;
+        border: solid $foreground-muted;
         padding: 1 2;
         color: $text-muted;
         margin: 0 0 1 0;

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1689,9 +1689,7 @@ def test_all_tui_screens_mount_and_keep_key_names(tmp_path, monkeypatch):
                     failures.append(f"{name} failed to mount: {exc!r}")
                     continue
                 await pilot.pause()
-                widgets = list(app.screen.query(Static)) + list(
-                    app.screen.query(Label)
-                )
+                widgets = list(app.screen.query(Static)) + list(app.screen.query(Label))
                 for widget in widgets:
                     try:
                         text = widget.visual.plain

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1617,3 +1617,94 @@ def test_key_name_brackets_survive_rich_markup_parsing():
     for markup, key in samples:
         plain = Text.from_markup(markup).plain
         assert key in plain, f"key name {key!r} stripped from: {plain!r}"
+
+
+def test_all_tui_screens_mount_and_keep_key_names(tmp_path, monkeypatch):
+    """Push every screen through the real app and inspect what it renders.
+
+    Reading source strings misses two classes of regression that only show
+    up once Textual actually renders a screen: CSS that fails to parse (a
+    `border:` referencing an auto-contrast variable like `$text-muted` is
+    invalid, even though the identical variable is fine for `color:`, so
+    the screen raises `StylesheetParseError` and never mounts at all), and
+    a "Press [x]" instruction whose bracketed key name Rich silently
+    stripped. Both classes previously escaped review because the affected
+    screens (Silent Standby, the context-profile selector) were never
+    actually pushed.
+    """
+    import asyncio
+    import re
+
+    from textual.widgets import Label, Static
+
+    from phasmid import config
+
+    monkeypatch.setattr(config, "DEFAULT_STATE_DIR", str(tmp_path))
+
+    from phasmid.tui.app import PhasmidApp
+    from phasmid.tui.screens.about import AboutScreen
+    from phasmid.tui.screens.audit import AuditScreen
+    from phasmid.tui.screens.context_profile_selector import (
+        ContextProfileSelectorScreen,
+    )
+    from phasmid.tui.screens.create_vessel import CreateVesselScreen
+    from phasmid.tui.screens.doctor import DoctorScreen
+    from phasmid.tui.screens.face_manager import FaceManagerScreen
+    from phasmid.tui.screens.guided import GuidedScreen
+    from phasmid.tui.screens.home import HomeScreen
+    from phasmid.tui.screens.inspect_vessel import InspectVesselScreen
+    from phasmid.tui.screens.luks_screen import LuksScreen
+    from phasmid.tui.screens.open_vessel import OpenVesselScreen
+    from phasmid.tui.screens.settings import SettingsScreen
+    from phasmid.tui.screens.simple_home import SimpleHomeScreen
+    from phasmid.tui.screens.standby import StandbyScreen
+
+    screens = [
+        ("SimpleHome", SimpleHomeScreen),
+        ("Home", HomeScreen),
+        ("Create", CreateVesselScreen),
+        ("Faces", FaceManagerScreen),
+        ("Audit", AuditScreen),
+        ("Doctor", DoctorScreen),
+        ("Settings", SettingsScreen),
+        ("Inspect", InspectVesselScreen),
+        ("Open", OpenVesselScreen),
+        ("Luks", LuksScreen),
+        ("Guided", GuidedScreen),
+        ("About", AboutScreen),
+        ("Standby", StandbyScreen),
+        ("ContextProfile", ContextProfileSelectorScreen),
+    ]
+    stripped_key_fingerprint = re.compile(r"[Pp]ress\s{2,}|PRESS\s{2,}")
+
+    async def scan() -> list[str]:
+        failures: list[str] = []
+        app = PhasmidApp(initial_screen="home")
+        async with app.run_test(size=(140, 60)) as pilot:
+            await pilot.pause()
+            for name, screen_cls in screens:
+                try:
+                    await app.push_screen(screen_cls())
+                except Exception as exc:  # noqa: BLE001 - want every screen's failure
+                    failures.append(f"{name} failed to mount: {exc!r}")
+                    continue
+                await pilot.pause()
+                widgets = list(app.screen.query(Static)) + list(
+                    app.screen.query(Label)
+                )
+                for widget in widgets:
+                    try:
+                        text = widget.visual.plain
+                    except Exception:  # noqa: BLE001 - not every widget renders text
+                        continue
+                    for line in text.splitlines():
+                        if stripped_key_fingerprint.search(line):
+                            failures.append(
+                                f"{name} {widget.id!r}: stripped key name in {line!r}"
+                            )
+                await app.pop_screen()
+                await pilot.pause()
+        return failures
+
+    failures = asyncio.run(scan())
+    assert not failures, "\n".join(failures)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1576,3 +1576,44 @@ def test_expert_entry_refreshes_simple_home_on_return(monkeypatch):
     assert pushed["callback"] is not None, "no return callback: list would go stale"
     pushed["callback"](None)
     assert refreshed == [True]
+
+
+def test_key_name_brackets_survive_rich_markup_parsing():
+    """`[x]` in a user-facing string is Rich markup, not a literal key name.
+
+    Unescaped, Rich strips the bracketed key name entirely instead of
+    rendering it, so operators never see which key to press. Every string
+    that names a key in brackets must escape it (`\\[x]`) so the plain
+    rendered text still contains the key name.
+    """
+    from rich.text import Text
+
+    from phasmid.tui.screens.base import OperatorScreen
+
+    samples = [
+        (OperatorScreen._WEBUI_WARNING_FALLBACK, "[w]"),
+        (
+            "Normal controls are ready. Press \\[e] Expert for diagnostics "
+            "and technical detail.",
+            "[e]",
+        ),
+        (
+            "[bold]Choose an action:[/bold]  \\[o] Open selected   "
+            "\\[n] New protected storage   \\[g] Guided help\n"
+            "[dim]Advanced diagnostics and forensic detail are available "
+            "under \\[e] Expert.[/dim]",
+            "[o]",
+        ),
+        (
+            "[bold]No protected storage found.[/bold]\n"
+            "Press \\[n] to create one, or \\[g] for guided help.",
+            "[n]",
+        ),
+        (
+            "[yellow]! SYSTEM: 7 WARN — press \\[d] to review[/yellow]",
+            "[d]",
+        ),
+    ]
+    for markup, key in samples:
+        plain = Text.from_markup(markup).plain
+        assert key in plain, f"key name {key!r} stripped from: {plain!r}"


### PR DESCRIPTION
## Summary

Started as a fix for Rich stripping bracketed key names (`[w]`, `[e]`, `[n]`, `[g]`, `[d]`) out of user-facing strings. Verifying it required actually rendering every screen instead of trusting grep, and that surfaced a second, more serious defect.

### 1. Rich markup stripping key names

Rich interprets `[x]` as a style tag and silently deletes it, so every string naming a key in brackets rendered with the key missing:

- `src/phasmid/tui/screens/base.py:28,41` — `_WEBUI_WARNING_FALLBACK` / `webui_running_message()`: `"WEBUI ACTIVE - PRESS [w] TO RETRACT"`. This is the only on-screen instruction for retracting an exposed WebUI, so this was a security-surface regression, not cosmetics.
- `src/phasmid/tui/screens/home.py:140` — matching `.replace()` call, updated to match.
- `src/phasmid/tui/screens/simple_home.py:85,92-93,134` — Simple Home's health message and empty-state / action-hint panels.
- `src/phasmid/tui/screens/home.py:207,212` — the Expert home doctor-status badge, `! SYSTEM: N WARN — press [d] to review`. This is the fourth string from the original handoff notes that a prior grep-based pass couldn't locate and guessed at (`[?]`, incorrectly) — it's actually `[d]`, confirming that string identification by inspection/guessing isn't reliable for this class of bug.

Fixed by escaping the literal key names with Rich's `\[x]` syntax, leaving real markup tags (`[bold]`, `[dim]`, `[yellow]`, `[bold red]`) intact.

### 2. Silent Standby and the context-profile screen crash on push (new finding)

To check whether any instance of this bug class was missed, I rendered every TUI screen through Textual's real test harness (`App.run_test()` + `push_screen`) instead of grepping source text again — grep already proved unreliable for locating instance #4 above. That surfaced an unrelated, previously-undiscovered defect:

`StandbyScreen` and `ContextProfileSelectorScreen` both declare `border: solid $text-muted;` in their CSS. `$text-muted` resolves to an auto-contrast token (`"auto 60%"`), which Textual accepts for `color:` but rejects for `border:` — pushing either screen raises `textual.css.stylesheet.StylesheetParseError` and the screen never mounts.

`PhasmidApp.action_trigger_standby` (`tui/app.py:203`) calls `self.push_screen(StandbyScreen(), ...)` with no `try`/`except` around the push. So triggering Silent Standby via the `Ctrl+S` hotkey would crash the running app instead of concealing the sensitive UI — the exact opposite of what that feature exists for. It's also the screen the original handoff notes flagged as highest risk ("Step 6 の山場") and noted had never actually been rendered during the rehearsal session that produced those notes.

Fixed both screens by switching to `$foreground-muted`, a literal blended color Textual accepts in border position (same visual intent, no `auto` token).

## Test plan

- [x] `test_key_name_brackets_survive_rich_markup_parsing` — renders each of the five key-name strings through `rich.text.Text.from_markup(...).plain` and asserts the key name survives; verified it fails against the pre-fix strings.
- [x] `test_all_tui_screens_mount_and_keep_key_names` — pushes all 14 TUI screens through a real `PhasmidApp` via `App.run_test()`, fails on either a mount exception (catches the CSS class of bug) or a re-stripped `Press [x]` fingerprint in any rendered `Static`/`Label` text (catches the markup class of bug) — reverting either fix locally reproduces the corresponding failure.
- [x] `python3 -m pytest` — 653 passed, 5 skipped (full suite).
- [x] `ruff check` on all changed files — clean.

Not yet re-verified on the physical Pi device (no hardware access from this session) — given the Standby crash is demo-critical (Step 6), recommend confirming `Ctrl+S` → Silent Standby → `Ctrl+R` recovery on-device before DEF CON.
