### PR TITLE
fix: restart the shared camera the WebUI itself stopped

### DIFF
--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -759,6 +759,7 @@ async def store_page(request: Request):
     guard = _guard_store_page(request)
     if guard:
         return guard
+    access_cue_service.start()
     return templates.TemplateResponse(
         request=request,
         name="store.html",
@@ -771,6 +772,7 @@ async def retrieve_page(request: Request):
     guard = _guard_page(request)
     if guard:
         return guard
+    access_cue_service.start()
     return templates.TemplateResponse(
         request=request,
         name="retrieve.html",
@@ -846,6 +848,12 @@ async def video_feed():
     # last was - a viewer closing this tab could leave Recover accepting
     # anything, or refusing everything, until the whole console was
     # restarted. See AIGate.generate_frames() / _finish_camera_consumer().
+    #
+    # start() is a no-op once the background matcher thread is already
+    # running; it only matters right after a successful Retrieve released
+    # the camera to save power (see the `/retrieve` handler) and no TUI
+    # Vessel Open has happened since to bring it back.
+    access_cue_service.start()
     return StreamingResponse(
         access_cue_service.generate_frames(),
         media_type="multipart/x-mixed-replace; boundary=frame",

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -351,6 +351,27 @@ class WebServerBoundaryTests(unittest.TestCase):
 
         asyncio.run(run())
 
+    def test_video_feed_restarts_a_camera_a_prior_retrieve_released(self):
+        """See test_store_page_restarts_a_camera_... for the failure this guards.
+
+        video_feed() itself must also bring the camera back, as a second line
+        of defense for any caller that reaches it without a fresh page load.
+        """
+
+        async def run():
+            with (
+                mock.patch.object(
+                    web_server.access_cue_service,
+                    "generate_frames",
+                    return_value=iter([]),
+                ),
+                mock.patch.object(web_server.access_cue_service, "start") as start,
+            ):
+                await web_server.video_feed()
+                start.assert_called_once()
+
+        asyncio.run(run())
+
     def test_restricted_confirmation_sets_short_lived_cookie(self):
         async def run():
             request = SimpleNamespace(
@@ -1693,6 +1714,34 @@ class AccessTokenRoleGateTests(unittest.TestCase):
         response = _asgi_request("GET", "/retrieve", cookies=cookies)
 
         self.assertEqual(response["status"], 200)
+
+    def test_store_page_restarts_a_camera_a_prior_retrieve_released(self):
+        """A successful Retrieve stops the camera thread to save power/heat.
+
+        Nothing but the TUI's Open Vessel action ever calls start() again.
+        A WebUI-only session (Store/Retrieve, no TUI Open) that hits Retrieve
+        once must still get a working camera preview on its next Store visit.
+        """
+        from phasmid.services.access_token_service import ROLE_STORE
+
+        token = self._service.issue(ROLE_STORE, gadget_ip=GADGET_BIND)
+        cookies = self._unlock_with(token)
+
+        with mock.patch.object(web_server.access_cue_service, "start") as start:
+            response = _asgi_request("GET", "/store", cookies=cookies)
+            self.assertEqual(response["status"], 200)
+            start.assert_called_once()
+
+    def test_retrieve_page_restarts_a_camera_a_prior_retrieve_released(self):
+        from phasmid.services.access_token_service import ROLE_RECOVER
+
+        token = self._service.issue(ROLE_RECOVER, gadget_ip=GADGET_BIND)
+        cookies = self._unlock_with(token)
+
+        with mock.patch.object(web_server.access_cue_service, "start") as start:
+            response = _asgi_request("GET", "/retrieve", cookies=cookies)
+            self.assertEqual(response["status"], 200)
+            start.assert_called_once()
 
     def test_recover_token_hides_store_and_maintenance_nav_links(self):
         from phasmid.services.access_token_service import ROLE_RECOVER


### PR DESCRIPTION
Found during a live hardware rehearsal, walking a Store/Retrieve-only WebUI session (no TUI Open Vessel action in the loop): after the first successful Retrieve, the camera preview went permanently black on every subsequent Store/Retrieve page - the match badge stayed frozen on whatever it last showed.

## What happened

A successful Retrieve calls `access_cue_service.close()` to release the camera and save power/heat on the Pi Zero 2 W (`web_server.py`, comment: "Release camera to save power and heat after successful retrieval"). That stops `AIGate`'s background thread and sets its internal stop event.

The only place that ever calls `access_cue_service.start()` again is the TUI's Open Vessel screen (`tui/screens/open_vessel.py`). Nothing in `web_server.py` ever restarts it. This session's whole redesign (#167/#168/#170) moved Face registration and retrieval onto the WebUI so an operator's flow can be Store/Retrieve entirely from the browser, with no TUI Open Vessel step in between - which is exactly the flow that never restarts the camera. Once the first Retrieve succeeds, `generate_frames()`'s loop condition (`while not self._stop_event.is_set()`) is permanently false and every later `/video_feed` request exits immediately with no frames, rendering a blank preview forever - only a full console restart brought it back.

## The fix

`access_cue_service.start()` is idempotent (a no-op once the background thread is already running - see its existing use in Open Vessel), so `/store`, `/retrieve`, and `/video_feed` now all call it before serving. Whichever of the three the operator hits next brings the camera back, regardless of what stopped it.

## Verification

`pytest` - 735 passed, 5 skipped (up from 732/5 - three new regression tests: `test_store_page_restarts_a_camera_a_prior_retrieve_released`, `test_retrieve_page_restarts_a_camera_a_prior_retrieve_released`, `test_video_feed_restarts_a_camera_a_prior_retrieve_released`, each verified against the unfixed handlers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_