### PR TITLE
fix: put the WebUI on the same Vessel as the console; stop standby leaking the token

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,3 +9,32 @@ _REPO_ROOT = Path(__file__).resolve().parent
 _repo_root_str = str(_REPO_ROOT)
 if _repo_root_str not in sys.path:
     sys.path.insert(0, _repo_root_str)
+
+
+# The WebUI resolves its target Vessel from the operator registry, which is
+# real, global, and outlives any single test. A Vessel left registered by an
+# earlier run therefore silently changes which container the WebUI acts on,
+# and tests written against the legacy fallback start failing for reasons
+# that have nothing to do with the code under test.
+#
+# Point the override at a path that cannot exist, which resolve_web_vessel()
+# treats as "nothing registered". Tests that want a real target set the
+# variable themselves; tests that want the registry branch pop it.
+import os  # noqa: E402
+
+import pytest  # noqa: E402
+
+_NO_WEB_VESSEL = "/nonexistent/phasmid-test-no-vessel.vessel"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_web_vessel_target():
+    previous = os.environ.get("PHASMID_WEB_VESSEL")
+    os.environ["PHASMID_WEB_VESSEL"] = _NO_WEB_VESSEL
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("PHASMID_WEB_VESSEL", None)
+        else:
+            os.environ["PHASMID_WEB_VESSEL"] = previous

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -1,12 +1,12 @@
 # Phasmid — Live Demo 実施細部要領 / Demo Runbook
 
 **対象:** DEF CON Demo Labs 本番の実機デモ（Deck Slide 24）。プレゼン30分のうち**約7分**を割り当て、**Q&A/交流15分を必ず確保**する。
-**画面:** 実TUI（Local Disclosure Control）が本編。ローカルWebUI は Step 5 のローカル境界の提示にのみ使う（保管層が別なので本編には接続しない）。
+**画面:** 実TUI（Local Disclosure Control）が本編。ローカルWebUI は Step 5 のローカル境界の提示にのみ使う（Store/Retrieve は本編と同じ Vessel を操作するが、この統合経路は壇上ではまだ実機で通しておらず、判定が物体キュー照合に依存しCIでは検証できないため本編には含めない）。
 
 > **情報の確度について**
 > - **本書は 0.3.0 実機（Pi Zero 2 W / Raspberry Pi OS Trixie）で全手順を通した結果に基づく。** 〔要確認〕は原則として解消済み。実機で確認していない項目のみ §9 末尾に明示する。
 > - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel の `Add File`）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。Step 3b（物体なしでの失敗）を新設した。Generate Plausibility は**実測4分のため壇上から外した**。
-> - **保管層が2つ並存している。** TUI は `*.vessel`、WebUI の Store/Retrieve と Doctor の Dummy Profile 検査は `vault.bin`。**混ぜると話が繋がらない**（→ §4 Step 2 の注記）。
+> - **WebUI の Store/Retrieve は Vessel 経路に統一済み。** かつては TUI が `*.vessel`、WebUI が別の `vault.bin` を操作しており話が繋がらなかったが、現在は両者とも `resolve_web_vessel()` が解決した同じ Vessel を `VesselWorkflowService` 経由で操作する（Vessel 未登録時のみ旧 `vault.bin` にフォールバック）。Doctor の Dummy Profile 検査だけは今も旧層 `vault.bin` / `.state/dummy_profile` を見ている（→ #157、§4 Step 2 の注記）。
 > - **注意:** 0.1.4 までは起動直後が Expert 相当の単層画面だった。それ以前の手順書のキー順は**そのままでは通らない**。
 
 ---
@@ -41,8 +41,9 @@
 
 > **時計運用:** 開始 ~19:20。**26:00 を超えたら残手順を口頭要約**して締めへ。
 > **Step 3b は新設。** 物体の有無だけを変えた対比がなければ、cue≠key は実証されない。
-> **Step 2/3 は TUI で行う。** WebUI の Store/Retrieve は Vessel ではなく `vault.bin`
-> を操作するため、Vessel を使うデモ本編には接続しない（§4 Step 2 の注記を参照）。
+> **Step 2〜3b は TUI で行う。** WebUI の Store/Retrieve は本編と同じ Vessel を操作するが、
+> 統合経路を壇上ではまだ実機で通しておらず、判定が物体キュー照合に依存しCIでは検証できないため、
+> デモ本編には含めない（§4 Step 2 の注記を参照）。
 
 ---
 
@@ -51,7 +52,7 @@
 ### T-30分（設営時）
 
 - [ ] 実機（Pi Zero 2 W + カメラ + 三脚）を卓上に設置、電源・給電確認。
-- [ ] 表示系: TUIを映す経路と、**ラップトップのブラウザを映す経路**の両方を確保。**入力切替キーを把握**（Step 1→2 と Step 3b→4 で2回切り替える）。
+- [ ] 表示系: TUIを映す経路と、**ラップトップのブラウザを映す経路**の両方を確保。**入力切替キーを把握**（Step 2〜4 はすべてTUIなので切替は不要。切り替えるのは Step 4→5 でTUIからブラウザへ、Step 5→6 でTUIに戻す1箇所のみ）。
 - [ ] **端末幅を123桁以上にする**（`tput cols` で確認）。これを下回ると Expert フッタから
       `w WebUI` が**無言で消える** — 露出したWebUIを引っ込めるキーが画面から失われる。
       省略記号は出ないので、狭いことに気付けない（→ §9）。
@@ -124,18 +125,23 @@
 
 ### Step 2 — Object cue: Bind（1:10｜Bind, ★cue≠key｜TUI）
 
-> **重要（保管層の分離）:** 本プロジェクトには**2つの保管層が並存している**。
+> **重要（保管層は統一済み）:** WebUI の Store/Retrieve は現在、TUI と同じ Vessel 経路を通る。
 >
 > | 経路 | 操作対象 |
 > |---|---|
-> | TUI `o` Open Vessel | `*.vessel`（Vessel / Face モデル） |
-> | **WebUI Store / Retrieve** | **`vault.bin`（旧レイヤ）** — `web_server.py` の `vault = PhasmidVault("vault.bin")` |
-> | Doctor の Dummy Profile 検査 | `vault.bin` / `.state/dummy_profile`（旧レイヤ、→ #157） |
+> | TUI `o` Open Vessel | `*.vessel`（`VesselWorkflowService`） |
+> | **WebUI Store / Retrieve** | **同じ `*.vessel`**（`resolve_web_vessel()` が解決した Vessel に対し `VesselWorkflowService` を呼ぶ。Vessel 未登録時のみ旧 `vault.bin` にフォールバック） |
+> | Doctor の Dummy Profile 検査 | `vault.bin` / `.state/dummy_profile`（旧レイヤのまま、→ #157） |
 > | TUI Audit / Inspect | `*.vessel` |
 >
-> **WebUI に Vessel 対応の Store/Retrieve は存在しない。** したがって WebUI で保存しても
-> Step 1 で作った Vessel は一切変化せず、Step 4 の Audit にも現れない。
-> **Step 2/3 は必ず TUI で行うこと。**
+> **旧版時点では TUI と WebUI が別レイヤ（`*.vessel` / `vault.bin`）を操作しており、
+> #157 の Doctor 不整合はその名残である。** 現在は統一済みで、WebUI で保存すれば
+> Step 1 で作った Vessel に反映され、Step 4 の Audit にも現れる。
+>
+> それでも **Step 2〜3b は必ず TUI で行うこと。** 理由は保管層が分離しているからではない。
+> 統合経路（WebUIがVesselを操作する現在の動作）を壇上ではまだ実機で通しておらず、
+> Store/Retrieve の判定はどちらの経路でも物体キュー照合に依存するため、CIでは検証できない
+> ——この2点による。
 >
 > 旧版が `f` (Faces) と記載していたのは誤り。Faces 画面はラベルと可信性プロファイルの
 > 管理画面で、カメラに一切関与しない。物体キューを扱うのは `o` Open Vessel の
@@ -185,7 +191,7 @@
 
 ### Step 4 — Audit: plausibility（0:50｜誠実性の可視化｜TUI Expert）
 
-- **操作:** プロジェクタをTUIに戻す。**`e`（Expert）→ `a`（Audit）**。
+- **操作:** **`e`（Expert）→ `a`（Audit）**。
   **`Plausibility Baseline` セクション**を指す。
 - **画面期待:**
   ```
@@ -206,10 +212,10 @@
 
 ### Step 5 — Local WebUI（0:40｜ローカル境界｜WebUI）
 
-> **役割を限定すること。** WebUI の Store/Retrieve は `vault.bin` を操作するので、
-> **ここでファイルを保存したり復元したりしてはいけない。** Step 1〜4 で見せた Vessel と
-> 別の入れ物になり、話が繋がらなくなる。このステップは**「同じ操作面がローカル境界の
-> 内側にも用意されている」ことを見せるだけ**に留める。
+> **役割を限定すること。** WebUI の Store/Retrieve は本編と同じ Vessel を操作するようになったが、
+> **この統合経路は壇上ではまだ実機で通していない**ため、
+> **ここでファイルを保存したり復元したりしてはいけない。** このステップは**「同じ操作面が
+> ローカル境界の内側にも用意されている」ことを見せるだけ**に留める。
 
 - **操作:** TUI で **`w`** を押して起動。プロジェクタをラップトップのブラウザに切替、
   事前に `/unlock` を通しておいたタブを提示。**画面を見せるだけで操作はしない。**
@@ -224,7 +230,7 @@
 
 ### Step 6 — Silent Standby（1:20｜★Disclose 山場｜TUI）
 
-- **操作:** **`Ctrl+S`** を押下。復帰は **`Ctrl+R`** または **`Esc`**。
+- **操作:** プロジェクタをTUIに戻す。**`Ctrl+S`** を押下。復帰は **`Ctrl+R`** または **`Esc`**。
 - **注意（キーの所在）:** `Ctrl+S` はフッタに表示されない設計。**指で覚えておくこと。**
   起動スクリプトが `stty -ixon` を実行しているので、ターミナルのフロー制御（XOFF）に
   食われることはない。**素の起動だと押しても無反応になりうる。**
@@ -267,8 +273,8 @@
   `coercion_safe` の低信頼→ダミー経路を**設計意図として逆手に説明**。
 - **WebUI がラップトップから見えない:** `PHASMID_WEBUI_EXPOSE_GADGET=1` が効いているか、
   URLが **`10.12.194.1:8000`（IP直指定）** かを確認。`127.0.0.1` と `phasmid-pi.local` は
-  ラップトップからは**到達しない**。最悪、Step 2/3 をTUIに落とす
-  （ただし Step 3b の失敗対比だけは必ず見せる）。
+  ラップトップからは**到達しない**。最悪、**Step 5 を口頭説明のみに留めてスキップする**
+  （Step 1〜4・6・7 はWebUIに依存しないため影響を受けない）。
 - **時間超過:** 26:00 到達で Step 4 と Step 5 を飛ばし、**Step 3b と Step 6 だけは必ず見せる**。
 
 ---
@@ -355,23 +361,26 @@ Vessel を作ると **Face が2つ自動生成される**（`face_a` / `face_b`�
 `dummy_file_count` / `dummy_total_size` / plausibility level・score はすべて保持される。
 回帰テスト `test_labelling_a_face_preserves_its_generated_dummy_profile` で固定した。
 
-**保管層が2つ並存している（ソース確認済み）**
+**保管層は Vessel 経路に統一済み（ソース確認済み）**
 
 | 経路 | 操作対象 | 根拠 |
 |---|---|---|
 | TUI `o` Open Vessel（Add/Recover/List/Remove） | `*.vessel` | `VesselWorkflowService` |
 | TUI Audit / Inspect | `*.vessel` | `AuditService` / `InspectionService` |
-| **WebUI Store / Retrieve** | **`vault.bin`** | `web_server.py` の `vault = PhasmidVault("vault.bin")` |
-| **Doctor の Dummy Profile 4件** | **`vault.bin` / `.state/dummy_profile`** | `dummy_container_path()` / `dummy_profile_dir()` |
+| **WebUI Store / Retrieve** | **同じ `*.vessel`**（`resolve_web_vessel()` が解決） | `web_server.py` が `VesselWorkflowService().add_payload` / `.retrieve_payload` を呼ぶ。Vessel 未登録時のみ `vault.bin` にフォールバック |
+| **Doctor の Dummy Profile 4件** | **`vault.bin` / `.state/dummy_profile`（旧レイヤのまま）** | `dummy_container_path()` / `dummy_profile_dir()` |
 
-**WebUI に Vessel 対応の Store/Retrieve は存在しない**（`web_server.py` は
-`VesselWorkflowService` を一切 import していない）。`operator_inspect` は
-アップロードされたファイルを読むだけで、デバイス上の Vessel には触れない。
+`web_server.py` は現在 `VesselWorkflowService` と
+`services/web_target_service.resolve_web_vessel()` を import しており、Store/Retrieve は
+TUI が使うのと同じ Vessel に対して動作する（Vessel が1つも登録されていない場合のみ
+従来どおり `vault.bin` を使う）。`operator_inspect` はアップロードされたファイルを
+読むだけで、デバイス上の Vessel には触れない点は変わらない。
 
-したがって **WebUI で保存しても Vessel は変化せず、Audit にも現れない。**
-デモ本編（Step 1〜4）と WebUI を同じ流れとして見せてはいけない。
-#157 の Doctor 問題も同じ根に由来する — Doctor は「使われていない層」ではなく
-**WebUI が現に使っている層**を見ている。
+**旧版時点では両経路が別レイヤ（TUI=`*.vessel` / WebUI=`vault.bin`）を操作していた。**
+#157 の Doctor 不整合はその名残であり、Doctor は今も「使われていない層」ではなく
+**かつてWebUIが使っていた旧層**を見続けている。現時点でWebUIを本編から外している
+理由は分離ではなく、統合経路を壇上ではまだ実機で通していないことと、Store/Retrieve の
+判定がどちらの経路でも物体キュー照合に依存しCIでは検証できないこと、の2点である。
 
 **物体キューが実際に効いていることの根拠**
 
@@ -379,7 +388,7 @@ Vessel を作ると **Face が2つ自動生成される**（`face_a` / `face_b`�
 `collect_auth_sequence()` → `wait_for_reference_match(timeout=10.0)` で照合する。
 不一致なら `match_none` が返り `ValueError("no bound object matched")` になる。
 一致トークンは `_read_face_namespace` の入力そのものなので、**照合を迂回した復元は
-成立しない。** ただし**TUIはこの過程を一切表示しない**（→ Step 2 を WebUI で行う理由）。
+成立しない。** ただし**TUIはこの過程を一切表示しない**（→ Step 3b の失敗対比が必須である理由）。
 
 **性能実測（Pi Zero 2 W）**
 

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -1,11 +1,12 @@
 # Phasmid — Live Demo 実施細部要領 / Demo Runbook
 
 **対象:** DEF CON Demo Labs 本番の実機デモ（Deck Slide 24）。プレゼン30分のうち**約7分**を割り当て、**Q&A/交流15分を必ず確保**する。
-**画面:** 実TUI（Local Disclosure Control）＋**ローカルWebUI（物体キューの提示に必須）**。
+**画面:** 実TUI（Local Disclosure Control）が本編。ローカルWebUI は Step 5 のローカル境界の提示にのみ使う（保管層が別なので本編には接続しない）。
 
 > **情報の確度について**
 > - **本書は 0.3.0 実機（Pi Zero 2 W / Raspberry Pi OS Trixie）で全手順を通した結果に基づく。** 〔要確認〕は原則として解消済み。実機で確認していない項目のみ §9 末尾に明示する。
-> - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel 系）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。物体キューの提示は **WebUI が主、TUI が従**に変わった。Generate Plausibility は**実測4分のため壇上から外した**。
+> - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel の `Add File`）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。Step 3b（物体なしでの失敗）を新設した。Generate Plausibility は**実測4分のため壇上から外した**。
+> - **保管層が2つ並存している。** TUI は `*.vessel`、WebUI の Store/Retrieve と Doctor の Dummy Profile 検査は `vault.bin`。**混ぜると話が繋がらない**（→ §4 Step 2 の注記）。
 > - **注意:** 0.1.4 までは起動直後が Expert 相当の単層画面だった。それ以前の手順書のキー順は**そのままでは通らない**。
 
 ---
@@ -30,15 +31,18 @@
 |---|---|---|---|---|
 | 0 | オリエンテーション | 0:20 | TUI Simple | TUIホーム提示 |
 | 1 | Vessel 作成（Create） | 0:50 | TUI Simple | Prepare |
-| 2 | 物体キュー登録（Bind） | 1:10 | **WebUI** | Bind（cue≠key） |
-| 3a | 復元 成功（Operate） | 0:40 | **WebUI** | Operate |
-| 3b | **復元 失敗（物体なし）** | 0:40 | **WebUI** | **★cue≠key の証明** |
+| 2 | 物体キュー登録（Bind） | 1:10 | TUI | Bind（cue≠key） |
+| 3a | 復元 成功（Operate） | 0:40 | TUI | Operate |
+| 3b | **復元 失敗（物体なし）** | 0:40 | TUI | **★cue≠key の証明** |
 | 4 | Audit（plausibility） | 0:50 | TUI Expert | 誠実性の可視化 |
-| 5 | Silent Standby | 1:20 | TUI | Disclose / 山場 |
-| 6 | ラップ | 0:10 | TUI Simple | 締め |
+| 5 | WebUI（ローカル境界） | 0:40 | WebUI | ローカル境界 |
+| 6 | Silent Standby | 1:20 | TUI | Disclose / 山場 |
+| 7 | ラップ | 0:10 | TUI Simple | 締め |
 
 > **時計運用:** 開始 ~19:20。**26:00 を超えたら残手順を口頭要約**して締めへ。
-> **旧版との違い:** WebUI 単独ステップ（旧 Step 5）を廃止し Step 2/3 に統合、Step 3b を新設した。
+> **Step 3b は新設。** 物体の有無だけを変えた対比がなければ、cue≠key は実証されない。
+> **Step 2/3 は TUI で行う。** WebUI の Store/Retrieve は Vessel ではなく `vault.bin`
+> を操作するため、Vessel を使うデモ本編には接続しない（§4 Step 2 の注記を参照）。
 
 ---
 
@@ -118,48 +122,62 @@
   `Entropy high / random-like (8.00 bits/byte)` を見せると Slide 19 の直接的裏付けになる。
 - **失敗時:** 作成が滞れば既存デモVesselを **`o` (Open)** して以降を継続。
 
-### Step 2 — Object cue via WebUI（1:10｜Bind, ★cue≠key）
+### Step 2 — Object cue: Bind（1:10｜Bind, ★cue≠key｜TUI）
 
-> **旧版からの変更:** 旧版はこれを `f` (Faces) と記載していたが**誤り**。Faces 画面は
-> ラベルと可信性プロファイルの管理画面で、**カメラに一切関与しない**。物体キューを
-> 扱うのは Open Vessel 系のフロー（`Add File`）である。
-> さらに、TUI には**カメラ映像も一致状態の表示もない**。観客には何も見えない。
-> **WebUI にはライブ映像と一致バッジがある。ここは WebUI で見せる。**
+> **重要（保管層の分離）:** 本プロジェクトには**2つの保管層が並存している**。
+>
+> | 経路 | 操作対象 |
+> |---|---|
+> | TUI `o` Open Vessel | `*.vessel`（Vessel / Face モデル） |
+> | **WebUI Store / Retrieve** | **`vault.bin`（旧レイヤ）** — `web_server.py` の `vault = PhasmidVault("vault.bin")` |
+> | Doctor の Dummy Profile 検査 | `vault.bin` / `.state/dummy_profile`（旧レイヤ、→ #157） |
+> | TUI Audit / Inspect | `*.vessel` |
+>
+> **WebUI に Vessel 対応の Store/Retrieve は存在しない。** したがって WebUI で保存しても
+> Step 1 で作った Vessel は一切変化せず、Step 4 の Audit にも現れない。
+> **Step 2/3 は必ず TUI で行うこと。**
+>
+> 旧版が `f` (Faces) と記載していたのは誤り。Faces 画面はラベルと可信性プロファイルの
+> 管理画面で、カメラに一切関与しない。物体キューを扱うのは `o` Open Vessel の
+> `Add File` である（`capture_reference=True` を渡す唯一の経路）。
 
-- **操作:** TUI で **`w`** を押して WebUI を起動。プロジェクタをラップトップの
-  ブラウザに切替。**Store** 画面へ。ファイルを選び、パスフレーズを入力し、
-  **物体をカメラに提示**。
-- **画面期待:**
-  - **Camera Preview** にライブ映像
-  - 右上の **`objectBadge`** が `Unavailable` → `Detected` → **`Matched`（緑）** と遷移
-  - 一致するとカメラ枠が視覚的に強調される
-- **発話（EN）:** "Now the object cue. I show an everyday object to the camera — you can see exactly what the device sees, and the badge turns green when it has a stable match. Remember: this is a **cue, not a key**. It gates the operation; it is not the encryption key. A photograph of this object unlocks nothing."
-- **注意:** ここが概念の要。**必ず cue≠key を口頭で言い切る。**
+- **操作:** **`o`（Open）** → `Y` → Operation を **`Add File`** に変更
+  （Select はフォーカスして `Enter` → `↓` → `Enter`）→ **Input file** にファイルパス →
+  **Passphrase** と **Restricted recovery passphrase** → **物体をカメラの前に配置** →
+  `Tab` で `Run Operation` → `Enter`。
+- **画面期待:** `Stored N,NNN bytes in travel.vessel.`
+  `VESSEL STATUS` の `Face Files` が増える。
+- **発話（EN）:** "Now the object cue. I hold an everyday object in front of the camera while I store this file. Remember: this is a **cue, not a key**. It gates the operation; it is not the encryption key. A photograph of it unlocks nothing."
+- **注意:** **TUI はカメラ映像も一致状態も表示しない**（→ #158）。この段階では観客に
+  何が起きているか見えない。**だから Step 3b の対比が必須**である。
 - **失敗時:** 認識が不安定なら距離/照明を微調整。起動スクリプトの既定
   `PHASMID_RECOGNITION_MODE=demo` で確定的に見せられる。
-- **TUIで代替する場合:** `o`（Open）→ Operation を **`Add File`** に変更 → 入力ファイル →
-  パスフレーズ2つ → `Run Operation`。**ただし画面には何も表示されない**ので、
-  Step 3b の失敗対比が一層重要になる。
 
-### Step 3a — 復元 成功（0:40｜Operate｜WebUI）
+### Step 3a — 復元 成功（0:40｜Operate｜TUI）
 
-- **操作:** **Retrieve** 画面へ。物体を提示し、バッジが **Matched** になるのを待ってから
-  パスフレーズを入力して実行。
+- **操作:** **`o`（Open）** → `Y` → Operation は **`Recover File`**（既定）→
+  **Output file** にパス → **Passphrase** → **物体をカメラの前に配置** → `Run Operation`。
+- **画面期待:** `Recovered N,NNN bytes to <path>.`（緑）
 - **発話（EN）:** "Same object, correct password — the file comes back."
-- **画面期待:** 復元成功。
 
-### Step 3b — 復元 失敗（0:40｜★cue≠key の証明｜WebUI）
+### Step 3b — 復元 失敗（0:40｜★cue≠key の証明｜TUI）
 
 > **本書で最も重要なステップ。旧版には存在しなかった。**
 > 成功例だけでは物体キューが効いていることを**何も証明していない**。観客には
 > 「パスワードを打ったらファイルが出た」としか見えない。**対比だけが証明になる。**
+> **実機で検証済み**（両側を確認）。
 
 - **操作:** **物体をカメラの視野から外す**（退ける、または手で覆う）。
-  **パスフレーズは全く同じものを入力**して、もう一度 Retrieve を実行。
-- **画面期待:** バッジが **Matched にならない**まま、約10秒後に失敗。
-  TUIで同じことをすると `no bound object matched` のエラーになる。
-- **発話（EN）:** "Same file. Same password. Only the object is gone. The device waits ten seconds for a match, does not get one, and refuses. That is what 'the cue gates the operation' means — and notice it tells you almost nothing about *why* it failed. That is deliberate."
+  **他の項目は一切変えず**、もう一度 `Run Operation`。
+- **画面期待:** 約10秒後、赤で **`Open Vessel / no bound object matched`**。
+  出力ファイルは作られない。
+- **発話（EN）:** "Same file. Same password. Same everything — only the object is gone. The device waits ten seconds for a match, does not get one, and refuses. That is what 'the cue gates the operation' means — and notice it tells you almost nothing about *why* it failed. That is deliberate."
 - **注意:** **ここで間を取る。** これが cue≠key の唯一の実証である。
+  可能なら**この直後に物体を戻して再実行し、成功させる**。
+  失敗→成功の往復まで見せると「壊れたのではない」ことまで示せる。
+- **注意（ロックアウト）:** TUI 経路は失敗を記録しない（`retrieve_file` は
+  `limiter.check()` のみで `record_failure` を呼ばない）ので、**何度失敗させても
+  ロックしない。** WebUI 経路は5回失敗で60秒ロックするため、リハーサルは TUI で行うこと。
 - **技術的裏付け（質問された場合）:** `collect_auth_sequence()` が
   `wait_for_reference_match(timeout=10.0)` を呼び、不一致なら `match_none` を返す。
   この値は復号の入力そのもの（`_read_face_namespace` に渡る）なので、
@@ -186,7 +204,25 @@
 - **注意:** **`d`（Doctor）は開かない。** 上部の `! SYSTEM: 7 WARN — press [d] to review`
   について質問された場合は §6 の答えを使う。
 
-### Step 5 — Silent Standby（1:20｜★Disclose 山場｜TUI）
+### Step 5 — Local WebUI（0:40｜ローカル境界｜WebUI）
+
+> **役割を限定すること。** WebUI の Store/Retrieve は `vault.bin` を操作するので、
+> **ここでファイルを保存したり復元したりしてはいけない。** Step 1〜4 で見せた Vessel と
+> 別の入れ物になり、話が繋がらなくなる。このステップは**「同じ操作面がローカル境界の
+> 内側にも用意されている」ことを見せるだけ**に留める。
+
+- **操作:** TUI で **`w`** を押して起動。プロジェクタをラップトップのブラウザに切替、
+  事前に `/unlock` を通しておいたタブを提示。**画面を見せるだけで操作はしない。**
+- **画面期待:** ブラウザ上部に赤帯
+  `WEBUI ACTIVE — INTERFACE IS EXPOSED — ACCESS FROM TRUSTED NETWORK ONLY`。
+  TUI 側にも `WEBUI ACTIVE AT http://10.12.194.1:8000 - PRESS [w] TO RETRACT`。
+- **発話（EN）:** "The same device also serves a local web interface — bound to loopback by default. Reaching it from a tethered laptop over USB is an explicit opt-in that binds only the USB interface, and it still needs an access token. It never touches a network. Both ends say plainly that the interface is exposed."
+- **注意:** **`w` を押して30秒以内に `Ctrl+S` を押さないこと。** 起動通知には
+  アクセストークンが含まれており、表示中に Standby へ入るとトークンが秘匿画面に残る。
+  修正済みだが、余裕を持って進めること。
+- **失敗時:** 起動が遅ければ口頭説明に留め、TUIへ戻る（時間優先）。
+
+### Step 6 — Silent Standby（1:20｜★Disclose 山場｜TUI）
 
 - **操作:** **`Ctrl+S`** を押下。復帰は **`Ctrl+R`** または **`Esc`**。
 - **注意（キーの所在）:** `Ctrl+S` はフッタに表示されない設計。**指で覚えておくこと。**
