### PR TITLE
fix: give the WebUI Store page an explicit entry selector

### DIFF
--- a/src/phasmid/templates/store.html
+++ b/src/phasmid/templates/store.html
@@ -35,6 +35,17 @@
             <section class="step-card">
                 <div class="step-head">
                     <span class="step-number">1</span>
+                    <div><h3>Choose the entry</h3><p class="step-help">Pick which protected space this goes into. Setting up both takes two passes, one entry at a time.</p></div>
+                </div>
+                <label class="field">
+                    <span>Entry</span>
+                    <select name="entry_hint" id="entryHint">{% for entry in entries %}<option value="{{ entry.id }}">{{ entry.label }}</option>{% endfor %}</select>
+                </label>
+            </section>
+
+            <section class="step-card">
+                <div class="step-head">
+                    <span class="step-number">2</span>
                     <div><h3>Choose the file</h3><p class="step-help">Select the one file you want Phasmid to protect.</p></div>
                 </div>
                 <label class="field">
@@ -45,7 +56,7 @@
 
             <section class="step-card">
                 <div class="step-head">
-                    <span class="step-number">2</span>
+                    <span class="step-number">3</span>
                     <div><h3>Create the access password</h3><p class="step-help">You will need this password together with the physical access object.</p></div>
                 </div>
                 {{ ui.password_field("password", "Access password", "Required") }}
@@ -53,7 +64,7 @@
 
             <section class="step-card camera-step">
                 <div class="step-head">
-                    <span class="step-number">3</span>
+                    <span class="step-number">4</span>
                     <div><h3>Set the physical access object</h3><p class="step-help">Place the object clearly in view, then capture it. Use an object you can reliably present again.</p></div>
                 </div>
                 {{ ui.camera_preview() }}
@@ -103,7 +114,6 @@
                 </div>
             </details>
 
-            <input type="hidden" name="entry_hint" id="entryHint">
             <input type="hidden" name="overwrite" id="overwriteFlag" value="false">
             <input type="hidden" name="overwrite_confirmation" id="overwriteConfirmation">
         </form>
@@ -146,6 +156,13 @@
 
     protectFile.addEventListener('change', updateReadiness);
     passwordInput.addEventListener('input', updateReadiness);
