### PR TITLE
fix: Simple Home's WebUI warning, and stale object cues on a new Vessel

### DIFF
--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -204,6 +204,13 @@ class VesselWorkflowService:
         self._vessels.register(vessel_path)
         if label:
             self._vessels.set_metadata(vessel_path, label=label)
+        # A brand new Vessel's two Faces are both unbound. The physical-object
+        # cue store is a device-wide singleton, not scoped to any one Vessel,
+        # so a reference left over from a prior Vessel would otherwise make
+        # the very first Store attempt here look already-bound to an object
+        # that has nothing to do with this Vessel - forcing an operator
+        # through the Replace confirmation flow for someone else's old data.
+        access_cue_service.clear_references()
         return CreateVesselResult(vessel_path=vessel_path, size_bytes=size_bytes)
 
     def create_face(

--- a/src/phasmid/tui/screens/simple_home.py
+++ b/src/phasmid/tui/screens/simple_home.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 from textual.app import ComposeResult
 from textual.binding import Binding
+from textual.css.query import NoMatches
 from textual.widgets import DataTable, Footer, Static
 
 from ...models.vessel import VesselMeta
 from ...services.profile_service import load_profile
 from ...services.vessel_service import VesselService
 from ..banner import COMPACT_BANNER, get_banner
+from ..widgets.warning_box import WarningBox
 from .base import OperatorScreen
+
+if TYPE_CHECKING:
+    from ..app import PhasmidApp
 
 
 class SimpleHomeScreen(OperatorScreen):
@@ -42,6 +49,10 @@ class SimpleHomeScreen(OperatorScreen):
         text-align: left;
         padding: 0 4;
         height: 2;
+    }
+    SimpleHomeScreen #webui-warning-panel {
+        margin: 0 0 1 0;
+        display: none;
     }
     SimpleHomeScreen #health {
         height: 3;
@@ -101,6 +112,11 @@ class SimpleHomeScreen(OperatorScreen):
             id="health",
             markup=True,
         )