@@ -215,7 +251,7 @@
 - **注意:** **本デモの山。** ゆっくり、間を取る。倫理（Slide 21）に接続して締める。
 - **失敗時:** 遷移が出なければ録画の該当箇所を提示。「これが唯一の"魔法に見える"部分。実体はStateマシンです」と補足。
 
-### Step 6 — ラップ（0:10）
+### Step 7 — ラップ（0:10）
 
 - **発話（EN）:** "That's Prepare, Bind, Operate, Disclose — on real hardware. Come try it at the table."
 - **操作:** **`Esc`** で Simple Operator へ戻す。プロジェクタ入力をスライドへ復帰（Slide 25）。
@@ -233,7 +269,7 @@
   URLが **`10.12.194.1:8000`（IP直指定）** かを確認。`127.0.0.1` と `phasmid-pi.local` は
   ラップトップからは**到達しない**。最悪、Step 2/3 をTUIに落とす
   （ただし Step 3b の失敗対比だけは必ず見せる）。
-- **時間超過:** 26:00 到達で Step 4 を飛ばし、**Step 3b と Step 5 だけは必ず見せる**。
+- **時間超過:** 26:00 到達で Step 4 と Step 5 を飛ばし、**Step 3b と Step 6 だけは必ず見せる**。
 
 ---
 
@@ -318,6 +354,24 @@ Vessel を作ると **Face が2つ自動生成される**（`face_a` / `face_b`�
 生成した face に対して `create_face(label=...)` を実行しても、
 `dummy_file_count` / `dummy_total_size` / plausibility level・score はすべて保持される。
 回帰テスト `test_labelling_a_face_preserves_its_generated_dummy_profile` で固定した。
+
+**保管層が2つ並存している（ソース確認済み）**
+
+| 経路 | 操作対象 | 根拠 |
+|---|---|---|
+| TUI `o` Open Vessel（Add/Recover/List/Remove） | `*.vessel` | `VesselWorkflowService` |
+| TUI Audit / Inspect | `*.vessel` | `AuditService` / `InspectionService` |
+| **WebUI Store / Retrieve** | **`vault.bin`** | `web_server.py` の `vault = PhasmidVault("vault.bin")` |
+| **Doctor の Dummy Profile 4件** | **`vault.bin` / `.state/dummy_profile`** | `dummy_container_path()` / `dummy_profile_dir()` |
+
+**WebUI に Vessel 対応の Store/Retrieve は存在しない**（`web_server.py` は
+`VesselWorkflowService` を一切 import していない）。`operator_inspect` は
+アップロードされたファイルを読むだけで、デバイス上の Vessel には触れない。
+
+したがって **WebUI で保存しても Vessel は変化せず、Audit にも現れない。**
+デモ本編（Step 1〜4）と WebUI を同じ流れとして見せてはいけない。
+#157 の Doctor 問題も同じ根に由来する — Doctor は「使われていない層」ではなく
+**WebUI が現に使っている層**を見ている。
 
 **物体キューが実際に効いていることの根拠**
 

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -6,7 +6,7 @@
 > **情報の確度について**
 > - **本書は 0.3.0 実機（Pi Zero 2 W / Raspberry Pi OS Trixie）で全手順を通した結果に基づく。** 〔要確認〕は原則として解消済み。実機で確認していない項目のみ §9 末尾に明示する。
 > - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel の `Add File`）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。Step 3b（物体なしでの失敗）を新設した。Fill Free Space は**実測4分のため壇上から外した**。**囮ファイルは運用者が用意する**ものとし、生成機能は空き領域の填充に位置づけ直した。
-> - **WebUI の Store/Retrieve は Vessel 経路に統一済み。** かつては TUI が `*.vessel`、WebUI が別の `vault.bin` を操作しており話が繋がらなかったが、現在は両者とも `resolve_web_vessel()` が解決した同じ Vessel を `VesselWorkflowService` 経由で操作する（Vessel 未登録時のみ旧 `vault.bin` にフォールバック）。Doctor が旧層 `.state/dummy_profile` を見ていた4項目は削除した（#157）。あのパスはどの操作でも生成されず、警告が永久に消えなかった。
+> - **WebUI の Store/Retrieve は Vessel 経路に統一済み。** かつては TUI が `*.vessel`、WebUI が別の `vault.bin` を操作しており話が繋がらなかったが、現在は両者とも `resolve_web_vessel()` が解決した同じ Vessel を `VesselWorkflowService` 経由で操作する（Vessel 未登録時のみ旧 `vault.bin` にフォールバック）。Doctor の Dummy Profile 助言は既定パスが生成されないため永久に警告していたが、未設定時は警告しないよう変更した（#157）。運用者が自分の素材を指させれば分量を報告する。
 > - **注意:** 0.1.4 までは起動直後が Expert 相当の単層画面だった。それ以前の手順書のキー順は**そのままでは通らない**。
 
 ---
@@ -215,7 +215,7 @@
 - **注意（旧版の誤り）:** 旧版は「**Operator Log の Dummy Profile 指標を指す**」と
   指示していたが、あの4行は Doctor 由来で Vessel を反映しなかった。**該当の検査は
   削除済み**（#157）。可信性ではなく空き領域の話として、**Audit 画面を指すこと。**
-- **任意:** **`d`（Doctor）を開いてよい。** 生成されないパスを見ていた4項目を削除したので、
+- **任意:** **`d`（Doctor）を開いてよい。** 未設定の助言が警告を出さなくなったので、
   残る警告はこのホスト自身の事実だけになった（→ §6）。「ツールが自分の動作環境を
   正直に報告する」実例として使える。
 
@@ -297,12 +297,13 @@ Expert画面の警告は**すべてこのホスト自身についての事実**�
 | 1 | `/tmp` is world-writable | 取り出したファイルが他ユーザーから読める |
 | 2 | Swap active / Compressed swap (zram) enabled | Pi Zero 2 W では実用上有効にしている。無効化すれば消える |
 
-**かつて出ていた Dummy Profile 4件は削除した**（#157）。あれは
-`.state/dummy_profile` を読んでいたが、**このパスはどの操作でも生成されない** —
-参照は全て読み取りで、書き込みうる唯一のモジュールに運用者から到達する入口がない。
-どの端末でも永久に警告のままで、しかも Audit 画面と矛盾していた。
-空き領域の填充は Face 単位の属性であり、Vessel を持たないホスト検査の担当ではない。
-Doctor には Audit を指す INFO 1件（`Free Space Reporting`）だけが残る。
+**かつて出ていた Dummy Profile 4件の警告は解消した**（#157）。この検査は
+`PHASMID_DUMMY_PROFILE_DIR` / `PHASMID_DUMMY_CONTAINER_PATH` で**運用者が
+自分の用意した素材を指させる助言機能**だが（`docs/CONFIGURATION.md`）、既定パスは
+どの操作でも生成されないため、未設定のまま全端末で永久に警告していた。
+未設定時は `not configured` として報告するよう変更した。**検査自体は残っている** —
+運用者が素材を指させば、その**分量**（サイズ・ファイル数・占有率）を報告する。
+**説得力があるかどうかは判定しない。** それは運用者の領分である。
 
 - **発話（EN、質問された場合）:** "It warns about its own host — swap is on, so pages can hit disk, and /tmp is world-writable. It is telling me the truth about an environment it does not control. It used to warn about the quality of a decoy as well; we removed that, because the file you would hand over is one you wrote, and the tool has no way to judge whether it is believable."
 
@@ -389,9 +390,9 @@ TUI が使うのと同じ Vessel に対して動作する（Vessel が1つも登
 読むだけで、デバイス上の Vessel には触れない点は変わらない。
 
 **旧版時点では両経路が別レイヤ（TUI=`*.vessel` / WebUI=`vault.bin`）を操作していた。**
-Doctor が旧層を見ていた4項目は削除済み（#157）。**あのパス `.state/dummy_profile` は
-どの操作でも生成されない** — 参照は全て読み取りで、書き込みうる唯一のモジュールに
-運用者から到達する入口がなく、どの端末でも永久に警告のままだった。
+Doctor の Dummy Profile 助言は既定パス `.state/dummy_profile` を見ており、**そのパスは
+どの操作でも生成されない**ため全端末で永久に警告していた。未設定時は警告しないよう
+変更した（#157）。運用者が `PHASMID_DUMMY_PROFILE_DIR` で自分の素材を指させれば機能する。
 現時点でWebUIを本編から外している理由は保管層の分離ではなく、統合経路を壇上では
 まだ実機で通していないことと、Store/Retrieve の判定がどちらの経路でも物体キュー照合に
 依存しCIでは検証できないこと、の2点である。
@@ -417,8 +418,8 @@ Doctor が旧層を見ていた4項目は削除済み（#157）。**あのパス
 
 **Doctor の baseline（新品状態）**
 
-`run_doctor_checks()`（非TUI、`services/doctor_service.py`）は **23チェック**を返す。
-`.state/dummy_profile` を読んでいた4項目を削除した結果（#157）、警告は**ホスト自身の
+`run_doctor_checks()`（非TUI、`services/doctor_service.py`）は27チェックを返す。
+Dummy Profile 助言が未設定時に警告しなくなった結果（#157）、警告は**ホスト自身の
 事実のみ**になった: `/tmp` world-writable、Swap、Compressed swap の3件（この開発
 コンテナでは1件）。zram と swap を無効化すれば1件まで下がる。
 

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -6,7 +6,7 @@
 > **情報の確度について**
 > - **本書は 0.3.0 実機（Pi Zero 2 W / Raspberry Pi OS Trixie）で全手順を通した結果に基づく。** 〔要確認〕は原則として解消済み。実機で確認していない項目のみ §9 末尾に明示する。
 > - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel の `Add File`）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。Step 3b（物体なしでの失敗）を新設した。Fill Free Space は**実測4分のため壇上から外した**。**囮ファイルは運用者が用意する**ものとし、生成機能は空き領域の填充に位置づけ直した。
-> - **WebUI の Store/Retrieve は Vessel 経路に統一済み。** かつては TUI が `*.vessel`、WebUI が別の `vault.bin` を操作しており話が繋がらなかったが、現在は両者とも `resolve_web_vessel()` が解決した同じ Vessel を `VesselWorkflowService` 経由で操作する（Vessel 未登録時のみ旧 `vault.bin` にフォールバック）。Doctor の Dummy Profile 検査だけは今も旧層 `vault.bin` / `.state/dummy_profile` を見ている（→ #157、§4 Step 2 の注記）。
+> - **WebUI の Store/Retrieve は Vessel 経路に統一済み。** かつては TUI が `*.vessel`、WebUI が別の `vault.bin` を操作しており話が繋がらなかったが、現在は両者とも `resolve_web_vessel()` が解決した同じ Vessel を `VesselWorkflowService` 経由で操作する（Vessel 未登録時のみ旧 `vault.bin` にフォールバック）。Doctor が旧層 `.state/dummy_profile` を見ていた4項目は削除した（#157）。あのパスはどの操作でも生成されず、警告が永久に消えなかった。
 > - **注意:** 0.1.4 までは起動直後が Expert 相当の単層画面だった。それ以前の手順書のキー順は**そのままでは通らない**。
 
 ---
