### PR TITLE
fix: pin the demo launch script to the new role tokens, not WEB_TOKEN

### DIFF
--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -62,7 +62,8 @@
       ```bash
       cd ~/Phasmid && bash scripts/pi_zero2w/run_demo_console.sh
       ```
-      `LIBCAMERA_LOG_LEVELS` / `PHASMID_WEBUI_EXPOSE_GADGET` / `PHASMID_WEB_TOKEN` /
+      `LIBCAMERA_LOG_LEVELS` / `PHASMID_WEBUI_EXPOSE_GADGET` /
+      `PHASMID_STORE_TOKEN` / `PHASMID_RECOVER_TOKEN` /
       `PHASMID_RECOGNITION_MODE=demo` と `stty -ixon` を設定する。**素の起動では
       デモが成立しない**（→ §0）。
 - [ ] **【重要】囮ファイルを自分で用意し、開示する Face に保存しておく。**
@@ -77,7 +78,9 @@
 - [ ] （任意）**Fill Free Space を事前実行**（約4分）。空き領域を埋め、
       容器が不自然に空でないようにする。経過時間が表示され画面は固まらない。
 - [ ] ラップトップのブラウザで `http://10.12.194.1:8000/unlock` を開き、
-      トークン（既定 `phasmid-demo-token`）を入力して**Homeまで進めた状態でタブを用意**。
+      **Recoverトークン**（既定 `phasmid-demo-recover-token`）を入力して
+      **Homeまで進めた状態でタブを用意**。Step 5は見せるだけで操作しないので、
+      壇上に出す面はStore/Maintenanceリンクの出ないRecoverロールにしておく。
       ※ `phasmid-pi.local` は使わない。**IPアドレス直指定**。
 - [ ] **バックアップ録画**（全手順を通した2〜3分クリップ）を再生機に用意し**頭出し**。
 - [ ] 予備電源／ケーブル。会場ネットワークは不要（WebUIはUSBガジェット面のみ）。

--- a/scripts/pi_zero2w/run_demo_console.sh
+++ b/scripts/pi_zero2w/run_demo_console.sh
@@ -19,11 +19,16 @@
 #       reach it at all. Opting in binds the USB gadget address (never all
 #       interfaces), which is what makes the browser view projectable.
 #
-#   PHASMID_WEB_TOKEN
-#       Off-device access requires a token at /unlock. Without a fixed value
-#       one is generated per start, meaning a long random string has to be
-#       typed by hand on stage. Pin it so the browser tab can be staged in
-#       advance.
+#   PHASMID_STORE_TOKEN / PHASMID_RECOVER_TOKEN
+#       /unlock now takes a role token - store (Face selection, registration)
+#       or recover (decrypt/destroy only) - instead of one shared secret.
+#       Pin both so neither has to be issued from the TUI's Access Tokens
+#       screen and copied down by hand before going on stage; a value shown
+#       once there is exactly the wrong shape for something staged in
+#       advance. Deliberately not PHASMID_WEB_TOKEN: once any role token
+#       exists, /unlock stops accepting the legacy shared token at all (see
+#       docs/THREAT_MODEL.md, "WebUI Access Roles"), so pinning both here
+#       instead is what actually lets the browser tab be staged in advance.
 #
 #   PHASMID_RECOGNITION_MODE
 #       There is no UI for this; it is environment-only. `demo` keeps object
@@ -49,7 +54,8 @@ fi
 
 export LIBCAMERA_LOG_LEVELS="${LIBCAMERA_LOG_LEVELS:-*:ERROR}"
 export PHASMID_WEBUI_EXPOSE_GADGET="${PHASMID_WEBUI_EXPOSE_GADGET:-1}"