+        yield WarningBox(
+            "WebUI active.",
+            level="error",
+            id="webui-warning-panel",
+        )
         yield Static("PROTECTED STORAGE", id="storage-label")
         yield DataTable(id="storage-table", cursor_type="row", zebra_stripes=True)
         yield Static(
@@ -127,6 +143,16 @@ class SimpleHomeScreen(OperatorScreen):
 
     def refresh_webui_status(self) -> None:
         super().refresh_webui_status()
+        try:
+            warning = self.query_one("#webui-warning-panel", WarningBox)
+        except NoMatches:
+            return
+        app = cast("PhasmidApp", self.app)
+        is_running = app.webui_svc.is_running()
+        warning.update_message(
+            self.webui_running_message().replace(" - PRESS \\[w] TO RETRACT", "")
+        )
+        warning.display = is_running
 
     def _refresh_table(self) -> None:
         default_dir = self._profile.default_vessel_dir if self._profile else None

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1812,6 +1812,44 @@ def test_expert_entry_refreshes_simple_home_on_return(monkeypatch):
     assert refreshed == [True]
 
 
+def test_simple_home_shows_a_persistent_webui_warning_like_expert_does():
+    """Simple Home must not go quiet about an exposed WebUI.
+
+    HomeScreen (Expert) carries a dedicated WarningBox in the body, in
+    addition to the shared top banner both screens compose, so the exposure
+    stays visible even if the top banner is easy to miss. SimpleHomeScreen
+    only had the top banner - reported missing on real hardware when the
+    WebUI was started while Expert was the active screen and the operator
+    then looked at Simple underneath it in the stack.
+    """
+    import asyncio
+
+    from phasmid.tui.app import PhasmidApp
+    from phasmid.tui.widgets.warning_box import WarningBox
+
+    async def scan():
+        app = PhasmidApp(initial_screen="home")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.screen.query_one("#webui-warning-panel", WarningBox)
+            assert not panel.display, "warning shown before WebUI ever started"
+
+            app.webui_svc.is_running = lambda: True
+            app.webui_svc.access_url = lambda: "http://10.55.0.10:8000"
+            app.screen.refresh_webui_status()
+            await pilot.pause()
+
+            assert panel.display, "WebUI is running but Simple Home stayed quiet"
+            assert "10.55.0.10:8000" in panel._message
+
+            app.webui_svc.is_running = lambda: False
+            app.screen.refresh_webui_status()
+            await pilot.pause()
+            assert not panel.display, "warning survived after WebUI stopped"
+
+    asyncio.run(scan())
+
+
 def test_key_name_brackets_survive_rich_markup_parsing():
     """`[x]` in a user-facing string is Rich markup, not a literal key name.
 

--- a/tests/test_vessel_workflow_service.py
+++ b/tests/test_vessel_workflow_service.py
@@ -158,6 +158,36 @@ class VesselWorkflowServiceTests(unittest.TestCase):
                 with self.assertRaises(FileExistsError):
                     svc.create_vessel(vessel_path, "8M")
 
+    def test_create_vessel_clears_any_object_cue_left_by_a_prior_vessel(self):
+        """A new Vessel's Faces are unbound; a stale cue must not look bound.
+
+        The object-cue reference store is a device-wide singleton, not
+        scoped to any one Vessel file. Without this, a physical object
+        registered for a Vessel that was since deleted (or a different
+        Vessel entirely) made the very first Store attempt on a brand new
+        Vessel look already-bound, forcing an operator through the Replace
+        confirmation flow for data that had nothing to do with the new
+        Vessel - reproduced live on hardware.
+        """
+        from phasmid.services.vessel_workflow_service import access_cue_service
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            vessel_path = Path(tmpdir) / "travel.vessel"
+
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+                mock.patch.object(access_cue_service, "clear_references") as cleared,
+            ):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel_path, "8M")
+                cleared.assert_called_once()
+
     def test_newly_created_vessel_is_inspectable(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             state_dir = Path(tmpdir) / "state"


### PR DESCRIPTION
Two gaps found on the demo hardware during the same rehearsal as #172.

## 1. Simple Home stayed quiet about an exposed WebUI

Both `HomeScreen` (Expert) and `SimpleHomeScreen` compose the same shared top banner (`webui_warning_banner()`), refreshed across the whole screen stack whenever WebUI state changes. Expert additionally carries a dedicated `WarningBox` in its body (`#webui-warning-panel`) with its own `refresh_webui_status()` override, so the exposure stays visible even if the top banner alone is missed. Simple never had this second, more prominent indicator - observed on real hardware: the WebUI was started while Expert was the active screen, and Simple (sitting underneath it on the screen stack) showed no warning at all when looked at afterward.

`SimpleHomeScreen` now carries the same dedicated `WarningBox`, wired the same way as `HomeScreen` (`refresh_webui_status()` override, CSS, `compose()` placement).

## 2. A new Vessel's Faces looked already-bound to someone else's old object

The physical-object cue store (`AIGate.reference_data` / `access_cue_service`) is a device-wide singleton, not scoped to any one Vessel file - `create_vessel()` never reset it. A cue left over from a deleted Vessel (or a different Vessel entirely) made the very first Store attempt on a brand new Vessel look already-bound to an object that has nothing to do with it, forcing an operator through the Replace confirmation flow - or, on the device, a manual `rm .state/store.bin .state/lock.bin` restart - to register Face 1/Face 2 on a Vessel that had just been created.

`create_vessel()` now calls `access_cue_service.clear_references()` as part of initializing a new Vessel, so a fresh Vessel always starts from a blank object-cue slate regardless of what a prior Vessel left behind.

## Verification

`pytest` - 737 passed, 5 skipped (up from 735/5 - two new regression tests: `test_simple_home_shows_a_persistent_webui_warning_like_expert_does` and `test_create_vessel_clears_any_object_cue_left_by_a_prior_vessel`). `black --check`, `ruff check`, and the terminology audit all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_