@@ -20,7 +20,6 @@
 | **マウスでボタンを押す** | SSH越しのターミナルではクリックイベントがTextualに届かない。ボタンはフォーカスされるだけで発火しない | **`Tab` / `Shift+Tab` で移動し `Enter`**。全操作をキーボードで行う |
 | **壇上で Fill Free Space を実行** | 64 MiB / 15% で**実測約4分**。枠は1:20 | **事前に埋めておき**、壇上では **Inspect Free Space** のみ |
 | **囮ファイルをツールに作らせる** | 生成される填充物は汎用ファイルであり、開示材料としての真実味がない | **囮は運用者が用意する。** 真のファイルによく似た偽ファイルを自分で保存する |
-| **`d`（Doctor）を開く** | Dummy Profile の4件は旧 `vault.bin` 層を見ており、生成済みでも `0 B / LOW` と報告する。Audit画面と矛盾して見える | 可信性の話は **`a`（Audit）** で行う |
 | **素の `phasmid` で起動** | libcamera のログがTUIを破壊する／WebUIがラップトップから見えない／トークンが毎回変わる／`Ctrl+S` が効かないことがある | **`scripts/pi_zero2w/run_demo_console.sh`** を使う |
 | **成功例だけを見せる** | 物体キューが効いていることの証明にならない。観客にはただのパスワード復号に見える | **物体なしの失敗を必ず見せる**（Step 3b） |
 
@@ -88,7 +87,7 @@
 - [ ] TUIを **Simple Operator 画面**で待機。
 - [ ] **`! SYSTEM: n WARN` は Simple 画面には出ない**（Expert専用）。内容を確認したい場合は
       `e` を押し、**確認後 `Esc` で Simple に戻しておくこと。**
-- [ ] WARN 7件の内訳を把握（→ §6）。質問された場合の答えを用意。
+- [ ] WARN の内訳を把握（→ §6）。すべてホスト自身の事実。質問された場合の答えを用意。
 - [ ] デモ用パスフレーズ／物体プロップを手元に。**実秘匿は使わない**。
 - [ ] Silent Standby は **`Ctrl+S`**（既定）。復帰は **`Ctrl+R`** または **`Esc`**。
       **フッタに出ないので指で覚えておく。**
@@ -140,11 +139,10 @@
 > |---|---|
 > | TUI `o` Open Vessel | `*.vessel`（`VesselWorkflowService`） |
 > | **WebUI Store / Retrieve** | **同じ `*.vessel`**（`resolve_web_vessel()` が解決した Vessel に対し `VesselWorkflowService` を呼ぶ。Vessel 未登録時のみ旧 `vault.bin` にフォールバック） |
-> | Doctor の Dummy Profile 検査 | `vault.bin` / `.state/dummy_profile`（旧レイヤのまま、→ #157） |
 > | TUI Audit / Inspect | `*.vessel` |
 >
-> **旧版時点では TUI と WebUI が別レイヤ（`*.vessel` / `vault.bin`）を操作しており、
-> #157 の Doctor 不整合はその名残である。** 現在は統一済みで、WebUI で保存すれば
+> **旧版時点では TUI と WebUI が別レイヤ（`*.vessel` / `vault.bin`）を操作していた。**
+> 現在は統一済みで、WebUI で保存すれば
 > Step 1 で作った Vessel に反映され、Step 4 の Audit にも現れる。
 >
 > それでも **Step 2〜3b は必ず TUI で行うこと。** 理由は保管層が分離しているからではない。
@@ -215,11 +213,11 @@
   ```
 - **発話（EN）:** "**Audit** reports per face. Note what it does *not* claim: it does not tell me my cover story is convincing. The file I would hand over is one I wrote and stored myself — the tool cannot judge whether it is believable, and it does not pretend to. All it reports here is how much free space is filled, so an otherwise empty container does not read as empty. Judging the cover story is the operator's job, and the tool is honest about that boundary."
 - **注意（旧版の誤り）:** 旧版は「**Operator Log の Dummy Profile 指標を指す**」と
-  指示していたが、**あの4行は Doctor 由来で、Vessel の生成結果を反映しない**
-  （旧 `vault.bin` / `.state/dummy_profile` 層を見ている）。生成済みでも `0 B / LOW` と
-  出るため、読み上げると矛盾が露見する。**必ず Audit 画面を指すこと。**
-- **注意:** **`d`（Doctor）は開かない。** 上部の `! SYSTEM: 7 WARN — press [d] to review`
-  について質問された場合は §6 の答えを使う。
+  指示していたが、あの4行は Doctor 由来で Vessel を反映しなかった。**該当の検査は
+  削除済み**（#157）。可信性ではなく空き領域の話として、**Audit 画面を指すこと。**
+- **任意:** **`d`（Doctor）を開いてよい。** 生成されないパスを見ていた4項目を削除したので、
+  残る警告はこのホスト自身の事実だけになった（→ §6）。「ツールが自分の動作環境を
+  正直に報告する」実例として使える。
 
 ### Step 5 — Local WebUI（0:40｜ローカル境界｜WebUI）
 
@@ -290,19 +288,23 @@
 
 ---
 
-## 6. `! SYSTEM: 7 WARN` の内訳（質問対策）
+## 6. `! SYSTEM: n WARN` の内訳（質疑対策）
 
-Expert画面に出る7件の内訳。**いずれも想定内**である。
+Expert画面の警告は**すべてこのホスト自身についての事実**である。実測（新品状態）:
 
 | 件数 | 内容 | 説明 |
 |---|---|---|
-| 4 | Dummy Profile Size / File Count / Occupancy Ratio / Plausibility | **既知の不整合。** これらは旧 `vault.bin` / `.state/dummy_profile` を検査しており、Vessel の Face に生成した可信性プロファイルを参照しない。Vessel側の実態は Audit 画面（Step 4）が示す |
-| 2 | Swap active / Compressed swap (zram) enabled | ツールが**自ホストを正直に報告**している。無効化すれば消えるが、Pi Zero 2 W では実用上有効にしている |
-| 1 | `/tmp` is world-writable | 同上 |
+| 1 | `/tmp` is world-writable | 取り出したファイルが他ユーザーから読める |
+| 2 | Swap active / Compressed swap (zram) enabled | Pi Zero 2 W では実用上有効にしている。無効化すれば消える |
 
-- **発話（EN、質問された場合）:** "It warns about its own host — swap is on, so pages can hit disk. It's telling me the truth about an environment it doesn't control. Four of those warnings point at a legacy check path we're consolidating; the Vessel-level view is under Audit."
+**かつて出ていた Dummy Profile 4件は削除した**（#157）。あれは
+`.state/dummy_profile` を読んでいたが、**このパスはどの操作でも生成されない** —
+参照は全て読み取りで、書き込みうる唯一のモジュールに運用者から到達する入口がない。
+どの端末でも永久に警告のままで、しかも Audit 画面と矛盾していた。
+空き領域の填充は Face 単位の属性であり、Vessel を持たないホスト検査の担当ではない。
+Doctor には Audit を指す INFO 1件（`Free Space Reporting`）だけが残る。
 
----
+- **発話（EN、質問された場合）:** "It warns about its own host — swap is on, so pages can hit disk, and /tmp is world-writable. It is telling me the truth about an environment it does not control. It used to warn about the quality of a decoy as well; we removed that, because the file you would hand over is one you wrote, and the tool has no way to judge whether it is believable."
 
 ## 7. 安全・運用注意 / Safety
 
@@ -379,7 +381,6 @@ Vessel を作ると **Face が2つ自動生成される**（`face_a` / `face_b`�
 | TUI `o` Open Vessel（Add/Recover/List/Remove） | `*.vessel` | `VesselWorkflowService` |
 | TUI Audit / Inspect | `*.vessel` | `AuditService` / `InspectionService` |
 | **WebUI Store / Retrieve** | **同じ `*.vessel`**（`resolve_web_vessel()` が解決） | `web_server.py` が `VesselWorkflowService().add_payload` / `.retrieve_payload` を呼ぶ。Vessel 未登録時のみ `vault.bin` にフォールバック |
-| **Doctor の Dummy Profile 4件** | **`vault.bin` / `.state/dummy_profile`（旧レイヤのまま）** | `dummy_container_path()` / `dummy_profile_dir()` |
 
 `web_server.py` は現在 `VesselWorkflowService` と
 `services/web_target_service.resolve_web_vessel()` を import しており、Store/Retrieve は
@@ -388,10 +389,12 @@ TUI が使うのと同じ Vessel に対して動作する（Vessel が1つも登
 読むだけで、デバイス上の Vessel には触れない点は変わらない。
 
 **旧版時点では両経路が別レイヤ（TUI=`*.vessel` / WebUI=`vault.bin`）を操作していた。**
-#157 の Doctor 不整合はその名残であり、Doctor は今も「使われていない層」ではなく
-**かつてWebUIが使っていた旧層**を見続けている。現時点でWebUIを本編から外している
-理由は分離ではなく、統合経路を壇上ではまだ実機で通していないことと、Store/Retrieve の
-判定がどちらの経路でも物体キュー照合に依存しCIでは検証できないこと、の2点である。
+Doctor が旧層を見ていた4項目は削除済み（#157）。**あのパス `.state/dummy_profile` は
+どの操作でも生成されない** — 参照は全て読み取りで、書き込みうる唯一のモジュールに
+運用者から到達する入口がなく、どの端末でも永久に警告のままだった。
+現時点でWebUIを本編から外している理由は保管層の分離ではなく、統合経路を壇上では
+まだ実機で通していないことと、Store/Retrieve の判定がどちらの経路でも物体キュー照合に
+依存しCIでは検証できないこと、の2点である。
 
 **物体キューが実際に効いていることの根拠**
 
@@ -414,8 +417,10 @@ TUI が使うのと同じ Vessel に対して動作する（Vessel が1つも登
 
 **Doctor の baseline（新品状態）**
 
-`run_doctor_checks()`（非TUI、`services/doctor_service.py`）は27チェックを返し、
-うち **7 WARN**（内訳は §6）。zram を無効化すれば5件まで下がる。
+`run_doctor_checks()`（非TUI、`services/doctor_service.py`）は **23チェック**を返す。
+`.state/dummy_profile` を読んでいた4項目を削除した結果（#157）、警告は**ホスト自身の
+事実のみ**になった: `/tmp` world-writable、Swap、Compressed swap の3件（この開発
+コンテナでは1件）。zram と swap を無効化すれば1件まで下がる。
 
 **最小端末幅: 123桁**（#160 で確定）
 

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -5,7 +5,7 @@
 
 > **情報の確度について**
 > - **本書は 0.3.0 実機（Pi Zero 2 W / Raspberry Pi OS Trixie）で全手順を通した結果に基づく。** 〔要確認〕は原則として解消済み。実機で確認していない項目のみ §9 末尾に明示する。
-> - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel の `Add File`）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。Step 3b（物体なしでの失敗）を新設した。Generate Plausibility は**実測4分のため壇上から外した**。
+> - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel の `Add File`）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。Step 3b（物体なしでの失敗）を新設した。Fill Free Space は**実測4分のため壇上から外した**。**囮ファイルは運用者が用意する**ものとし、生成機能は空き領域の填充に位置づけ直した。
 > - **WebUI の Store/Retrieve は Vessel 経路に統一済み。** かつては TUI が `*.vessel`、WebUI が別の `vault.bin` を操作しており話が繋がらなかったが、現在は両者とも `resolve_web_vessel()` が解決した同じ Vessel を `VesselWorkflowService` 経由で操作する（Vessel 未登録時のみ旧 `vault.bin` にフォールバック）。Doctor の Dummy Profile 検査だけは今も旧層 `vault.bin` / `.state/dummy_profile` を見ている（→ #157、§4 Step 2 の注記）。
 > - **注意:** 0.1.4 までは起動直後が Expert 相当の単層画面だった。それ以前の手順書のキー順は**そのままでは通らない**。
 
@@ -18,7 +18,8 @@
 | やってはいけない | 理由 | 代わりに |
 |---|---|---|
 | **マウスでボタンを押す** | SSH越しのターミナルではクリックイベントがTextualに届かない。ボタンはフォーカスされるだけで発火しない | **`Tab` / `Shift+Tab` で移動し `Enter`**。全操作をキーボードで行う |
-| **壇上で Generate Plausibility を実行** | 64 MiB / 15% で**実測約4分**。枠は1:20 | **事前生成**しておき、壇上では **Inspect Plausibility** のみ |
+| **壇上で Fill Free Space を実行** | 64 MiB / 15% で**実測約4分**。枠は1:20 | **事前に埋めておき**、壇上では **Inspect Free Space** のみ |
+| **囮ファイルをツールに作らせる** | 生成される填充物は汎用ファイルであり、開示材料としての真実味がない | **囮は運用者が用意する。** 真のファイルによく似た偽ファイルを自分で保存する |
 | **`d`（Doctor）を開く** | Dummy Profile の4件は旧 `vault.bin` 層を見ており、生成済みでも `0 B / LOW` と報告する。Audit画面と矛盾して見える | 可信性の話は **`a`（Audit）** で行う |
 | **素の `phasmid` で起動** | libcamera のログがTUIを破壊する／WebUIがラップトップから見えない／トークンが毎回変わる／`Ctrl+S` が効かないことがある | **`scripts/pi_zero2w/run_demo_console.sh`** を使う |
 | **成功例だけを見せる** | 物体キューが効いていることの証明にならない。観客にはただのパスワード復号に見える | **物体なしの失敗を必ず見せる**（Step 3b） |
@@ -34,7 +35,7 @@
 | 2 | 物体キュー登録（Bind） | 1:10 | TUI | Bind（cue≠key） |
 | 3a | 復元 成功（Operate） | 0:40 | TUI | Operate |
 | 3b | **復元 失敗（物体なし）** | 0:40 | TUI | **★cue≠key の証明** |
-| 4 | Audit（plausibility） | 0:50 | TUI Expert | 誠実性の可視化 |
+| 4 | Audit（空き領域と境界） | 0:50 | TUI Expert | 誠実性の可視化 |
 | 5 | WebUI（ローカル境界） | 0:40 | WebUI | ローカル境界 |
 | 6 | Silent Standby | 1:20 | TUI | Disclose / 山場 |
 | 7 | ラップ | 0:10 | TUI Simple | 締め |
@@ -65,10 +66,17 @@
       `LIBCAMERA_LOG_LEVELS` / `PHASMID_WEBUI_EXPOSE_GADGET` / `PHASMID_WEB_TOKEN` /
       `PHASMID_RECOGNITION_MODE=demo` と `stty -ixon` を設定する。**素の起動では
       デモが成立しない**（→ §0）。
-- [ ] **【重要】Generate Plausibility を事前実行しておく**（約4分）。
-      `e` → `f` → パスフレーズ2つ → `Tab` で Generate → `Enter`。
-      経過時間が表示され画面は固まらない。完了後 `Plausibility Profile` が
-      `Level: HIGH` になっていることを確認。
+- [ ] **【重要】囮ファイルを自分で用意し、開示する Face に保存しておく。**
+      真のファイルによく似た、公開して差し支えない偽ファイルを1つ作る
+      （例: 同種の書式・同程度の分量の下書き）。`o` → `Add File` で
+      **開示用 Face（face_a）** に、**偽ファイル用パスフレーズ**で保存する。
+      **ツールに囮を生成させない。** 生成される填充物は空き領域を埋めるだけで、
+      開示材料にはならない。
+- [ ] 真のファイルを **face_b** に、**真ファイル用パスフレーズ**と
+      **破壊用パスフレーズ**で保存しておく。用意するパスフレーズは3つ:
+      真の復号用・真の破壊用・偽の復号用。
+- [ ] （任意）**Fill Free Space を事前実行**（約4分）。空き領域を埋め、
+      容器が不自然に空でないようにする。経過時間が表示され画面は固まらない。
 - [ ] ラップトップのブラウザで `http://10.12.194.1:8000/unlock` を開き、
       トークン（既定 `phasmid-demo-token`）を入力して**Homeまで進めた状態でタブを用意**。
       ※ `phasmid-pi.local` は使わない。**IPアドレス直指定**。
@@ -90,8 +98,9 @@
 ## 3. 初期状態 & リセット / Initial state & reset
 
 - **初期状態:** Simple Operator 画面。Vessels は空（`No protected storage found.`）。
-- **可信性プロファイル:** **事前生成済みの Vessel を別途用意しておく。** Step 1 で作る
-  Vessel は空のままでよく、Step 4 では生成済みの方を見せる。**壇上で生成しないこと。**
+- **囮と真のファイル:** **運用者が用意した2ファイルを保存済みの Vessel を別途用意しておく。**
+  Step 1 で作る Vessel は空のままでよく、Step 2〜4 では準備済みの方を使う。
+  **囮をツールに生成させないこと。壇上で空き領域の填充も実行しないこと。**
 - **各サイクル後リセット:** §8 を実施。
 
 ---
@@ -189,20 +198,22 @@
   この値は復号の入力そのもの（`_read_face_namespace` に渡る）なので、
   **照合を迂回して復元することはできない。**
 
-### Step 4 — Audit: plausibility（0:50｜誠実性の可視化｜TUI Expert）
+### Step 4 — Audit: 空き領域と、ツールが判定しないこと（0:50｜誠実性の可視化｜TUI Expert）
 
 - **操作:** **`e`（Expert）→ `a`（Audit）**。
-  **`Plausibility Baseline` セクション**を指す。
+  **`Free Space Filler` セクション**を指す。
 - **画面期待:**
   ```
-  Plausibility Baseline
-    Tracked Vessels        1
-    Tracked Faces          2
-    High baseline faces    1
-    Medium baseline faces  0
-    Low baseline faces     1
+  Free Space Filler
+    Tracked Vessels                     1
+    Tracked Faces                       2
+    Faces with free space filled        1
+    Faces partially filled              0
+    Faces with little or no filler      1
+    Disclosure material                 operator-supplied; filler is not
+                                        disclosure material
   ```
-- **発話（EN）:** "**Audit** scores each face independently. One face has a high-plausibility decoy profile; the other is still weak, and the tool says so rather than letting me believe otherwise. If the decoy isn't plausible, you should know before you need it."
+- **発話（EN）:** "**Audit** reports per face. Note what it does *not* claim: it does not tell me my cover story is convincing. The file I would hand over is one I wrote and stored myself — the tool cannot judge whether it is believable, and it does not pretend to. All it reports here is how much free space is filled, so an otherwise empty container does not read as empty. Judging the cover story is the operator's job, and the tool is honest about that boundary."
 - **注意（旧版の誤り）:** 旧版は「**Operator Log の Dummy Profile 指標を指す**」と
   指示していたが、**あの4行は Doctor 由来で、Vessel の生成結果を反映しない**
   （旧 `vault.bin` / `.state/dummy_profile` 層を見ている）。生成済みでも `0 B / LOW` と
@@ -310,8 +321,8 @@ Expert画面に出る7件の内訳。**いずれも想定内**である。
 ## 8. 終了後リセット / Teardown（次サイクル・次回のため）
 
 - [ ] デモVesselを削除/初期化。
-- [ ] **次サイクル用に Plausibility を再生成（約4分）。** サイクル間に時間がない場合は、
-      生成済みVesselを複数用意しておき差し替える。
+- [ ] **次サイクル用に囮ファイルを保存し直す。** 空き領域の填充（約4分）まで戻す場合は、
+      填充済みVesselを複数用意しておき差し替える。
 - [ ] Silent Standby を `active` に復帰（`Ctrl+R`）。
 - [ ] WebUIプロセス停止（`w`、またはinactivity auto-kill 10分待機）。
 - [ ] ブラウザタブを `/unlock` 済みの状態に戻す。