-export PHASMID_WEB_TOKEN="${PHASMID_WEB_TOKEN:-phasmid-demo-token}"
+export PHASMID_STORE_TOKEN="${PHASMID_STORE_TOKEN:-phasmid-demo-store-token}"
+export PHASMID_RECOVER_TOKEN="${PHASMID_RECOVER_TOKEN:-phasmid-demo-recover-token}"
 export PHASMID_RECOGNITION_MODE="${PHASMID_RECOGNITION_MODE:-demo}"
 
 # Ctrl+S is the Silent Standby hotkey. It is also the terminal's traditional
@@ -63,7 +69,8 @@ fi
 echo "Phasmid demo console"
 echo "  recognition mode : $PHASMID_RECOGNITION_MODE"
 echo "  webui gadget     : $PHASMID_WEBUI_EXPOSE_GADGET (press w to expose)"
-echo "  webui token      : $PHASMID_WEB_TOKEN"
+echo "  store token      : $PHASMID_STORE_TOKEN"
+echo "  recover token    : $PHASMID_RECOVER_TOKEN"
 echo "  libcamera logs   : $LIBCAMERA_LOG_LEVELS"
 echo
 echo "Operate by keyboard. Mouse clicks do not reach the app over SSH:"

--- a/scripts/pi_zero2w/run_demo_smoke_test.sh
+++ b/scripts/pi_zero2w/run_demo_smoke_test.sh
@@ -263,9 +263,11 @@ cat <<'MANUAL'
      unlock, so testing on the device alone does not prove this path.
 
   3. Access token handling on stage
-     Pressing `w` prints the token into the TUI notification for 30 seconds.
-     Either pin PHASMID_WEB_TOKEN to a demo value beforehand, or switch the
-     projector to the laptop before pressing `w`.
+     Pressing `w` prints the legacy shared WEB_TOKEN into the TUI notification
+     for 30 seconds. It no longer unlocks anything once PHASMID_STORE_TOKEN /
+     PHASMID_RECOVER_TOKEN are pinned (see run_demo_console.sh), but it is
+     still a credential-shaped string - switch the projector to the laptop
+     before pressing `w`, or wait out the 30 seconds off-camera.
 
   4. Silent Standby on the real screen
      Press the standby hotkey and confirm the sensitive surface actually


### PR DESCRIPTION
Follow-on to #168/#170, found while walking through the live demo launch flow.

## What happened

`scripts/pi_zero2w/run_demo_console.sh` pinned `PHASMID_WEB_TOKEN` to a fixed demo value so a browser tab could be unlocked and staged in advance of the talk. #167's self-review fix made `/unlock` stop accepting `WEB_TOKEN` on its own the moment any role token has been issued for either role (closing the escalation where a leaked recover-role page could mint a fresh store-role session). Pinning `PHASMID_STORE_TOKEN`/`PHASMID_RECOVER_TOKEN` alongside the old `PHASMID_WEB_TOKEN` pin would have made the script set a token that no longer unlocks anything - silently broken for stage use.

## The fix

- `run_demo_console.sh` now pins `PHASMID_STORE_TOKEN`/`PHASMID_RECOVER_TOKEN` instead of `PHASMID_WEB_TOKEN`, with the header comment explaining why the swap was necessary rather than additive.
- `docs/submissions/Phasmid_Demo_Runbook.md`'s pre-flight checklist is updated to match: the browser tab staged in advance for Step 5 (a show-only WebUI viewing - the runbook is explicit that nothing is stored or retrieved there) now unlocks with the Recover token, since that step should default to the role with nothing to disclose (no Store/Maintenance nav links) rather than the full store surface.
- `run_demo_smoke_test.sh`'s manual checklist note is updated: the legacy `WEB_TOKEN` still gets printed by the TUI's `w` (expose WebUI) notification, but it no longer unlocks anything once role tokens are pinned - still worth keeping off-camera since it's a credential-shaped string, but it is not a functional leak anymore.

Docs/scripts only, no source changes. `pytest`/`tests_optional` unaffected (732 passed / 5 skipped, 124 passed - reconfirmed after this change), terminology audit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_