+    document.getElementById('entryHint').addEventListener('change', () => {
+        // Switching entries mid-setup must not carry over a capture done for
+        // the previous one - each entry needs its own object presented and
+        // captured before it can be protected.
+        accessObjectCaptured = false;
+        updateReadiness();
+    });
 
     function activateSaveButton() {
         accessObjectCaptured = true;

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -603,6 +603,28 @@ def _matched_entry():
 
 
 def _select_entry_for_store(entry_hint=None, overwrite=False):
+    """Resolve which entry a store operation targets.
+
+    An explicit, valid ``entry_hint`` takes priority - the store page's
+    visible entry selector lets an operator deliberately set up Entry 1 and
+    Entry 2 in turn, rather than depending on whichever entry the camera
+    happens to match or the dict-iteration order of the first unbound one.
+    The object cue itself is still what actually authorizes the write: an
+    already-bound entry is only reused when the camera currently matches it
+    (or, for a deliberate replacement, when ``overwrite`` is set), so picking
+    an entry from a menu can target a slot but can never substitute for
+    presenting its object.
+    """
+    if entry_hint in ENTRY_TO_MODE:
+        mode = ENTRY_TO_MODE[entry_hint]
+        if not _raw_gate_status().get("registered_modes", {}).get(mode):
+            return entry_hint, True
+        if overwrite:
+            return entry_hint, True
+        if _matched_entry() == entry_hint:
+            return entry_hint, False
+        return None, False
+
     matched_entry = _matched_entry()
     if matched_entry:
         return matched_entry, False
@@ -610,9 +632,6 @@ def _select_entry_for_store(entry_hint=None, overwrite=False):
     free_entry = _first_unbound_entry()
     if free_entry:
         return free_entry, True
-
-    if overwrite and entry_hint in ENTRY_TO_MODE:
-        return entry_hint, True
 
     return None, False
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1149,6 +1149,117 @@ class WebServerBoundaryTests(unittest.TestCase):
         asyncio.run(run())
 
 
+class SelectEntryForStoreTests(unittest.TestCase):
+    """The Store page's visible entry selector must actually control targeting.
+
+    Before this, `/store` ignored `entry_hint` unless `overwrite` was set,
+    so there was no way for an operator to deliberately choose which entry a
+    file went into - the very first store on a fresh Vessel silently landed
+    on Entry 1 because of dict iteration order in `_first_unbound_entry()`,
+    not operator intent.
+    """
+
+    def test_explicit_hint_on_an_unbound_entry_requests_a_fresh_capture(self):
+        with mock.patch.object(
+            web_server,
+            "_raw_gate_status",
+            return_value={"registered_modes": {"dummy": False, "secret": False}},
+        ):
+            entry_id, needs_capture = web_server._select_entry_for_store(
+                entry_hint="entry_2"
+            )
+        self.assertEqual(entry_id, "entry_2")
+        self.assertTrue(needs_capture)
+
+    def test_explicit_hint_on_an_already_bound_entry_reuses_it_when_matched(self):
+        with (
+            mock.patch.object(
+                web_server,
+                "_raw_gate_status",
+                return_value={"registered_modes": {"dummy": True, "secret": False}},
+            ),
+            mock.patch.object(web_server, "_matched_entry", return_value="entry_1"),
+        ):
+            entry_id, needs_capture = web_server._select_entry_for_store(
+                entry_hint="entry_1"
+            )
+        self.assertEqual(entry_id, "entry_1")
+        self.assertFalse(needs_capture)
+
+    def test_explicit_hint_on_an_already_bound_entry_is_refused_without_a_match(self):
+        """Picking an entry from the menu can target a slot, not substitute for its object.
+
+        The camera must currently show the object already registered for the
+        chosen entry - otherwise this would let an operator write to Entry 1
+        while merely selecting it from a dropdown, with no object check at all.
+        """
+        with (
+            mock.patch.object(
+                web_server,
+                "_raw_gate_status",
+                return_value={"registered_modes": {"dummy": True, "secret": False}},
+            ),
+            mock.patch.object(web_server, "_matched_entry", return_value=None),
+        ):
+            entry_id, needs_capture = web_server._select_entry_for_store(
+                entry_hint="entry_1"
+            )
+        self.assertIsNone(entry_id)
+        self.assertFalse(needs_capture)
+
+    def test_explicit_hint_on_an_already_bound_entry_with_overwrite_recaptures(self):
+        with mock.patch.object(
+            web_server,
+            "_raw_gate_status",
+            return_value={"registered_modes": {"dummy": True, "secret": False}},
+        ):
+            entry_id, needs_capture = web_server._select_entry_for_store(
+                entry_hint="entry_1", overwrite=True
+            )
+        self.assertEqual(entry_id, "entry_1")
+        self.assertTrue(needs_capture)
+
+    def test_no_hint_falls_back_to_matched_then_first_unbound_as_before(self):
+        with (
+            mock.patch.object(
+                web_server,
+                "_raw_gate_status",
+                return_value={"registered_modes": {"dummy": True, "secret": False}},
+            ),
+            mock.patch.object(web_server, "_matched_entry", return_value="entry_1"),
+        ):
+            entry_id, needs_capture = web_server._select_entry_for_store()
+        self.assertEqual(entry_id, "entry_1")
+        self.assertFalse(needs_capture)
+
+        with (
+            mock.patch.object(
+                web_server,
+                "_raw_gate_status",
+                return_value={"registered_modes": {"dummy": True, "secret": False}},
+            ),
+            mock.patch.object(web_server, "_matched_entry", return_value=None),
+        ):
+            entry_id, needs_capture = web_server._select_entry_for_store()
+        self.assertEqual(entry_id, "entry_2")
+        self.assertTrue(needs_capture)
+
+    def test_invalid_hint_is_treated_the_same_as_no_hint(self):
+        with (
+            mock.patch.object(
+                web_server,
+                "_raw_gate_status",
+                return_value={"registered_modes": {"dummy": False, "secret": False}},
+            ),
+            mock.patch.object(web_server, "_matched_entry", return_value=None),
+        ):
+            entry_id, needs_capture = web_server._select_entry_for_store(
+                entry_hint="not-a-real-entry"
+            )
+        self.assertEqual(entry_id, "entry_1")
+        self.assertTrue(needs_capture)
+
+
 def _asgi_request(
     method,
     path,


### PR DESCRIPTION
Follow-on to #168 (merged in #167), found during a live hardware rehearsal of the demo runbook.

## What happened

#168 gave the WebUI a store-role token whose intended surface includes explicitly setting up Face 1 and Face 2 - the same control the TUI's Add File screen already had. Walking through that on real hardware surfaced that the Store page (`/store`) never actually had this control: `entry_hint` was a hidden field only ever populated by the "overwrite an existing entry" flow. A normal store request always fell through to `_matched_entry() or _first_unbound_entry()`, so the very first registration on a fresh Vessel silently landed on Entry 1 - not because the operator chose it, but because of dict iteration order in `_first_unbound_entry()`. There was no visible way to deliberately target Entry 2 at all.

## The fix

The entry selector is now a visible first step on the Store form (`src/phasmid/templates/store.html`), instead of a hidden input only the overwrite flow ever touched.

`_select_entry_for_store()` (`src/phasmid/web_server.py`) now honors an explicit, valid `entry_hint` as top priority - mirroring the priority `register_key` already gave it for the object-cue capture step. An already-bound entry is only reused when the camera currently matches its registered object (or, for a deliberate replacement, when `overwrite` is confirmed) - picking an entry from the menu can target a slot, but it can never substitute for presenting that entry's physical object. Switching the selector resets the page's "captured" indicator, since each entry needs its own capture.

The camera-capture step's own request (`/register_key`) is intentionally left unchanged - it still auto-resolves via camera-match/first-unbound - so re-presenting an object to add another file to an already-configured entry keeps working exactly as it did before. Only the final store submission's target now follows the operator's explicit choice.

## Verification

`black --check`, `ruff check` clean. `mypy src` clean except pre-existing unrelated findings (none in the touched files). **732 passed, 5 skipped** (pytest - one `test_headerless_invariant` case is a known 1/256 flake unrelated to this change), **124 passed** (`tests_optional`). New tests in `tests/test_web_server.py::SelectEntryForStoreTests` cover the explicit-hint priority, the bound-but-unmatched rejection, the overwrite re-capture path, and confirm the no-hint fallback behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_