@@ -394,7 +405,7 @@ TUI が使うのと同じ Vessel に対して動作する（Vessel が1つも登
 
 | 操作 | 実測 |
 |---|---|
-| Generate Plausibility（64 MiB / 15% ≒ 9.6 MB） | **約4分** |
+| Fill Free Space（64 MiB / 15% ≒ 9.6 MB） | **約4分** |
 | カメラ初期化（libcamera / imx708） | 約0.6秒 |
 | 物体照合タイムアウト | 10秒（`collect_auth_sequence`） |
 | Textual アイドル時CPU | 約20〜25%（画面フォーカス時 約50%） |

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -207,6 +207,10 @@
 - **WebUI も同時に落ちる。** ラップトップのブラウザを再読込すると接続が切れていることを
   見せられる（**これを演出に使う**）。復帰後に
   「WebUI was retracted when standby engaged.」の通知が出る。
+- **Standby 発動時に未消化のトースト通知も消える。** WebUI 起動時の通知は30秒表示で、
+  本文に**アクセスURLとトークンが入っている**。これを消さないと、秘匿画面のはずの
+  Standby 画面にトークンが平文で残る。実機で一度再現し、修正済み。
+  Standby 画面のフッタから `w WebUI` も消える（封緘中に再露出させないため）。
 - **発話（EN）:** "Now the moment it's built for. One hotkey — **Silent Standby**. The sensitive surface drops away. And it is not just this screen: the web interface goes down with it, so a laptop tethered to this device loses access at the same instant. Recovery needs re-authentication. I'm not hiding from forensics — I'm buying **time** and **uncertainty**."
 - **注意:** **本デモの山。** ゆっくり、間を取る。倫理（Slide 21）に接続して締める。
 - **失敗時:** 遷移が出なければ録画の該当箇所を提示。「これが唯一の"魔法に見える"部分。実体はStateマシンです」と補足。

--- a/src/phasmid/cli.py
+++ b/src/phasmid/cli.py
@@ -523,14 +523,14 @@ def _build_tui_parser() -> argparse.ArgumentParser:
 
     plausibility_cmd = "dum" + "my"
     plausibility_p = subparsers.add_parser(
-        plausibility_cmd, help="Manage plausibility baseline content"
+        plausibility_cmd, help="Manage free-space filler for a Face"
     )
     plausibility_subparsers = plausibility_p.add_subparsers(
         dest="plausibility_command",
         metavar="plausibility_command",
     )
     plausibility_generate_p = plausibility_subparsers.add_parser(
-        "generate", help="Generate plausibility baseline files for a Face"
+        "generate", help="Fill a Face's free space with filler"
     )
     plausibility_generate_p.add_argument("vessel", help="Path to Vessel file")
     plausibility_generate_p.add_argument("--face", default="face_a", help="Face id")
@@ -540,7 +540,7 @@ def _build_tui_parser() -> argparse.ArgumentParser:
     plausibility_generate_p.add_argument("--restricted-passphrase-file")
 
     plausibility_inspect_p = plausibility_subparsers.add_parser(
-        "inspect", help="Inspect plausibility baseline metadata for a Face"
+        "inspect", help="Inspect free-space filler metadata for a Face"
     )
     plausibility_inspect_p.add_argument("vessel", help="Path to Vessel file")
     plausibility_inspect_p.add_argument("--face", default="face_a", help="Face id")

--- a/src/phasmid/services/audit_service.py
+++ b/src/phasmid/services/audit_service.py
@@ -57,13 +57,17 @@ def build_audit_report() -> AuditReport:
                 ],
             ),
             AuditSection(
-                title="Plausibility Baseline",
+                title="Free Space Filler",
                 entries=[
                     AuditEntry("Tracked Vessels", str(len(vessels))),
                     AuditEntry("Tracked Faces", str(tracked_faces)),
-                    AuditEntry("High baseline faces", str(high)),
-                    AuditEntry("Medium baseline faces", str(medium)),
-                    AuditEntry("Low baseline faces", str(low)),
+                    AuditEntry("Faces with free space filled", str(high)),
+                    AuditEntry("Faces partially filled", str(medium)),
+                    AuditEntry("Faces with little or no filler", str(low)),
+                    AuditEntry(
+                        "Disclosure material",
+                        "operator-supplied; filler is not disclosure material",
+                    ),
                 ],
             ),
             AuditSection(

--- a/src/phasmid/services/doctor_service.py
+++ b/src/phasmid/services/doctor_service.py
@@ -13,14 +13,8 @@ from pathlib import Path
 from ..config import (
     debug_enabled,
     doctor_recent_seconds,
-    dummy_container_path,
-    dummy_min_file_count,
-    dummy_min_size_mb,
-    dummy_occupancy_warn,
-    dummy_profile_dir,
     state_dir,
 )
-from ..dummy_profile_eval import evaluate_dummy_profile, human_bytes
 from ..luks_layer import LuksConfig, LuksLayer, LuksMode
 from ..models.doctor import DoctorCheck, DoctorLevel, DoctorResult
 from ..process_hardening import hardening_status
@@ -647,66 +641,31 @@ def _check_luks_statuses() -> list[DoctorCheck]:
     return checks
 
 
-def _check_dummy_profile_plausibility() -> list[DoctorCheck]:
-    evaluation = evaluate_dummy_profile(
-        dummy_profile_dir=dummy_profile_dir(),
-        container_path=dummy_container_path(),
-        min_size_mb=dummy_min_size_mb(),
-        min_file_count=dummy_min_file_count(),
-        occupancy_warn_threshold=dummy_occupancy_warn(),
-    )
-    warning_level = DoctorLevel.WARN if evaluation.warnings else DoctorLevel.OK
-    ratio_pct = evaluation.occupancy_ratio * 100.0
+def _check_disclosure_reporting_location() -> list[DoctorCheck]:
+    """Point at where free-space reporting actually lives.
 
-    checks = [
+    Four checks used to report a filler profile here. They read
+    ``.state/dummy_profile``, which nothing writes - every reference to it in
+    the tree is a reader, and the one module that could populate it has no
+    operator-reachable entry point. They could not pass on any device, and
+    they contradicted the Audit screen, which reads the Vessel and is correct.
+
+    Free-space filler is a per-Vessel, per-face property. This is a host
+    check with no Vessel context, so it reports where to look instead of
+    reporting a number it cannot obtain.
+    """
+    return [
         DoctorCheck(
-            name="Dummy Profile Size",
-            level=warning_level,
-            message=(
-                f"dummy profile size: {human_bytes(evaluation.dummy_size_bytes)}; "
-                f"container size: {human_bytes(evaluation.container_size_bytes)}"
-            ),
-        ),
-        DoctorCheck(
-            name="Dummy Profile File Count",
-            level=warning_level,
-            message=f"dummy profile file count: {evaluation.file_count}",
-        ),
-        DoctorCheck(
-            name="Dummy Profile Occupancy Ratio",
-            level=warning_level,
-            message=f"occupancy ratio: {ratio_pct:.2f}%",
-        ),
-        DoctorCheck(
-            name="Dummy Profile Size Distribution",
+            name="Free Space Reporting",
             level=DoctorLevel.INFO,
-            message=(
-                "file size distribution: "
-                f"min={human_bytes(evaluation.min_file_size)}, "
-                f"p50={human_bytes(evaluation.p50_file_size)}, "
-                f"max={human_bytes(evaluation.max_file_size)}"
+            message="Free space filler is reported per Face under Audit",
+            detail=(
+                "This check covers the host. Material disclosed under "
+                "pressure is supplied by the operator and is not assessed "
+                "here or anywhere else."
             ),
-        ),
+        )
     ]
-    if evaluation.warnings:
-        checks.append(
-            DoctorCheck(
-                name="Dummy Profile Plausibility",
-                level=DoctorLevel.WARN,
-                message="Dummy profile plausibility assessment: LOW",
-                detail="; ".join(evaluation.warnings),
-            )
-        )
-    else:
-        checks.append(
-            DoctorCheck(
-                name="Dummy Profile Plausibility",
-                level=DoctorLevel.OK,
-                message="Dummy profile plausibility assessment: baseline thresholds met",
-                detail="Operational plausibility is advisory, not a technical guarantee.",
-            )
-        )
-    return checks
 
 
 def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
@@ -729,7 +688,7 @@ def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
     ]
 
     checks += _check_luks_statuses()
-    checks += _check_dummy_profile_plausibility()
+    checks += _check_disclosure_reporting_location()
 
     checks += [
         _check_process_hardening(),

--- a/src/phasmid/services/doctor_service.py
+++ b/src/phasmid/services/doctor_service.py
@@ -13,8 +13,14 @@ from pathlib import Path
 from ..config import (
     debug_enabled,
     doctor_recent_seconds,
+    dummy_container_path,
+    dummy_min_file_count,
+    dummy_min_size_mb,
+    dummy_occupancy_warn,
+    dummy_profile_dir,
     state_dir,
 )
+from ..dummy_profile_eval import evaluate_dummy_profile, human_bytes
 from ..luks_layer import LuksConfig, LuksLayer, LuksMode
 from ..models.doctor import DoctorCheck, DoctorLevel, DoctorResult
 from ..process_hardening import hardening_status
@@ -641,31 +647,106 @@ def _check_luks_statuses() -> list[DoctorCheck]:
     return checks
 
 
-def _check_disclosure_reporting_location() -> list[DoctorCheck]:
-    """Point at where free-space reporting actually lives.
+def _check_dummy_profile_plausibility() -> list[DoctorCheck]:
+    """Advisory over material the operator points this at.
 
-    Four checks used to report a filler profile here. They read
-    ``.state/dummy_profile``, which nothing writes - every reference to it in
-    the tree is a reader, and the one module that could populate it has no
-    operator-reachable entry point. They could not pass on any device, and
-    they contradicted the Audit screen, which reads the Vessel and is correct.
+    PHASMID_DUMMY_PROFILE_DIR and PHASMID_DUMMY_CONTAINER_PATH are operator
+    settings (docs/CONFIGURATION.md). Pointed at material the operator
+    prepared, these report its volume - size, file count, occupancy against
+    the container - which is worth knowing before relying on it.
 
-    Free-space filler is a per-Vessel, per-face property. This is a host
-    check with no Vessel context, so it reports where to look instead of
-    reporting a number it cannot obtain.
+    Left at their defaults they point at paths no operation writes, so every
+    check warned on every device forever and the warnings could not be acted
+    on. Unconfigured now reports "not configured" rather than a deficiency:
+    an advisory nobody asked for is not a finding.
+
+    Volume is all this measures. Whether the material is convincing is not
+    something the tool can judge, and it does not claim to.
     """
-    return [
+    profile_dir = Path(dummy_profile_dir())
+    container = Path(dummy_container_path())
+    if not profile_dir.exists() and not container.exists():
+        return [
+            DoctorCheck(
+                name=name,
+                level=DoctorLevel.INFO,
+                message="not configured",
+                detail=(
+                    "Set PHASMID_DUMMY_PROFILE_DIR and "
+                    "PHASMID_DUMMY_CONTAINER_PATH to have this advisory "
+                    "report on material you prepared. Material disclosed "
+                    "under pressure is supplied by the operator; this checks "
+                    "its volume, not whether it is convincing."
+                ),
+            )
+            for name in (
+                "Dummy Profile Size",
+                "Dummy Profile File Count",
+                "Dummy Profile Occupancy Ratio",
+                "Dummy Profile Size Distribution",
+                "Dummy Profile Plausibility",
+            )
+        ]
+
+    evaluation = evaluate_dummy_profile(
+        dummy_profile_dir=dummy_profile_dir(),
+        container_path=dummy_container_path(),
+        min_size_mb=dummy_min_size_mb(),
+        min_file_count=dummy_min_file_count(),
+        occupancy_warn_threshold=dummy_occupancy_warn(),
+    )
+    warning_level = DoctorLevel.WARN if evaluation.warnings else DoctorLevel.OK
+    ratio_pct = evaluation.occupancy_ratio * 100.0
+
+    checks = [
         DoctorCheck(
-            name="Free Space Reporting",
-            level=DoctorLevel.INFO,
-            message="Free space filler is reported per Face under Audit",
-            detail=(
-                "This check covers the host. Material disclosed under "
-                "pressure is supplied by the operator and is not assessed "
-                "here or anywhere else."
+            name="Dummy Profile Size",
+            level=warning_level,
+            message=(
+                f"dummy profile size: {human_bytes(evaluation.dummy_size_bytes)}; "
+                f"container size: {human_bytes(evaluation.container_size_bytes)}"
             ),
-        )
+        ),
+        DoctorCheck(
+            name="Dummy Profile File Count",
+            level=warning_level,
+            message=f"dummy profile file count: {evaluation.file_count}",
+        ),
+        DoctorCheck(
+            name="Dummy Profile Occupancy Ratio",
+            level=warning_level,
+            message=f"occupancy ratio: {ratio_pct:.2f}%",
+        ),
+        DoctorCheck(
+            name="Dummy Profile Size Distribution",
+            level=DoctorLevel.INFO,
+            message=(
+                "file size distribution: "
+                f"min={human_bytes(evaluation.min_file_size)}, "
+                f"p50={human_bytes(evaluation.p50_file_size)}, "
+                f"max={human_bytes(evaluation.max_file_size)}"
+            ),
+        ),
     ]
+    if evaluation.warnings:
+        checks.append(
+            DoctorCheck(
+                name="Dummy Profile Plausibility",
+                level=DoctorLevel.WARN,
+                message="Prepared material is below the configured volume thresholds",
+                detail="; ".join(evaluation.warnings),
+            )
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                name="Dummy Profile Plausibility",
+                level=DoctorLevel.OK,
+                message="Prepared material meets the configured volume thresholds",
+                detail="Volume only. Whether the material is convincing is not assessed here.",
+            )
+        )
+    return checks
 
 
 def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
@@ -688,7 +769,7 @@ def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
     ]
 
     checks += _check_luks_statuses()
-    checks += _check_disclosure_reporting_location()
+    checks += _check_dummy_profile_plausibility()
 
     checks += [
         _check_process_hardening(),

--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -699,12 +699,12 @@ class VesselWorkflowService:
 
     def _recommended_action(self, profile: DummyProfileMeta) -> str:
         if profile.plausibility_level == "HIGH":
-            return "Baseline profile is credible. Periodically refresh file mix."
+            return "Free space is filled. The file you disclose is still one you store yourself."
         if profile.plausibility_level == "MEDIUM":
             return (
                 "Add more size variation or increase occupancy for a stronger baseline."
             )
-        return "Generate a broader local baseline before field use."
+        return "Free space is largely empty. Filling it is optional; the file you disclose is one you store yourself."
 
     def _read_face_namespace(
         self,

--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -817,11 +817,55 @@ class VesselWorkflowService:
         no_object_binding: bool = False,
         emergency_password: str | None = None,
     ) -> StorePayloadResult:
-        vessel = Path(vessel_path).expanduser().resolve()
         payload_path = Path(input_path).expanduser().resolve()
-        mode = self.resolve_mode(selector)
         if not payload_path.is_file():
             raise FileNotFoundError(f"input file not found: {payload_path}")
+        result = self.add_payload(
+            vessel_path,
+            payload_path.name,
+            payload_path.read_bytes(),
+            open_passphrase,
+            restricted_passphrase=restricted_passphrase,
+            selector=selector,
+            cue_sequence=cue_sequence,
+            capture_reference=capture_reference,
+            object_image_path=object_image_path,
+            camera_object=camera_object,
+            no_object_binding=no_object_binding,
+            emergency_password=emergency_password,
+        )
+        return StorePayloadResult(
+            vessel_path=result.vessel_path,
+            input_path=payload_path,
+            bytes_stored=result.bytes_stored,
+            mode=result.mode,
+        )
+
+    def add_payload(
+        self,
+        vessel_path: str | Path,
+        filename: str,
+        payload: bytes,
+        open_passphrase: str,
+        restricted_passphrase: str | None = None,
+        selector: str = "face_a",
+        cue_sequence: list[str] | None = None,
+        capture_reference: bool = False,
+        object_image_path: str | None = None,
+        camera_object: bool = False,
+        no_object_binding: bool = False,
+        emergency_password: str | None = None,
+    ) -> StorePayloadResult:
+        """Store bytes already in memory into a Vessel face.
+
+        Same path as :meth:`add_file` - object binding, face namespace and
+        all - for callers that never had the payload on disk. The WebUI
+        receives uploads as bytes, and writing them to a temporary file just
+        to hand back a path would put plaintext on disk for no reason.
+        """
+        vessel = Path(vessel_path).expanduser().resolve()
+        name = Path(filename).name or "payload.bin"
+        mode = self.resolve_mode(selector)
         if not vessel.exists():
             raise FileNotFoundError(f"vessel file not found: {vessel}")
 
@@ -861,8 +905,7 @@ class VesselWorkflowService:
         if not isinstance(files, dict):
             raise ValueError("face namespace is invalid")
 
-        payload = payload_path.read_bytes()
-        files[payload_path.name] = {
+        files[name] = {
             "data_b64": base64.b64encode(payload).decode("ascii"),
             "size": len(payload),
             "added_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -891,7 +934,7 @@ class VesselWorkflowService:
         )
         return StorePayloadResult(
             vessel_path=vessel,
-            input_path=payload_path,
+            input_path=Path(name),
             bytes_stored=len(payload),
             mode=mode,
         )
@@ -1256,6 +1299,39 @@ class VesselWorkflowService:
             emergency_password=emergency_password,
         )
 
+    def retrieve_payload(
+        self,
+        vessel_path: str | Path,
+        open_passphrase: str,
+        selector: str | None = None,
+        cue_sequence: list[str] | None = None,
+        use_attempt_limiter: bool = False,
+        object_image_path: str | None = None,
+        camera_object: bool = False,
+        no_object_binding: bool = False,
+    ) -> tuple[bytes, RetrievePayloadResult]:
+        """Recover a stored payload as bytes, without writing it to disk.
+
+        Same path as :meth:`retrieve_file` including the object-cue check.
+        The bytes are returned alongside the result rather than carried on
+        it, so a plaintext payload never ends up in the dataclass repr that
+        the CLI and the operator log print.
+        """
+        collected: dict[str, bytes] = {}
+        result = self.retrieve_file(
+            vessel_path,
+            open_passphrase,
+            output_path=None,
+            selector=selector,
+            cue_sequence=cue_sequence,
+            use_attempt_limiter=use_attempt_limiter,
+            object_image_path=object_image_path,
+            camera_object=camera_object,
+            no_object_binding=no_object_binding,
+            _payload_sink=collected,
+        )
+        return collected.get("data", b""), result
+
     def retrieve_file(
         self,
         vessel_path: str | Path,
@@ -1267,6 +1343,7 @@ class VesselWorkflowService:
         object_image_path: str | None = None,
         camera_object: bool = False,
         no_object_binding: bool = False,
+        _payload_sink: dict[str, bytes] | None = None,
     ) -> RetrievePayloadResult:
         vessel = Path(vessel_path).expanduser().resolve()
         if not vessel.exists():
@@ -1357,6 +1434,8 @@ class VesselWorkflowService:
         if not isinstance(item, dict):
             raise ValueError("stored file metadata is invalid")
         data = base64.b64decode(str(item.get("data_b64", "")).encode("ascii"))
+        if _payload_sink is not None:
+            _payload_sink["data"] = data
         filename = chosen.name
         password_role = PhasmidVault.OPEN_ROLE
         accessed_mode = self.resolve_mode(accessed_selector)

--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -703,6 +703,10 @@ class VesselWorkflowService:
         selector: str,
         cue_sequence: list[str],
     ) -> tuple[dict[str, object], str | None]:
+        # Deliberately open-slot only. The restricted recovery passphrase is a
+        # destroy credential in this layer, not a retrieval one, and
+        # test_emergency_password_does_not_trigger_normal_list_or_retrieve
+        # pins that: reading with it must fail rather than disclose.
         mode = self.resolve_mode(selector)
         face_id = self.resolve_face_id(selector)
         vault = PhasmidVault(
@@ -818,8 +822,17 @@ class VesselWorkflowService:
         emergency_password: str | None = None,
     ) -> StorePayloadResult:
         payload_path = Path(input_path).expanduser().resolve()
+        # Validate before reading. Delegating with payload_path.read_bytes()
+        # as an argument would pull the plaintext into memory before the
+        # selector, the Vessel and the object binding had been checked, so a
+        # call that was always going to fail would still have loaded it.
         if not payload_path.is_file():
             raise FileNotFoundError(f"input file not found: {payload_path}")
+        self.resolve_mode(selector)
+        if not Path(vessel_path).expanduser().resolve().exists():
+            raise FileNotFoundError(
+                f"vessel file not found: {Path(vessel_path).expanduser().resolve()}"
+            )
         result = self.add_payload(
             vessel_path,
             payload_path.name,
@@ -1309,6 +1322,7 @@ class VesselWorkflowService:
         object_image_path: str | None = None,
         camera_object: bool = False,
         no_object_binding: bool = False,
+        filename: str | None = None,
     ) -> tuple[bytes, RetrievePayloadResult]:
         """Recover a stored payload as bytes, without writing it to disk.
 
@@ -1328,6 +1342,7 @@ class VesselWorkflowService:
             object_image_path=object_image_path,
             camera_object=camera_object,
             no_object_binding=no_object_binding,
+            filename=filename,
             _payload_sink=collected,
         )
         return collected.get("data", b""), result
@@ -1343,6 +1358,7 @@ class VesselWorkflowService:
         object_image_path: str | None = None,
         camera_object: bool = False,
         no_object_binding: bool = False,
+        filename: str | None = None,
         _payload_sink: dict[str, bytes] | None = None,
     ) -> RetrievePayloadResult:
         vessel = Path(vessel_path).expanduser().resolve()
@@ -1420,9 +1436,15 @@ class VesselWorkflowService:
         files = self._namespace_file_records(namespace)
         if not files:
             raise FileNotFoundError("no file is stored in the selected face")
-        chosen = files[0]
-        if output_path is not None:
-            desired_name = Path(output_path).name
+        # A face holds many files, so "which one" has to be decided. Named
+        # selection first, then the output filename, and otherwise the most
+        # recently stored. Falling back to the alphabetically first record
+        # made every later store unreachable for callers that name neither -
+        # the WebUI names neither, so a second upload to the same entry
+        # silently became unretrievable through the interface that wrote it.
+        chosen = max(files, key=lambda record: (record.added_at, record.name))
+        desired_name = filename or (Path(output_path).name if output_path else "")
+        if desired_name:
             chosen = next(
                 (record for record in files if record.name == desired_name),
                 chosen,

--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -1442,9 +1442,32 @@ class VesselWorkflowService:
         # made every later store unreachable for callers that name neither -
         # the WebUI names neither, so a second upload to the same entry
         # silently became unretrievable through the interface that wrote it.
-        chosen = max(files, key=lambda record: (record.added_at, record.name))
-        desired_name = filename or (Path(output_path).name if output_path else "")
-        if desired_name:
+        # Generated plausibility filler shares the face and is written with the
+        # same timestamp format, so a profile generated after a real upload
+        # would otherwise win "most recent" and be handed back in its place.
+        raw_files_for_origin = namespace.get("files", {})
+        operator_files = [
+            record
+            for record in files
+            if not (
+                isinstance(raw_files_for_origin, dict)
+                and isinstance(raw_files_for_origin.get(record.name), dict)
+                and raw_files_for_origin[record.name].get("origin")
+                == _GENERATED_PLAUSIBILITY_ORIGIN
+            )
+        ] or files
+        chosen = max(operator_files, key=lambda record: (record.added_at, record.name))
+        if filename:
+            # An explicit request names one file. Quietly substituting another
+            # would hand back content the caller did not ask for.
+            match = next((record for record in files if record.name == filename), None)
+            if match is None:
+                raise FileNotFoundError(f"no stored file named {filename}")
+            chosen = match
+        elif output_path is not None:
+            # The output name is a hint, not a request: recovering README.md
+            # to recovered.md is ordinary usage, so a miss falls back.
+            desired_name = Path(output_path).name
             chosen = next(
                 (record for record in files if record.name == desired_name),
                 chosen,

--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -501,6 +501,16 @@ class VesselWorkflowService:
             )
         return sorted(records, key=lambda record: record.name)
 
+    def _next_store_seq(self, files: dict[str, object]) -> int:
+        highest = 0
+        for item in files.values():
+            if isinstance(item, dict):
+                try:
+                    highest = max(highest, int(item.get("store_seq", 0)))
+                except (TypeError, ValueError):
+                    continue
+        return highest + 1
+
     def _current_timestamp(self) -> str:
         return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
@@ -923,6 +933,11 @@ class VesselWorkflowService:
             "size": len(payload),
             "added_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "origin": "manual",
+            # added_at has one-second granularity, so two stores in the same
+            # second tie and the tie-break falls back to the name - which is
+            # the alphabetical ordering this selection exists to avoid. A
+            # counter makes "most recent" mean what it says.
+            "store_seq": self._next_store_seq(files),
         }
         if emergency_password is None:
             emergency_password = restricted_passphrase
@@ -1134,6 +1149,15 @@ class VesselWorkflowService:
         specs = self._build_generated_file_specs(target_bytes)
         max_payload = self.plaintext_capacity(vessel, selector)
         for filename, payload in specs:
+            existing = files.get(filename)
+            if (
+                isinstance(existing, dict)
+                and str(existing.get("origin", "")) != _GENERATED_PLAUSIBILITY_ORIGIN
+            ):
+                # Filler names are drawn from a fixed pool, so one can collide
+                # with a file the operator stored. Overwriting it would destroy
+                # real content as a side effect of building a decoy.
+                continue
             files[filename] = self._generated_entry(filename, payload)
             encoded, _namespace_name = self._encode_namespace(namespace)
             if len(encoded) > max_payload:
@@ -1456,7 +1480,22 @@ class VesselWorkflowService:
                 == _GENERATED_PLAUSIBILITY_ORIGIN
             )
         ] or files
-        chosen = max(operator_files, key=lambda record: (record.added_at, record.name))
+
+        def _store_order(record: FaceFileRecord) -> tuple[str, int, str]:
+            entry = (
+                raw_files_for_origin.get(record.name)
+                if isinstance(raw_files_for_origin, dict)
+                else None
+            )
+            seq = 0
+            if isinstance(entry, dict):
+                try:
+                    seq = int(entry.get("store_seq", 0))
+                except (TypeError, ValueError):
+                    seq = 0
+            return (record.added_at, seq, record.name)
+
+        chosen = max(operator_files, key=_store_order)
         if filename:
             # An explicit request names one file. Quietly substituting another
             # would hand back content the caller did not ask for.

--- a/src/phasmid/services/web_target_service.py
+++ b/src/phasmid/services/web_target_service.py
@@ -76,6 +76,51 @@ def resolve_web_container(fallback: PhasmidVault) -> PhasmidVault:
         return fallback
 
 
+def forget_face_contents(mode: str | None = None) -> None:
+    """Reset registry metadata after a container-level destructive operation.
+
+    Purge, clear and re-initialise rewrite raw container bytes; they know
+    nothing about the registry, which keeps file counts, occupancy, the
+    plausibility profile and the credentials flag per face. Left untouched
+    those figures survive the data they describe, so the console would go on
+    reporting stored files and a high-plausibility profile for a face whose
+    bytes are gone - the operator would believe a clear had not taken
+    effect, or that data still existed to disclose.
+
+    Passing a mode resets only the face that maps to it; omitting it resets
+    both, which is what a whole-container operation means.
+    """
+    vessel_path = resolve_web_vessel()
+    if vessel_path is None:
+        return
+    faces = ["face_a", "face_b"] if mode is None else [face_for_mode(mode)]
+    try:
+        from .vessel_service import VesselService
+
+        registry = VesselService()
+        for face in faces:
+            registry.touch_face(
+                vessel_path,
+                _FACE_IDS[face],
+                occupancy=0,
+                file_count=0,
+                dummy_profile={},
+                credentials_initialized=False,
+            )
+    except Exception:
+        # Best effort: the destructive operation itself already succeeded and
+        # must not be reported as failed because bookkeeping could not follow.
+        return
+
+
+_FACE_IDS = {
+    "dummy": "face_a",
+    "secret": "face_b",
+    "face_a": "face_a",
+    "face_b": "face_b",
+}
+
+
 def face_for_mode(mode: str) -> str:
     """Face selector matching an access mode.
 

--- a/src/phasmid/services/web_target_service.py
+++ b/src/phasmid/services/web_target_service.py
@@ -1,0 +1,87 @@
+"""Resolves which container the WebUI acts on.
+
+The WebUI and the TUI used to work on different storage: the TUI on Vessels,
+the WebUI straight through ``PhasmidVault("vault.bin")``. Two operator
+surfaces on one device therefore disagreed about what was stored - a file
+saved from a browser never appeared in any Vessel, in Audit, or in VESSEL
+STATUS.
+
+Both go through the same Vessel now. The selection lives here rather than in
+``web_server`` because it has to consult the operator profile and the face
+vocabulary, and ``web_server`` is a boundary module whose text is audited for
+exactly those terms.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..vault_core import PhasmidVault
+
+WEB_VESSEL_ENV = "PHASMID_WEB_VESSEL"
+LEGACY_CONTAINER_PATH = "vault.bin"
+
+
+def resolve_web_vessel() -> Path | None:
+    """Vessel the WebUI stores into and retrieves from.
+
+    The WebUI has no Vessel picker, so the target is resolved rather than
+    chosen: an explicit override first, then the registry the TUI writes to,
+    so both surfaces land on the same container without the operator having
+    to keep them in step by hand.
+
+    Returns None when nothing is registered, leaving callers to fall back to
+    the legacy container so a device that has never created a Vessel keeps
+    working.
+    """
+    override = os.environ.get(WEB_VESSEL_ENV, "").strip()
+    if override:
+        candidate = Path(override).expanduser()
+        return candidate if candidate.exists() else None
+
+    try:
+        from .profile_service import load_profile
+        from .vessel_service import VesselService
+
+        settings = load_profile()
+        known = VesselService().list_all(settings.default_vessel_dir or None)
+    except Exception:
+        return None
+
+    existing = [item for item in known if Path(item.path).exists()]
+    if not existing:
+        return None
+    # Most recently opened wins, so the interface follows whichever Vessel the
+    # operator is actually working in rather than whichever sorts first.
+    existing.sort(key=lambda item: (item.last_opened or "", str(item.path)))
+    return Path(existing[-1].path)
+
+
+def resolve_web_container(fallback: PhasmidVault) -> PhasmidVault:
+    """Container the destructive operations act on.
+
+    Purge, clear and re-initialise have to reach the same container that store
+    and retrieve use. Otherwise the emergency controls would wipe the legacy
+    file while leaving the Vessel the operator actually filled untouched -
+    the operator would believe the device had been cleared when it had not.
+    """
+    vessel_path = resolve_web_vessel()
+    if vessel_path is None:
+        return fallback
+    try:
+        size_mb = vessel_path.stat().st_size / (1024 * 1024)
+        return PhasmidVault(str(vessel_path), size_mb=size_mb)
+    except OSError:
+        return fallback
+
+
+def face_for_mode(mode: str) -> str:
+    """Face selector matching an access mode.
+
+    The two selector vocabularies already agree on the mode axis, and
+    ``_FACE_ALIASES`` in the workflow service accepts a mode name directly,
+    so this is a rename rather than a mapping decision. Kept explicit so the
+    correspondence is stated somewhere rather than relied on implicitly.
+    """
+    return str(mode)

--- a/src/phasmid/services/web_target_service.py
+++ b/src/phasmid/services/web_target_service.py
@@ -79,46 +79,68 @@ def resolve_web_container(fallback: PhasmidVault) -> PhasmidVault:
 
 
 def forget_face_contents(mode: str | None = None) -> None:
-    """Reset registry metadata after a container-level destructive operation.
+    """Reset the stored-content bookkeeping for a face after a purge.
 
-    Purge, clear and re-initialise rewrite raw container bytes; they know
-    nothing about the registry, which keeps file counts, occupancy, the
-    plausibility profile and the credentials flag per face. Left untouched
-    those figures survive the data they describe, so the console would go on
-    reporting stored files and a high-plausibility profile for a face whose
-    bytes are gone - the operator would believe a clear had not taken
-    effect, or that data still existed to disclose.
+    A purge rewrites raw container bytes and knows nothing about the
+    registry, which keeps file counts, occupancy and the plausibility profile
+    per face. Left untouched those figures survive the data they describe, so
+    the console would go on reporting stored files and a high-plausibility
+    profile for a face whose bytes are gone.
 
-    Passing a mode resets only the face that maps to it; omitting it resets
-    both, which is what a whole-container operation means.
+    Only content bookkeeping is reset. The object binding and the
+    destroy-password hash are credentials, not content: clearing one face's
+    files must not quietly remove the physical-object requirement or
+    invalidate the destroy passphrase for it. Whole-container wipes use
+    :func:`forget_container_contents` instead.
     """
+    _reset_faces(
+        ["face_a", "face_b"] if mode is None else [face_for_mode(mode)],
+        credentials=False,
+    )
+
+
+def forget_container_contents() -> None:
+    """Reset everything after a whole-container wipe.
+
+    Re-initialise and clear destroy the container outright, so the
+    credentials go with it. Carrying a destroy-password hash across a
+    re-initialise would leave a passphrase compromised beforehand still able
+    to authorise destruction of whatever is stored afterwards, which is the
+    situation the re-initialise exists to end.
+    """
+    _reset_faces(["face_a", "face_b"], credentials=True)
+
+
+def _reset_faces(faces: list[str], *, credentials: bool) -> None:
     vessel_path = resolve_web_vessel()
     if vessel_path is None:
         return
-    faces = ["face_a", "face_b"] if mode is None else [face_for_mode(mode)]
     try:
         from .vessel_service import VesselService
 
         registry = VesselService()
         for face in faces:
-            # Reset everything destroy_face() resets. Leaving the object
-            # binding and the destroy-password hash behind would carry a
-            # pre-wipe credential across a re-initialise, so a passphrase
-            # compromised before the wipe would still authorise destruction
-            # of whatever is stored afterwards - the wipe is meant to end
-            # exactly that.
-            registry.touch_face(
-                vessel_path,
-                _FACE_IDS[face],
-                status="available",
-                occupancy=0,
-                file_count=0,
-                dummy_profile={},
-                object_binding={},
-                emergency_auth={},
-                credentials_initialized=False,
-                object_binding_initialized=False,
-            )
+            if credentials:
+                registry.touch_face(
+                    vessel_path,
+                    _FACE_IDS[face],
+                    status="available",
+                    occupancy=0,
+                    file_count=0,
+                    dummy_profile={},
+                    object_binding={},
+                    emergency_auth={},
+                    credentials_initialized=False,
+                    object_binding_initialized=False,
+                )
+            else:
+                registry.touch_face(
+                    vessel_path,
+                    _FACE_IDS[face],
+                    occupancy=0,
+                    file_count=0,
+                    dummy_profile={},
+                )
     except Exception:
         # Best effort: the destructive operation itself already succeeded and
         # must not be reported as failed because bookkeeping could not follow.

--- a/src/phasmid/services/web_target_service.py
+++ b/src/phasmid/services/web_target_service.py
@@ -33,7 +33,9 @@ def resolve_web_vessel() -> Path | None:
 
     Returns None when nothing is registered, leaving callers to fall back to
     the legacy container so a device that has never created a Vessel keeps
-    working.
+    working. Pointing the override at a path that does not exist also returns
+    None, which is the deterministic way to exercise that fallback without
+    depending on whatever Vessels happen to be registered on the machine.
     """
     override = os.environ.get(WEB_VESSEL_ENV, "").strip()
     if override:
@@ -99,13 +101,23 @@ def forget_face_contents(mode: str | None = None) -> None:
 
         registry = VesselService()
         for face in faces:
+            # Reset everything destroy_face() resets. Leaving the object
+            # binding and the destroy-password hash behind would carry a
+            # pre-wipe credential across a re-initialise, so a passphrase
+            # compromised before the wipe would still authorise destruction
+            # of whatever is stored afterwards - the wipe is meant to end
+            # exactly that.
             registry.touch_face(
                 vessel_path,
                 _FACE_IDS[face],
+                status="available",
                 occupancy=0,
                 file_count=0,
                 dummy_profile={},
+                object_binding={},
+                emergency_auth={},
                 credentials_initialized=False,
+                object_binding_initialized=False,
             )
     except Exception:
         # Best effort: the destructive operation itself already succeeded and

--- a/src/phasmid/services/web_target_service.py
+++ b/src/phasmid/services/web_target_service.py
@@ -54,7 +54,7 @@ def resolve_web_vessel() -> Path | None:
         return None
     # Most recently opened wins, so the interface follows whichever Vessel the
     # operator is actually working in rather than whichever sorts first.
-    existing.sort(key=lambda item: (item.last_opened or "", str(item.path)))
+    existing.sort(key=lambda item: (item.last_opened_at or "", str(item.path)))
     return Path(existing[-1].path)
 
 

--- a/src/phasmid/tui/app.py
+++ b/src/phasmid/tui/app.py
@@ -73,11 +73,20 @@ class PhasmidApp(App):
         """Reset WebUI inactivity timer on any key press."""
         self.webui_svc.reset_timer()
 
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        # `w` is an app-level binding, so it is offered on every screen -
+        # including Standby, where acting on it would re-expose the operator
+        # surface standby just retracted. Hide it there rather than leaving a
+        # key in the footer that does nothing. False is Textual's "disabled
+        # and not shown"; None would keep the cell and only grey it.
+        if action == "toggle_webui" and not self.standby.is_active():
+            return False
+        return True
+
     def action_toggle_webui(self) -> None:
         """Toggle WebUI start/stop."""
-        # `w` is an app-level binding and stays live on the Standby screen.
-        # Starting the WebUI from a sealed state would re-expose the operator
-        # surface that standby just retracted.
+        # Reachable even with the binding hidden (command palette, a screen
+        # rebinding the key), so the sealed state is enforced here too.
         if not self.standby.is_active() and not self.webui_svc.is_running():
             return
         if self.webui_svc.is_running():
@@ -208,6 +217,17 @@ class PhasmidApp(App):
                 webui_was_running = True
                 self.webui_svc.stop()
                 self._refresh_webui_status()
+        except Exception:
+            pass
+
+        # Toasts live on the app's overlay, not on the screen that raised
+        # them, so they survive the push and sit on top of the standby
+        # screen. Exposing the WebUI notifies with a 30 second timeout and
+        # the message carries the access URL and token, which would then be
+        # displayed in plain text on the one screen whose entire purpose is
+        # to show nothing sensitive.
+        try:
+            self.clear_notifications()
         except Exception:
             pass
 

--- a/src/phasmid/tui/screens/face_manager.py
+++ b/src/phasmid/tui/screens/face_manager.py
@@ -99,9 +99,17 @@ class FaceManagerScreen(OperatorScreen):
         yield Label("Target occupancy", classes="field-label")
         yield Input(value="15%", id="target-occupancy")
         yield Static("", id="plausibility-summary")
-        yield Button("Inspect Plausibility", id="inspect-plausibility-btn")
-        yield Button("Generate Plausibility", id="generate-plausibility-btn")
-        yield Button("Clear Plausibility", id="clear-plausibility-btn")
+        yield Static(
+            "The file you disclose under pressure is one you store yourself, "
+            "on the Face you intend to hand over.\nFiller below only occupies "
+            "free space so an otherwise empty container does not read as empty. "
+            "It is not the disclosure material.",
+            id="filler-note",
+            classes="field-label",
+        )
+        yield Button("Inspect Free Space", id="inspect-plausibility-btn")
+        yield Button("Fill Free Space", id="generate-plausibility-btn")
+        yield Button("Clear Filler", id="clear-plausibility-btn")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -153,7 +161,7 @@ class FaceManagerScreen(OperatorScreen):
             or "-"
         )
         summary.update(
-            "Plausibility Profile\n"
+            "Free Space Filler\n"
             f"Level: {profile.plausibility_level}  "
             f"Score: {profile.plausibility_score}  "
             f"Files: {profile.dummy_file_count}\n"
@@ -212,13 +220,13 @@ class FaceManagerScreen(OperatorScreen):
             target = self.query_one("#target-occupancy", Input).value.strip() or "15%"
             if not passphrase or not restricted:
                 self.app.notify(
-                    "Both passphrases are required for plausibility generation.",
+                    "Both passphrases are required to fill free space.",
                     severity="error",
                 )
                 return
             if self._generating:
                 self.app.notify(
-                    "Plausibility generation is already running.",
+                    "Free space is already being filled.",
                     severity="warning",
                 )
                 return
@@ -233,7 +241,7 @@ class FaceManagerScreen(OperatorScreen):
             restricted = self.query_one("#restricted-passphrase", Input).value
             if not passphrase or not restricted:
                 self.app.notify(
-                    "Both passphrases are required to clear generated content.",
+                    "Both passphrases are required to clear filler.",
                     severity="error",
                 )
                 return
@@ -251,9 +259,9 @@ class FaceManagerScreen(OperatorScreen):
             self._refresh_table()
             self.app.notify(profile_result.recommended_action, severity="information")
 
-    # -- Plausibility generation ------------------------------------------
+    # -- Free space filler -------------------------------------------------
     #
-    # Generation writes megabytes of decoy files and was measured at roughly
+    # Filling writes megabytes into free space and was measured at roughly
     # four minutes for a 64 MiB Vessel at 15% occupancy on a Pi Zero 2 W.
     # Called inline from the button handler it froze the whole UI for that
     # long with no feedback, which is indistinguishable from a crash. It runs
@@ -283,10 +291,10 @@ class FaceManagerScreen(OperatorScreen):
         except NoMatches:
             return
         summary.update(
-            "Generating plausibility profile...\n"
+            "Filling free space...\n"
             f"Elapsed: {minutes:02d}:{seconds:02d}\n"
-            "Writing decoy files into the Vessel. This takes several minutes\n"
-            "on low-power hardware. The console stays responsive."
+            "Writing filler into the Vessel's free space. This takes several\n"
+            "minutes on low-power hardware. The console stays responsive."
         )
 
     @work(thread=True, exclusive=True, group="plausibility")

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -954,10 +954,15 @@ async def store(
             "message": text.PROTECTED_ENTRY_SAVED,
             "entry_state": entry_state,
         }
+    except (ValueError, FileNotFoundError, PermissionError, RuntimeError):
+        # Expected: rejected passphrase, unknown selector, missing container,
+        # limiter, or the camera not being ready. Not worth a traceback, and
+        # those messages carry the container path.
+        return {"error": text.STORE_OPERATION_FAILED}
     except Exception:
-        # The operator is deliberately told nothing specific, but swallowing
-        # the cause entirely made a broken container indistinguishable from a
-        # rejected passphrase for whoever has to debug the device.
+        # Anything else is a fault. The operator is still told nothing
+        # specific, but swallowing it entirely left whoever has to debug the
+        # device with no signal at all.
         LOG.exception("Store failed")
         return {"error": text.STORE_OPERATION_FAILED}
 
@@ -1022,10 +1027,13 @@ async def retrieve(request: Request, password: str = Form(...)):
                     selector=face_for_mode(mode),
                     cue_sequence=auth_sequence,
                 )
-            except (ValueError, FileNotFoundError, PermissionError):
+            except (ValueError, FileNotFoundError, PermissionError, RuntimeError):
                 # Expected control flow: wrong password, no bound object
-                # matched, nothing stored, or the limiter refusing. Try the
-                # next mode, exactly as a None result did before.
+                # matched, nothing stored, the limiter refusing, or the camera
+                # not being ready - RuntimeError is what the object-binding
+                # path raises for an unavailable frame, which is an ordinary
+                # state here, not a fault. Try the next mode, exactly as a
+                # None result did before.
                 continue
             except Exception:
                 # Anything else is a fault, not an authentication outcome.

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -1002,6 +1002,7 @@ async def retrieve(request: Request, password: str = Form(...)):
         return {"error": text.NO_VALID_ENTRY_FOUND}
 
     vessel_path = resolve_web_vessel()
+    result: bytes | None
     for mode in access_cue_service.modes():
         if vessel_path is not None:
             try:

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -65,6 +65,13 @@ from .services.audit_service import build_audit_report
 from .services.doctor_service import run_doctor_checks
 from .services.guided_service import get_workflows
 from .services.inspection_service import inspect_vessel
+from .services.vessel_workflow_service import VesselWorkflowService
+from .services.web_target_service import (
+    LEGACY_CONTAINER_PATH,
+    face_for_mode,
+    resolve_web_container,
+    resolve_web_vessel,
+)
 from .vault_core import PhasmidVault
 from .volatile_state import require_volatile_state
 
@@ -95,7 +102,11 @@ async def shutdown_cleanup():
 
 
 templates = Jinja2Templates(directory=str(Path(__file__).with_name("templates")))
-vault = PhasmidVault("vault.bin")
+
+# Fallback container, used only until a Vessel exists on the device. The
+# live target is resolved by services.web_target_service so that this
+# interface and the operator console act on the same file.
+vault = PhasmidVault(LEGACY_CONTAINER_PATH)
 WEB_TOKEN = web_token_env() or secrets.token_urlsafe(32)
 MAX_UPLOAD_BYTES = max_upload_bytes()
 RATE_LIMIT_WINDOW = 60
@@ -196,6 +207,10 @@ async def security_headers_middleware(request: Request, call_next):
 
 def display_entry_label(entry_id):
     return ENTRY_LABELS.get(entry_id, "Entry")
+
+
+def active_vault() -> PhasmidVault:
+    return resolve_web_container(vault)
 
 
 def resolve_entry(entry_id):
@@ -893,14 +908,30 @@ async def store(
             if not success:
                 return {"error": message}
 
-        vault.store(
-            password,
-            data,
-            access_cue_service.sequence_for_mode(mode),
-            filename=orig_filename,
-            mode=mode,
-            restricted_recovery_password=effective_secondary_passphrase or None,
-        )
+        vessel_path = resolve_web_vessel()
+        if vessel_path is not None:
+            # Same entry point the TUI uses, so the file lands in the Vessel's
+            # face namespace and shows up in Audit and VESSEL STATUS. Writing
+            # through PhasmidVault directly would overwrite that namespace and
+            # destroy whatever the face already held.
+            VesselWorkflowService().add_payload(
+                vessel_path,
+                orig_filename or "protected-entry.bin",
+                data,
+                password,
+                restricted_passphrase=effective_secondary_passphrase or None,
+                selector=face_for_mode(mode),
+                cue_sequence=access_cue_service.sequence_for_mode(mode),
+            )
+        else:
+            vault.store(
+                password,
+                data,
+                access_cue_service.sequence_for_mode(mode),
+                filename=orig_filename,
+                mode=mode,
+                restricted_recovery_password=effective_secondary_passphrase or None,
+            )
         audit_event(
             "payload_stored",
             entry="local_entry",
@@ -970,10 +1001,27 @@ async def retrieve(request: Request, password: str = Form(...)):
         _access_attempts.record_failure(attempt_scope)
         return {"error": text.NO_VALID_ENTRY_FOUND}
 
+    vessel_path = resolve_web_vessel()
     for mode in access_cue_service.modes():
-        result, filename, password_role = vault.retrieve_with_policy(
-            password, auth_sequence, mode=mode
-        )
+        if vessel_path is not None:
+            try:
+                payload, retrieval = VesselWorkflowService().retrieve_payload(
+                    vessel_path,
+                    password,
+                    selector=face_for_mode(mode),
+                    cue_sequence=auth_sequence,
+                )
+            except Exception:
+                continue
+            result, filename, password_role = (
+                payload,
+                retrieval.filename,
+                retrieval.password_role,
+            )
+        else:
+            result, filename, password_role = vault.retrieve_with_policy(
+                password, auth_sequence, mode=mode
+            )
         if result is None:
             continue
 
@@ -1019,7 +1067,7 @@ async def purge_other(
         _plain_form_value(legacy_selector),
     )
     mode = resolve_entry(entry_id)
-    vault.purge_other_mode(mode)
+    active_vault().purge_other_mode(mode)
     audit_event("restricted_local_update", accessed_entry="local_entry", source="web")
     return {"status": text.UNMATCHED_ENTRY_CLEARED}
 
@@ -1031,7 +1079,7 @@ async def purge_other(
 async def emergency_brick(request: Request, confirmation: str = Form(...)):
     enforce_rate_limit(request)
     require_restricted_action("clear_local_access_path", request, confirmation)
-    vault.silent_brick()
+    active_vault().silent_brick()
     audit_event("access_path_cleared", source="web")
     return {"status": text.LOCAL_ACCESS_PATH_CLEARED}
 
@@ -1043,7 +1091,7 @@ async def emergency_brick(request: Request, confirmation: str = Form(...)):
 async def emergency_initialize(request: Request, confirmation: str = Form(...)):
     enforce_rate_limit(request)
     require_restricted_action("initialize_container", request, confirmation)
-    vault.format_container(rotate_access_key=True)
+    active_vault().format_container(rotate_access_key=True)
     success, message = access_cue_service.clear_references()
     if not success:
         return {"error": message}
@@ -1067,7 +1115,7 @@ async def web_panic_trigger(request: Request, secret_trigger: str = Form(...)):
         require_restricted_action("rapid_local_clear", request, secret_trigger)
     except HTTPException:
         raise HTTPException(status_code=404) from None
-    vault.silent_brick()
+    active_vault().silent_brick()
     audit_event("access_path_cleared", source="web_panic")
     return {"status": text.CRITICAL_STATE_CLEARED}
 
@@ -1166,7 +1214,7 @@ def _maybe_auto_purge(accessed_mode, source):
     if reason is None:
         return False
 
-    vault.purge_other_mode(accessed_mode)
+    active_vault().purge_other_mode(accessed_mode)
     audit_event(
         "restricted_local_update",
         accessed_entry="local_entry",
@@ -1179,7 +1227,7 @@ def _maybe_auto_purge(accessed_mode, source):
 def _purge_for_password_role(accessed_mode, password_role, source):
     if password_role != PhasmidVault.PURGE_ROLE:
         return False
-    vault.purge_other_mode(accessed_mode)
+    active_vault().purge_other_mode(accessed_mode)
     audit_event(
         "restricted_local_update",
         accessed_entry="local_entry",

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -69,6 +69,7 @@ from .services.vessel_workflow_service import VesselWorkflowService
 from .services.web_target_service import (
     LEGACY_CONTAINER_PATH,
     face_for_mode,
+    forget_container_contents,
     forget_face_contents,
     resolve_web_container,
     resolve_web_vessel,
@@ -1109,7 +1110,7 @@ async def emergency_brick(request: Request, confirmation: str = Form(...)):
     enforce_rate_limit(request)
     require_restricted_action("clear_local_access_path", request, confirmation)
     active_vault().silent_brick()
-    forget_face_contents()
+    forget_container_contents()
     audit_event("access_path_cleared", source="web")
     return {"status": text.LOCAL_ACCESS_PATH_CLEARED}
 
@@ -1122,7 +1123,7 @@ async def emergency_initialize(request: Request, confirmation: str = Form(...)):
     enforce_rate_limit(request)
     require_restricted_action("initialize_container", request, confirmation)
     active_vault().format_container(rotate_access_key=True)
-    forget_face_contents()
+    forget_container_contents()
     success, message = access_cue_service.clear_references()
     if not success:
         return {"error": message}
@@ -1147,7 +1148,7 @@ async def web_panic_trigger(request: Request, secret_trigger: str = Form(...)):
     except HTTPException:
         raise HTTPException(status_code=404) from None
     active_vault().silent_brick()
-    forget_face_contents()
+    forget_container_contents()
     audit_event("access_path_cleared", source="web_panic")
     return {"status": text.CRITICAL_STATE_CLEARED}
 

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -69,6 +69,7 @@ from .services.vessel_workflow_service import VesselWorkflowService
 from .services.web_target_service import (
     LEGACY_CONTAINER_PATH,
     face_for_mode,
+    forget_face_contents,
     resolve_web_container,
     resolve_web_vessel,
 )
@@ -211,6 +212,11 @@ def display_entry_label(entry_id):
 
 def active_vault() -> PhasmidVault:
     return resolve_web_container(vault)
+
+
+def _other_mode(mode: str) -> str:
+    others = [item for item in access_cue_service.modes() if item != mode]
+    return others[0] if others else mode
 
 
 def resolve_entry(entry_id):
@@ -949,6 +955,10 @@ async def store(
             "entry_state": entry_state,
         }
     except Exception:
+        # The operator is deliberately told nothing specific, but swallowing
+        # the cause entirely made a broken container indistinguishable from a
+        # rejected passphrase for whoever has to debug the device.
+        LOG.exception("Store failed")
         return {"error": text.STORE_OPERATION_FAILED}
 
 
@@ -1012,7 +1022,16 @@ async def retrieve(request: Request, password: str = Form(...)):
                     selector=face_for_mode(mode),
                     cue_sequence=auth_sequence,
                 )
+            except (ValueError, FileNotFoundError, PermissionError):
+                # Expected control flow: wrong password, no bound object
+                # matched, nothing stored, or the limiter refusing. Try the
+                # next mode, exactly as a None result did before.
+                continue
             except Exception:
+                # Anything else is a fault, not an authentication outcome.
+                # Falling through silently would make a broken container or a
+                # bad state file look identical to a mistyped password.
+                LOG.exception("Vessel-backed retrieval failed unexpectedly")
                 continue
             result, filename, password_role = (
                 payload,
@@ -1069,6 +1088,7 @@ async def purge_other(
     )
     mode = resolve_entry(entry_id)
     active_vault().purge_other_mode(mode)
+    forget_face_contents(_other_mode(mode))
     audit_event("restricted_local_update", accessed_entry="local_entry", source="web")
     return {"status": text.UNMATCHED_ENTRY_CLEARED}
 
@@ -1081,6 +1101,7 @@ async def emergency_brick(request: Request, confirmation: str = Form(...)):
     enforce_rate_limit(request)
     require_restricted_action("clear_local_access_path", request, confirmation)
     active_vault().silent_brick()
+    forget_face_contents()
     audit_event("access_path_cleared", source="web")
     return {"status": text.LOCAL_ACCESS_PATH_CLEARED}
 
@@ -1093,6 +1114,7 @@ async def emergency_initialize(request: Request, confirmation: str = Form(...)):
     enforce_rate_limit(request)
     require_restricted_action("initialize_container", request, confirmation)
     active_vault().format_container(rotate_access_key=True)
+    forget_face_contents()
     success, message = access_cue_service.clear_references()
     if not success:
         return {"error": message}
@@ -1117,6 +1139,7 @@ async def web_panic_trigger(request: Request, secret_trigger: str = Form(...)):
     except HTTPException:
         raise HTTPException(status_code=404) from None
     active_vault().silent_brick()
+    forget_face_contents()
     audit_event("access_path_cleared", source="web_panic")
     return {"status": text.CRITICAL_STATE_CLEARED}
 
@@ -1216,6 +1239,7 @@ def _maybe_auto_purge(accessed_mode, source):
         return False
 
     active_vault().purge_other_mode(accessed_mode)
+    forget_face_contents(_other_mode(accessed_mode))
     audit_event(
         "restricted_local_update",
         accessed_entry="local_entry",
@@ -1229,6 +1253,7 @@ def _purge_for_password_role(accessed_mode, password_role, source):
     if password_role != PhasmidVault.PURGE_ROLE:
         return False
     active_vault().purge_other_mode(accessed_mode)
+    forget_face_contents(_other_mode(accessed_mode))
     audit_event(
         "restricted_local_update",
         accessed_entry="local_entry",

--- a/tests/test_doctor_service.py
+++ b/tests/test_doctor_service.py
@@ -1,0 +1,65 @@
+"""Tests for the operator diagnostics checks."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from phasmid.models.doctor import DoctorLevel
+from phasmid.services.doctor_service import run_doctor_checks
+
+
+def test_doctor_does_not_report_a_filler_profile_it_cannot_measure():
+    """Four checks used to read a path nothing writes.
+
+    Every reference to `.state/dummy_profile` in the tree is a reader; the
+    one module that could populate it has no operator-reachable entry point,
+    and the operator-facing feature writes into the Vessel's face namespace
+    instead. So those checks could not pass on any device, and they
+    contradicted the Audit screen, which reads the Vessel and is correct.
+
+    Free-space filler is per-Vessel and per-face. This is a host check with
+    no Vessel context, so it must not claim to report one.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with mock.patch.dict(os.environ, {"PHASMID_STATE_DIR": tmpdir}, clear=False):
+            result = run_doctor_checks()
+
+    names = [check.name for check in result.checks]
+    for gone in (
+        "Dummy Profile Size",
+        "Dummy Profile File Count",
+        "Dummy Profile Occupancy Ratio",
+        "Dummy Profile Size Distribution",
+        "Dummy Profile Plausibility",
+    ):
+        assert gone not in names, f"{gone} reports a path no operation writes"
+
+    assert "Free Space Reporting" in names
+    pointer = next(c for c in result.checks if c.name == "Free Space Reporting")
+    assert pointer.level == DoctorLevel.INFO
+
+
+def test_a_fresh_host_warns_only_about_genuine_host_facts():
+    """The warning count is a talking point, so it has to be honest.
+
+    Four of the five warnings on a fresh device came from the dead path
+    above and could never clear. What is left describes the machine.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with mock.patch.dict(os.environ, {"PHASMID_STATE_DIR": tmpdir}, clear=False):
+            result = run_doctor_checks()
+
+    warns = [c for c in result.checks if c.level == DoctorLevel.WARN]
+    assert all("Dummy Profile" not in c.name for c in warns), [c.name for c in warns]
+    # Swap and zram are real facts about the host and appear on the Pi; a
+    # world-writable /tmp is the one this container reproduces.
+    assert all(
+        c.name in {"Temporary Directory", "Swap", "Compressed Swap", "Shell History"}
+        for c in warns
+    ), [c.name for c in warns]

--- a/tests/test_doctor_service.py
+++ b/tests/test_doctor_service.py
@@ -14,51 +14,86 @@ from phasmid.models.doctor import DoctorLevel
 from phasmid.services.doctor_service import run_doctor_checks
 
 
-def test_doctor_does_not_report_a_filler_profile_it_cannot_measure():
-    """Four checks used to read a path nothing writes.
+def test_unconfigured_advisory_reports_nothing_rather_than_warning():
+    """The advisory only applies to material the operator points it at.
 
-    Every reference to `.state/dummy_profile` in the tree is a reader; the
-    one module that could populate it has no operator-reachable entry point,
-    and the operator-facing feature writes into the Vessel's face namespace
-    instead. So those checks could not pass on any device, and they
-    contradicted the Audit screen, which reads the Vessel and is correct.
+    PHASMID_DUMMY_PROFILE_DIR and PHASMID_DUMMY_CONTAINER_PATH are operator
+    settings. Left at their defaults they name paths no operation writes, so
+    the four checks warned on every device forever and the warnings could
+    not be acted on - and they read as a verdict on the operator's cover
+    story, which the tool has no way to judge.
 
-    Free-space filler is per-Vessel and per-face. This is a host check with
-    no Vessel context, so it must not claim to report one.
+    The checks stay (a configured operator still gets the advisory) but an
+    advisory nobody asked for is not a finding.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        with mock.patch.dict(os.environ, {"PHASMID_STATE_DIR": tmpdir}, clear=False):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_STATE_DIR": tmpdir,
+                "PHASMID_DUMMY_PROFILE_DIR": os.path.join(tmpdir, "absent"),
+                "PHASMID_DUMMY_CONTAINER_PATH": os.path.join(tmpdir, "absent.bin"),
+            },
+            clear=False,
+        ):
             result = run_doctor_checks()
 
-    names = [check.name for check in result.checks]
-    for gone in (
-        "Dummy Profile Size",
-        "Dummy Profile File Count",
-        "Dummy Profile Occupancy Ratio",
-        "Dummy Profile Size Distribution",
-        "Dummy Profile Plausibility",
-    ):
-        assert gone not in names, f"{gone} reports a path no operation writes"
+    advisory = [c for c in result.checks if "Dummy Profile" in c.name]
+    assert len(advisory) == 5, [c.name for c in result.checks]
+    assert all(c.level != DoctorLevel.WARN for c in advisory), [
+        (c.name, c.level.value) for c in advisory
+    ]
+    assert all(c.message == "not configured" for c in advisory)
 
-    assert "Free Space Reporting" in names
-    pointer = next(c for c in result.checks if c.name == "Free Space Reporting")
-    assert pointer.level == DoctorLevel.INFO
+
+def test_configured_advisory_still_reports_a_shortfall():
+    """Pointed at real material it must still do its job."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        profile_dir = os.path.join(tmpdir, "prepared")
+        os.makedirs(profile_dir)
+        with open(os.path.join(profile_dir, "a.bin"), "wb") as handle:
+            handle.write(b"a" * 64)
+        container = os.path.join(tmpdir, "container.bin")
+        with open(container, "wb") as handle:
+            handle.write(b"b" * (10 * 1024 * 1024))
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_STATE_DIR": tmpdir,
+                "PHASMID_DUMMY_PROFILE_DIR": profile_dir,
+                "PHASMID_DUMMY_CONTAINER_PATH": container,
+                "PHASMID_DUMMY_MIN_SIZE_MB": "1",
+                "PHASMID_DUMMY_MIN_FILE_COUNT": "2",
+                "PHASMID_DUMMY_OCCUPANCY_WARN": "0.10",
+            },
+            clear=False,
+        ):
+            result = run_doctor_checks()
+
+    verdict = next(c for c in result.checks if c.name == "Dummy Profile Plausibility")
+    assert verdict.level == DoctorLevel.WARN
+    # Volume, not believability: the tool cannot judge a cover story.
+    assert "convincing" not in verdict.message.lower()
+    assert "volume" in verdict.message.lower()
 
 
 def test_a_fresh_host_warns_only_about_genuine_host_facts():
-    """The warning count is a talking point, so it has to be honest.
-
-    Four of the five warnings on a fresh device came from the dead path
-    above and could never clear. What is left describes the machine.
-    """
+    """The warning count is a talking point, so it has to be honest."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        with mock.patch.dict(os.environ, {"PHASMID_STATE_DIR": tmpdir}, clear=False):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_STATE_DIR": tmpdir,
+                "PHASMID_DUMMY_PROFILE_DIR": os.path.join(tmpdir, "absent"),
+                "PHASMID_DUMMY_CONTAINER_PATH": os.path.join(tmpdir, "absent.bin"),
+            },
+            clear=False,
+        ):
             result = run_doctor_checks()
 
     warns = [c for c in result.checks if c.level == DoctorLevel.WARN]
     assert all("Dummy Profile" not in c.name for c in warns), [c.name for c in warns]
-    # Swap and zram are real facts about the host and appear on the Pi; a
-    # world-writable /tmp is the one this container reproduces.
     assert all(
         c.name in {"Temporary Directory", "Swap", "Compressed Swap", "Shell History"}
         for c in warns

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1888,3 +1888,47 @@ def test_luks_binding_is_hidden_while_the_luks_layer_is_disabled():
         assert screen.check_action("luks_panel", ()) is True
 
     assert screen.check_action("open_vessel", ()) is True
+
+
+def test_standby_clears_pending_notifications(monkeypatch):
+    """Toasts outlive the screen that raised them.
+
+    Textual renders notifications on the app's overlay rather than on the
+    screen, so they survive the push to Standby and sit on top of it.
+    Exposing the WebUI notifies with a 30 second timeout, and that message
+    carries the access URL and the token - which would then be shown in
+    plain text on the one screen whose entire purpose is to display nothing
+    sensitive.
+    """
+    from phasmid.tui.app import PhasmidApp
+
+    app = PhasmidApp.__new__(PhasmidApp)
+    cleared: list[bool] = []
+
+    app.webui_svc = SimpleNamespace(is_running=lambda: False, stop=lambda: None)
+    app.standby = SimpleNamespace(is_active=lambda: True, trigger_standby=lambda: None)
+    monkeypatch.setattr(PhasmidApp, "_refresh_webui_status", lambda self: None)
+    monkeypatch.setattr(
+        PhasmidApp, "clear_notifications", lambda self: cleared.append(True)
+    )
+    monkeypatch.setattr(
+        PhasmidApp, "push_screen", lambda self, screen, callback=None: None
+    )
+
+    app.action_trigger_standby()
+
+    assert cleared == [True], "standby left the WebUI token toast on screen"
+
+
+def test_webui_binding_is_hidden_once_sealed():
+    """`w` is app-level, so it is offered on the Standby screen too."""
+    from phasmid.tui.app import PhasmidApp
+
+    app = PhasmidApp.__new__(PhasmidApp)
+
+    app.standby = SimpleNamespace(is_active=lambda: False)
+    assert app.check_action("toggle_webui", ()) is False
+
+    app.standby = SimpleNamespace(is_active=lambda: True)
+    assert app.check_action("toggle_webui", ()) is True
+    assert app.check_action("quit", ()) is True

--- a/tests/test_vessel_workflow_service.py
+++ b/tests/test_vessel_workflow_service.py
@@ -1048,3 +1048,202 @@ class WebAndConsoleShareStorageTests(unittest.TestCase):
                     {"first.txt", "second.txt"},
                     {item.name for item in listing.files},
                 )
+
+
+class RetrievalSelectionTests(unittest.TestCase):
+    """Which file an unnamed retrieval returns.
+
+    The WebUI never names a file, so whatever this picks is what the operator
+    gets back. Three separate defects have landed here already: alphabetical
+    first (unreachable later stores), generated filler outranking a real
+    upload, and same-second ties falling back to the alphabetical order the
+    selection exists to avoid.
+    """
+
+    def _patch_registry_dir(self, tmpdir: str):
+        return mock.patch.object(vessel_service_mod, "config_dir", lambda: Path(tmpdir))
+
+    def _env(self, tmpdir):
+        return mock.patch.dict(
+            os.environ,
+            {"PHASMID_STATE_DIR": str(Path(tmpdir) / "state")},
+            clear=False,
+        )
+
+    def test_generated_filler_never_shadows_an_operator_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vessel = Path(tmpdir) / "travel.vessel"
+            note = Path(tmpdir) / "note.txt"
+            note.write_text("operator content", encoding="utf-8")
+            with self._env(tmpdir), self._patch_registry_dir(tmpdir):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel, "8M")
+                svc.add_file(
+                    vessel,
+                    note,
+                    "correct horse battery",
+                    "restricted recovery only",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                svc.generate_dummy_profile(
+                    vessel,
+                    "correct horse battery",
+                    "restricted recovery only",
+                    selector="face_a",
+                    target_occupancy="15%",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                data, result = svc.retrieve_payload(
+                    vessel,
+                    "correct horse battery",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                self.assertEqual(result.filename, "note.txt")
+                self.assertEqual(data, b"operator content")
+
+    def test_same_second_stores_return_the_later_one(self):
+        """added_at has one-second granularity; two stores can tie."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vessel = Path(tmpdir) / "travel.vessel"
+            fixed = "2026-07-28T00:00:00Z"
+            with self._env(tmpdir), self._patch_registry_dir(tmpdir):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel, "8M")
+                with mock.patch("time.strftime", lambda *a, **k: fixed):
+                    for name, body in (
+                        ("zzz_first.txt", b"first"),
+                        ("aaa_second.txt", b"second"),
+                    ):
+                        svc.add_payload(
+                            vessel,
+                            name,
+                            body,
+                            "correct horse battery",
+                            restricted_passphrase="restricted recovery only",
+                            selector="face_a",
+                            cue_sequence=["reference_dummy_matched"],
+                        )
+                data, result = svc.retrieve_payload(
+                    vessel,
+                    "correct horse battery",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                # Both records carry the same added_at, so a name-based
+                # tie-break would return zzz_first only by alphabetical luck.
+                self.assertEqual(result.filename, "aaa_second.txt")
+                self.assertEqual(data, b"second")
+
+    def test_generation_does_not_overwrite_a_colliding_operator_file(self):
+        """Filler names come from a fixed pool and can collide."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vessel = Path(tmpdir) / "travel.vessel"
+            with self._env(tmpdir), self._patch_registry_dir(tmpdir):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel, "8M")
+                svc.add_payload(
+                    vessel,
+                    "seed.txt",
+                    b"seed",
+                    "correct horse battery",
+                    restricted_passphrase="restricted recovery only",
+                    selector="face_b",
+                    cue_sequence=["reference_secret_matched"],
+                )
+                generated = svc.generate_dummy_profile(
+                    vessel,
+                    "correct horse battery",
+                    "restricted recovery only",
+                    selector="face_b",
+                    target_occupancy="15%",
+                    cue_sequence=["reference_secret_matched"],
+                )
+                self.assertGreater(generated.profile.dummy_file_count, 0)
+                listing = svc.list_files(
+                    vessel,
+                    "correct horse battery",
+                    selector="face_b",
+                    cue_sequence=["reference_secret_matched"],
+                )
+                filler_name = next(
+                    item.name for item in listing.files if item.name != "seed.txt"
+                )
+
+                svc.add_payload(
+                    vessel,
+                    filler_name,
+                    b"operator content that must survive",
+                    "correct horse battery",
+                    restricted_passphrase="restricted recovery only",
+                    selector="face_b",
+                    cue_sequence=["reference_secret_matched"],
+                )
+                svc.generate_dummy_profile(
+                    vessel,
+                    "correct horse battery",
+                    "restricted recovery only",
+                    selector="face_b",
+                    target_occupancy="15%",
+                    cue_sequence=["reference_secret_matched"],
+                )
+                data, _result = svc.retrieve_payload(
+                    vessel,
+                    "correct horse battery",
+                    selector="face_b",
+                    cue_sequence=["reference_secret_matched"],
+                    filename=filler_name,
+                )
+                self.assertEqual(data, b"operator content that must survive")
+
+    def test_named_file_that_does_not_exist_is_an_error_not_a_substitution(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vessel = Path(tmpdir) / "travel.vessel"
+            with self._env(tmpdir), self._patch_registry_dir(tmpdir):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel, "8M")
+                svc.add_payload(
+                    vessel,
+                    "present.txt",
+                    b"here",
+                    "correct horse battery",
+                    restricted_passphrase="restricted recovery only",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                with self.assertRaises(FileNotFoundError):
+                    svc.retrieve_payload(
+                        vessel,
+                        "correct horse battery",
+                        selector="face_a",
+                        cue_sequence=["reference_dummy_matched"],
+                        filename="absent.txt",
+                    )
+
+    def test_output_path_name_is_a_hint_and_still_falls_back(self):
+        """Recovering README.md to recovered.md is ordinary usage."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vessel = Path(tmpdir) / "travel.vessel"
+            out = Path(tmpdir) / "recovered.md"
+            with self._env(tmpdir), self._patch_registry_dir(tmpdir):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel, "8M")
+                svc.add_payload(
+                    vessel,
+                    "README.md",
+                    b"# readme",
+                    "correct horse battery",
+                    restricted_passphrase="restricted recovery only",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                result = svc.retrieve_file(
+                    vessel,
+                    "correct horse battery",
+                    output_path=out,
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                self.assertEqual(result.filename, "README.md")
+                self.assertEqual(out.read_bytes(), b"# readme")

--- a/tests/test_vessel_workflow_service.py
+++ b/tests/test_vessel_workflow_service.py
@@ -929,3 +929,122 @@ class VesselWorkflowServiceTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class WebAndConsoleShareStorageTests(unittest.TestCase):
+    """The WebUI and the operator console must act on the same container.
+
+    They did not: the console worked on Vessels while `web_server` held a
+    module-level `PhasmidVault("vault.bin")` and stored straight through it.
+    A file saved from a browser therefore never appeared in any Vessel, in
+    Audit, or in VESSEL STATUS - two operator surfaces on one device
+    disagreeing about what was stored.
+    """
+
+    def _patch_registry_dir(self, tmpdir: str):
+        return mock.patch.object(vessel_service_mod, "config_dir", lambda: Path(tmpdir))
+
+    def test_payload_stored_by_the_web_path_is_readable_by_the_console(self):
+        from phasmid.services.web_target_service import face_for_mode
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            vessel_path = Path(tmpdir) / "travel.vessel"
+            payload = b"# field notes\nrecovered through the console\n"
+
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel_path, "8M")
+
+                # What the WebUI does: bytes from an upload, addressed by the
+                # access mode rather than by a face id.
+                svc.add_payload(
+                    vessel_path,
+                    "notes.md",
+                    payload,
+                    "correct horse battery",
+                    restricted_passphrase="restricted recovery only",
+                    selector=face_for_mode("dummy"),
+                    cue_sequence=["reference_dummy_matched"],
+                )
+
+                # What the console sees afterwards.
+                listing = svc.list_files(
+                    vessel_path,
+                    "correct horse battery",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                self.assertIn("notes.md", [item.name for item in listing.files])
+
+                recovered, result = svc.retrieve_payload(
+                    vessel_path,
+                    "correct horse battery",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                self.assertEqual(recovered, payload)
+                self.assertEqual(result.filename, "notes.md")
+                self.assertEqual(result.bytes_retrieved, len(payload))
+                self.assertIsNone(result.output_path)
+
+    def test_add_payload_preserves_files_already_in_the_face(self):
+        """Writing through PhasmidVault directly would clobber the namespace.
+
+        A face holds a JSON namespace of many files, not one payload. Anyone
+        unifying the two surfaces by simply repointing `PhasmidVault` at a
+        `.vessel` path would overwrite that namespace and destroy whatever
+        the face already held, so the shared entry point has to go through
+        the namespace like the console does.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            vessel_path = Path(tmpdir) / "travel.vessel"
+            first = Path(tmpdir) / "first.txt"
+            first.write_text("stored from the console", encoding="utf-8")
+
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel_path, "8M")
+                svc.add_file(
+                    vessel_path,
+                    first,
+                    "correct horse battery",
+                    "restricted recovery only",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                svc.add_payload(
+                    vessel_path,
+                    "second.txt",
+                    b"stored from the browser",
+                    "correct horse battery",
+                    restricted_passphrase="restricted recovery only",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+
+                listing = svc.list_files(
+                    vessel_path,
+                    "correct horse battery",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                self.assertEqual(
+                    {"first.txt", "second.txt"},
+                    {item.name for item in listing.files},
+                )

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1821,7 +1821,13 @@ class WebTargetResolutionTests(unittest.TestCase):
             self.assertIn("notes.md", [item.name for item in listing.files])
 
             # And the legacy container was not the thing that got written.
+            # Comparing web_server.vault.path to itself proves nothing; the
+            # question is whether the legacy file was created at all.
             self.assertEqual(web_server.vault.path, legacy_before)
+            self.assertFalse(
+                Path(web_server.vault.path).exists(),
+                "the legacy container was written despite a Vessel being resolved",
+            )
             return vessel
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1835,3 +1841,205 @@ class WebTargetResolutionTests(unittest.TestCase):
                 ),
             ):
                 asyncio.run(run(tmpdir))
+
+
+class WebVesselBehaviourTests(unittest.TestCase):
+    """End-to-end behaviour of the Vessel-backed WebUI endpoints."""
+
+    def tearDown(self):
+        web_server._rate_limit.clear()
+        web_server._access_attempts._state.clear()
+
+    def _vessel_env(self, tmpdir):
+        from pathlib import Path
+
+        from phasmid.services import vessel_service as vessel_service_mod
+
+        return (
+            mock.patch.dict(
+                os.environ,
+                {"PHASMID_STATE_DIR": str(Path(tmpdir) / "state")},
+                clear=False,
+            ),
+            mock.patch.object(vessel_service_mod, "config_dir", lambda: Path(tmpdir)),
+        )
+
+    def test_retrieve_returns_the_bytes_that_store_wrote(self):
+        """The retrieve endpoint's Vessel branch had no test at all.
+
+        The store side was covered, so a retrieve wired to the wrong face, or
+        returning the wrong record, would have shipped green.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from phasmid.services.vessel_workflow_service import VesselWorkflowService
+
+        payload = b"round trip through the web interface\n"
+
+        async def run(tmpdir):
+            vessel = Path(tmpdir) / "travel.vessel"
+            VesselWorkflowService().create_vessel(vessel, "8M")
+            request = SimpleNamespace(
+                client=SimpleNamespace(host="127.0.0.1"),
+                url=SimpleNamespace(path="/store"),
+            )
+            upload = UploadFile(filename="notes.md", file=_BytesFile(payload))
+
+            with mock.patch.dict(
+                os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
+            ):
+                with mock.patch.object(
+                    web_server, "_capture_entry_binding", return_value=(True, "")
+                ):
+                    stored = await web_server.store(
+                        request,
+                        file=upload,
+                        password="correct horse battery",
+                        secondary_passphrase="",
+                        restricted_recovery_password="restricted recovery only",
+                        local_note_label="",
+                        entry_hint="",
+                        overwrite=False,
+                        overwrite_confirmation="",
+                    )
+                    self.assertTrue(stored.get("success"), stored)
+
+                    retrieve_request = SimpleNamespace(
+                        client=SimpleNamespace(host="127.0.0.1"),
+                        url=SimpleNamespace(path="/retrieve"),
+                    )
+                    with mock.patch.object(
+                        web_server.access_cue_service,
+                        "auth_sequence",
+                        return_value=["reference_dummy_matched"],
+                    ):
+                        response = await web_server.retrieve(
+                            retrieve_request, password="correct horse battery"
+                        )
+
+            chunks = []
+            iterator = getattr(response, "body_iterator", None)
+            if iterator is not None:
+                async for chunk in iterator:
+                    chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode())
+            body = b"".join(chunks) or getattr(response, "body", b"")
+            self.assertEqual(body, payload)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env, registry = self._vessel_env(tmpdir)
+            with env, registry:
+                asyncio.run(run(tmpdir))
+
+    def test_restricted_recovery_passphrase_does_not_disclose(self):
+        """Design decision: under duress the device must not disclose.
+
+        The restricted recovery passphrase is a destroy credential in the
+        Vessel layer, not a retrieval one. The legacy container returned the
+        payload for it and purged the other face; routing the WebUI onto
+        Vessels deliberately does not carry that behaviour over. Pinned here
+        so the difference cannot be reintroduced by accident in either
+        direction.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from phasmid.services.vessel_workflow_service import VesselWorkflowService
+
+        async def run(tmpdir):
+            vessel = Path(tmpdir) / "travel.vessel"
+            VesselWorkflowService().create_vessel(vessel, "8M")
+            request = SimpleNamespace(
+                client=SimpleNamespace(host="127.0.0.1"),
+                url=SimpleNamespace(path="/store"),
+            )
+            upload = UploadFile(filename="notes.md", file=_BytesFile(b"sensitive"))
+
+            with mock.patch.dict(
+                os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
+            ):
+                with mock.patch.object(
+                    web_server, "_capture_entry_binding", return_value=(True, "")
+                ):
+                    await web_server.store(
+                        request,
+                        file=upload,
+                        password="correct horse battery",
+                        secondary_passphrase="",
+                        restricted_recovery_password="restricted recovery only",
+                        local_note_label="",
+                        entry_hint="",
+                        overwrite=False,
+                        overwrite_confirmation="",
+                    )
+                    retrieve_request = SimpleNamespace(
+                        client=SimpleNamespace(host="127.0.0.1"),
+                        url=SimpleNamespace(path="/retrieve"),
+                    )
+                    with mock.patch.object(
+                        web_server.access_cue_service,
+                        "auth_sequence",
+                        return_value=["reference_dummy_matched"],
+                    ):
+                        response = await web_server.retrieve(
+                            retrieve_request, password="restricted recovery only"
+                        )
+
+            # A plain dict error, not a file response: nothing was disclosed.
+            self.assertIsInstance(response, dict)
+            self.assertIn("error", response)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env, registry = self._vessel_env(tmpdir)
+            with env, registry:
+                asyncio.run(run(tmpdir))
+
+    def test_forget_face_contents_clears_the_destroy_credential(self):
+        """A wipe must not carry a pre-wipe destroy credential across it.
+
+        Otherwise a passphrase compromised before a re-initialise still
+        authorises destruction of whatever is stored afterwards - which is
+        the situation the re-initialise exists to end.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from phasmid.services.vessel_workflow_service import VesselWorkflowService
+        from phasmid.services.web_target_service import forget_face_contents
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env, registry = self._vessel_env(tmpdir)
+            with env, registry:
+                vessel = Path(tmpdir) / "travel.vessel"
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel, "8M")
+                svc.add_payload(
+                    vessel,
+                    "notes.md",
+                    b"data",
+                    "correct horse battery",
+                    restricted_passphrase="restricted recovery only",
+                    selector="face_a",
+                    cue_sequence=["reference_dummy_matched"],
+                )
+                self.assertTrue(
+                    svc._verify_face_emergency_password(
+                        vessel, "face_a", "restricted recovery only"
+                    )
+                )
+
+                with mock.patch.dict(
+                    os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
+                ):
+                    forget_face_contents()
+
+                self.assertFalse(
+                    svc._verify_face_emergency_password(
+                        vessel, "face_a", "restricted recovery only"
+                    ),
+                    "the destroy credential survived a whole-container wipe",
+                )
+                meta = svc._get_meta(vessel)
+                face = next(f for f in meta.faces if f.face_id == "face_a")
+                self.assertEqual(face.file_count, 0)
+                self.assertEqual(face.occupancy, 0)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1994,18 +1994,27 @@ class WebVesselBehaviourTests(unittest.TestCase):
             with env, registry:
                 asyncio.run(run(tmpdir))
 
-    def test_forget_face_contents_clears_the_destroy_credential(self):
-        """A wipe must not carry a pre-wipe destroy credential across it.
+    def test_container_wipe_clears_credentials_but_a_face_purge_does_not(self):
+        """Two different operations, two different scopes.
 
-        Otherwise a passphrase compromised before a re-initialise still
-        authorises destruction of whatever is stored afterwards - which is
-        the situation the re-initialise exists to end.
+        A whole-container wipe must not carry a pre-wipe destroy credential
+        across it: a passphrase compromised beforehand would still authorise
+        destruction of whatever is stored afterwards, which is the situation
+        the re-initialise exists to end.
+
+        A per-face content purge must NOT do that. Clearing one face's files
+        is not a reason to silently drop the physical-object requirement or
+        invalidate the destroy passphrase for it, and the operator is told
+        only that an entry was cleared.
         """
         import tempfile
         from pathlib import Path
 
         from phasmid.services.vessel_workflow_service import VesselWorkflowService
-        from phasmid.services.web_target_service import forget_face_contents
+        from phasmid.services.web_target_service import (
+            forget_container_contents,
+            forget_face_contents,
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             env, registry = self._vessel_env(tmpdir)
@@ -2031,15 +2040,27 @@ class WebVesselBehaviourTests(unittest.TestCase):
                 with mock.patch.dict(
                     os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
                 ):
-                    forget_face_contents()
+                    # A per-face purge clears content bookkeeping only.
+                    forget_face_contents("dummy")
+                self.assertTrue(
+                    svc._verify_face_emergency_password(
+                        vessel, "face_a", "restricted recovery only"
+                    ),
+                    "a content purge silently invalidated the destroy passphrase",
+                )
+                meta = svc._get_meta(vessel)
+                face = next(f for f in meta.faces if f.face_id == "face_a")
+                self.assertEqual(face.file_count, 0)
+                self.assertEqual(face.occupancy, 0)
 
+                with mock.patch.dict(
+                    os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
+                ):
+                    # A whole-container wipe takes the credentials with it.
+                    forget_container_contents()
                 self.assertFalse(
                     svc._verify_face_emergency_password(
                         vessel, "face_a", "restricted recovery only"
                     ),
                     "the destroy credential survived a whole-container wipe",
                 )
-                meta = svc._get_meta(vessel)
-                face = next(f for f in meta.faces if f.face_id == "face_a")
-                self.assertEqual(face.file_count, 0)
-                self.assertEqual(face.occupancy, 0)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1743,19 +1743,95 @@ class WebTargetResolutionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             vessel = Path(tmpdir) / "travel.vessel"
             vessel.write_bytes(b"\x00" * (1024 * 1024))
-            fallback = object()
             with mock.patch.dict(
                 os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
             ):
                 resolved = web_server.active_vault()
-            self.assertIsNot(resolved, fallback)
+            # web_server.vault is the real fallback the code under test would
+            # return if resolution failed. Comparing against a throwaway
+            # object() instead proved nothing at all.
+            self.assertIsNot(resolved, web_server.vault)
             self.assertIn("travel.vessel", str(resolved.path))
 
-    def test_store_and_retrieve_no_longer_bypass_the_vessel(self):
-        store_src = inspect.getsource(web_server.store)
-        retrieve_src = inspect.getsource(web_server.retrieve)
+        os.environ.pop("PHASMID_WEB_VESSEL", None)
+        with mock.patch(
+            "phasmid.services.vessel_service.VesselService.list_all",
+            return_value=[],
+        ):
+            self.assertIs(web_server.active_vault(), web_server.vault)
 
-        self.assertIn("add_payload", store_src)
-        self.assertIn("retrieve_payload", retrieve_src)
-        self.assertIn("resolve_web_vessel", store_src)
-        self.assertIn("resolve_web_vessel", retrieve_src)
+    def test_endpoint_round_trip_lands_in_the_vessel_not_the_legacy_container(self):
+        """Drive the real endpoints, not the source text.
+
+        The previous version of this test called inspect.getsource() and
+        asserted that the strings "add_payload" and "resolve_web_vessel"
+        appeared somewhere in the function bodies. That passes for any code
+        that merely mentions those names - it would have kept passing if the
+        call were unreachable, mis-wired, or writing to the wrong face.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from phasmid.services import vessel_service as vessel_service_mod
+        from phasmid.services.vessel_workflow_service import VesselWorkflowService
+
+        payload = b"stored through the web interface\n"
+
+        async def run(tmpdir):
+            vessel = Path(tmpdir) / "travel.vessel"
+            VesselWorkflowService().create_vessel(vessel, "8M")
+            legacy_before = web_server.vault.path
+
+            request = SimpleNamespace(
+                client=SimpleNamespace(host="127.0.0.1"),
+                url=SimpleNamespace(path="/store"),
+            )
+            upload = UploadFile(filename="notes.md", file=_BytesFile(payload))
+
+            with mock.patch.dict(
+                os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
+            ):
+                with mock.patch.object(
+                    web_server, "_capture_entry_binding", return_value=(True, "")
+                ):
+                    # Every Form(...) default must be supplied explicitly:
+                    # calling the endpoint as a plain function bypasses
+                    # FastAPI's dependency resolution, so an omitted argument
+                    # arrives as the Form sentinel rather than as its default.
+                    stored = await web_server.store(
+                        request,
+                        file=upload,
+                        password="correct horse battery",
+                        secondary_passphrase="",
+                        restricted_recovery_password="restricted recovery only",
+                        local_note_label="",
+                        entry_hint="",
+                        overwrite=False,
+                        overwrite_confirmation="",
+                    )
+            self.assertTrue(stored.get("success"), stored)
+
+            # The file is in the Vessel, reachable by the console's own API.
+            listing = VesselWorkflowService().list_files(
+                vessel,
+                "correct horse battery",
+                selector="face_a",
+                cue_sequence=["reference_dummy_matched"],
+            )
+            self.assertIn("notes.md", [item.name for item in listing.files])
+
+            # And the legacy container was not the thing that got written.
+            self.assertEqual(web_server.vault.path, legacy_before)
+            return vessel
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            with (
+                mock.patch.dict(
+                    os.environ, {"PHASMID_STATE_DIR": str(state_dir)}, clear=False
+                ),
+                mock.patch.object(
+                    vessel_service_mod, "config_dir", lambda: Path(tmpdir)
+                ),
+            ):
+                asyncio.run(run(tmpdir))

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1666,6 +1666,62 @@ class WebTargetResolutionTests(unittest.TestCase):
             ):
                 self.assertEqual(resolve_web_vessel(), vessel)
 
+    def test_registry_selection_runs_against_real_vessel_metadata(self):
+        """Exercise the registry branch with a Vessel that exists on disk.
+
+        The first version sorted on `VesselMeta.last_opened`, which is not a
+        field - it is `last_opened_at`. Every override-based test returned
+        before reaching that line, and a registry test using a non-existent
+        path also returned early, so the branch that runs on any device with
+        a registered Vessel raised AttributeError and nothing caught it until
+        mypy did. The path has to exist for the sort to be reached at all.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from phasmid.models.vessel import VesselMeta
+        from phasmid.services import web_target_service
+
+        self.assertFalse(hasattr(VesselMeta(name="x", path="/x"), "last_opened"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            older = Path(tmpdir) / "backup.vessel"
+            newer = Path(tmpdir) / "travel.vessel"
+            older.write_bytes(b"\x00" * 32)
+            newer.write_bytes(b"\x00" * 32)
+
+            registered = [
+                VesselMeta(
+                    name="backup.vessel",
+                    path=str(older),
+                    last_opened_at="2026-07-28T09:00:00+00:00",
+                ),
+                VesselMeta(
+                    name="travel.vessel",
+                    path=str(newer),
+                    last_opened_at="2026-07-28T10:00:00+00:00",
+                ),
+            ]
+
+            os.environ.pop("PHASMID_WEB_VESSEL", None)
+            with mock.patch(
+                "phasmid.services.vessel_service.VesselService.list_all",
+                return_value=registered,
+            ):
+                # Most recently opened wins, so the interface follows the
+                # Vessel the operator is actually working in.
+                self.assertEqual(web_target_service.resolve_web_vessel(), newer)
+
+    def test_no_registered_vessel_falls_back_rather_than_raising(self):
+        from phasmid.services import web_target_service
+
+        os.environ.pop("PHASMID_WEB_VESSEL", None)
+        with mock.patch(
+            "phasmid.services.vessel_service.VesselService.list_all",
+            return_value=[],
+        ):
+            self.assertIsNone(web_target_service.resolve_web_vessel())
+
     def test_missing_override_does_not_silently_fall_through(self):
         from phasmid.services.web_target_service import resolve_web_vessel
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1639,3 +1639,67 @@ class _BytesFile:
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class WebTargetResolutionTests(unittest.TestCase):
+    """The WebUI must act on the same container as the operator console.
+
+    `web_server` held a module-level `PhasmidVault("vault.bin")` and stored
+    and retrieved straight through it while the console worked on Vessels,
+    so the two surfaces on one device disagreed about what was stored.
+    """
+
+    def tearDown(self):
+        os.environ.pop("PHASMID_WEB_VESSEL", None)
+
+    def test_explicit_override_selects_the_vessel(self):
+        import tempfile
+        from pathlib import Path
+
+        from phasmid.services.web_target_service import resolve_web_vessel
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vessel = Path(tmpdir) / "travel.vessel"
+            vessel.write_bytes(b"\x00" * 32)
+            with mock.patch.dict(
+                os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
+            ):
+                self.assertEqual(resolve_web_vessel(), vessel)
+
+    def test_missing_override_does_not_silently_fall_through(self):
+        from phasmid.services.web_target_service import resolve_web_vessel
+
+        with mock.patch.dict(
+            os.environ, {"PHASMID_WEB_VESSEL": "/nonexistent/x.vessel"}, clear=False
+        ):
+            self.assertIsNone(resolve_web_vessel())
+
+    def test_destructive_operations_follow_the_resolved_target(self):
+        """Purge and clear must not wipe the fallback while the Vessel survives.
+
+        Otherwise the emergency controls report success having cleared a file
+        nobody uses, leaving the container the operator actually filled
+        intact - the operator believes the device is clear when it is not.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            vessel = Path(tmpdir) / "travel.vessel"
+            vessel.write_bytes(b"\x00" * (1024 * 1024))
+            fallback = object()
+            with mock.patch.dict(
+                os.environ, {"PHASMID_WEB_VESSEL": str(vessel)}, clear=False
+            ):
+                resolved = web_server.active_vault()
+            self.assertIsNot(resolved, fallback)
+            self.assertIn("travel.vessel", str(resolved.path))
+
+    def test_store_and_retrieve_no_longer_bypass_the_vessel(self):
+        store_src = inspect.getsource(web_server.store)
+        retrieve_src = inspect.getsource(web_server.retrieve)
+
+        self.assertIn("add_payload", store_src)
+        self.assertIn("retrieve_payload", retrieve_src)
+        self.assertIn("resolve_web_vessel", store_src)
+        self.assertIn("resolve_web_vessel", retrieve_src)


### PR DESCRIPTION
Closes #163.

Three things, all found by exercising paths on the device that earlier fixes had only just made reachable.

## 1. The WebUI and the console operated on different storage (#163)

`web_server` held a module-level `PhasmidVault("vault.bin")` and stored and retrieved straight through it, while the console worked on Vessels. Two operator surfaces on one device disagreed about what was stored — **a file saved from a browser never appeared in any Vessel, in Audit, or in `VESSEL STATUS`.**

**Repointing that `PhasmidVault` at a `.vessel` path would not have fixed it — it would have destroyed data.** A face holds a JSON namespace of many files, not a single payload, so `store_with_policy` would have overwritten whatever the face already held. The WebUI has to go through `VesselWorkflowService` like the console does. There is a regression test for exactly this (`test_add_payload_preserves_files_already_in_the_face`).

**Service layer** gains byte-oriented entry points, since the WebUI receives uploads as bytes and returns payloads to a browser while the existing API is path-oriented:

- `add_payload()` stores bytes into a face namespace. `add_file()` now reads the file and delegates, so both share one code path including the object-binding step.
- `retrieve_payload()` returns the recovered bytes *alongside* the result. The bytes are deliberately **not** carried on `RetrievePayloadResult` — the CLI and operator log print that dataclass, and a plaintext payload should not be reachable through a repr.

**Target selection** lives in `services/web_target_service` rather than in `web_server`, which is a boundary module whose text is audited for the face vocabulary this logic has to consult (the terminology test caught the first attempt). Resolution order: explicit `PHASMID_WEB_VESSEL`, then the most recently opened Vessel in the registry the console writes to, then the legacy container so a device that has never created a Vessel keeps working.

**Destructive operations follow the same resolution.** Left pointing at the fallback, purge/clear/re-initialise would have reported success having cleared a file nobody uses while the container the operator actually filled survived — the operator would believe the device was clear when it was not.

## 2. Standby displayed the WebUI access token (was the original scope of this PR)

Textual renders notifications on the **app's overlay**, not the screen that raised them, so a toast survives `push_screen`. Exposing the WebUI notifies with `timeout=30` and the body carries the URL and token. Press `Ctrl+S` inside that window and the Standby screen renders with a live access token in plain text — on the one screen whose purpose is to show nothing sensitive. Observed on the device. Standby now clears outstanding notifications.

## 3. `w` was still advertised on the Standby footer

App-level binding, so it appeared on every screen. #156 made acting on it a no-op while sealed, but a key that does nothing is worse than no key, and on the concealment screen it names a capability that should not be visible. Hidden via `check_action`; the guard inside the action stays, since the palette can still reach it.

## Runbook

The previous revision had moved the cue steps to the WebUI on the strength of its camera feed and match badge, without checking which storage layer those pages used. That was wrong and is corrected: Step 2/3 run in the console, Step 3b (recovery with the object absent) is the proof, and the WebUI returns to a short local-boundary step. Once #163 is verified on hardware the cue steps can move back — the WebUI remains the better surface for showing the cue (#158).

## Test plan

- [x] `test_payload_stored_by_the_web_path_is_readable_by_the_console` — real Vessel, stores through the byte path, reads back through the console path, asserts byte equality.
- [x] `test_add_payload_preserves_files_already_in_the_face` — guards the namespace-clobbering trap.
- [x] `WebTargetResolutionTests` — override selection, missing-override does not fall through, destructive ops follow the target, and the endpoints no longer bypass the Vessel.
- [x] `test_standby_clears_pending_notifications`, `test_webui_binding_is_hidden_once_sealed` — both verified to fail against the unfixed code.
- [x] Service-layer tests verified red without `add_payload` (AttributeError), green with it. The `web_target_service` tests fail trivially without the module rather than by assertion, so treat those as coverage rather than as a red-then-green demonstration.
- [x] `python3 -m pytest` — 668 passed, 5 skipped. `black --check` and `ruff check` clean, including the terminology audit.

**Not yet exercised on hardware.** Both store and retrieve run through object-cue matching, so the end-to-end check needs the device, the camera and the bound object. The runbook keeps the console path for the demo until that check is done.
