### PR TITLE
fix: deduplicate the 0.4.0 CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,36 +186,6 @@ and this project follows SemVer-style release intent for documented interfaces.
   Vessel existed: `_refresh_table` only ever assigned the "No protected
   storage found" text and never restored the default, so it kept
   contradicting the vessel table listed directly above it.
-- `scripts/pi_zero2w/run_webui_probe.sh` treated an `/unlock` redirect as a
-  successful response, timing an empty 303 instead of failing with an
-  explanation.
-- `scripts/bootstrap_pi.sh` aborted before creating the virtualenv on
-  Raspberry Pi OS Trixie: the apt package list named `libatlas-base-dev`,
-  which Debian 13 dropped, and `set -e` turned one missing candidate into a
-  total failure. The list now names `libopenblas-dev`; packages with no
-  installation candidate are reported and skipped instead of ending the run.
-- `scripts/validate_pi_environment.sh` recorded Stage A as failed under
-  Python 3.13 because `import importlib` does not bind `importlib.util` as an
-  attribute; it now imports `importlib.util` directly.
-- `.gitignore` did not cover `_pi_field_test/`, so running the remote
-  performance or demo smoke test scripts left the working tree dirty for
-  good.
-
-### Changed
-
-- The demo launch script and runbook pin `PHASMID_STORE_TOKEN` /
-  `PHASMID_RECOVER_TOKEN` rather than the legacy `PHASMID_WEB_TOKEN`, since
-  `/unlock` stops accepting the legacy token the moment any role token
-  exists; the pre-staged browser tab for the runbook's show-only step now
-  unlocks with the Recover token, the role with nothing to disclose.
-- The DEF CON Demo Labs materials (runbook, talk script, deck) are revised to
-  v4 to match the settled product model: the operator supplies both the
-  material they would disclose and the material they would withhold, and the
-  restricted credential destroys under coercion rather than fabricating a
-  false disclosure. The demo walkthrough now includes recovering with the
-  object absent, refused after ten seconds — without that contrast, a
-  successful recovery alone does not demonstrate that the object cue gates
-  anything.
 
 - Expert controls are no longer a one-way trip. `escape` returns to the Simple
   Operator screen, matching every other pushed screen in the TUI; previously the
@@ -256,6 +226,20 @@ and this project follows SemVer-style release intent for documented interfaces.
   directory itself was not.
 
 ### Changed
+
+- The demo launch script and runbook pin `PHASMID_STORE_TOKEN` /
+  `PHASMID_RECOVER_TOKEN` rather than the legacy `PHASMID_WEB_TOKEN`, since
+  `/unlock` stops accepting the legacy token the moment any role token
+  exists; the pre-staged browser tab for the runbook's show-only step now
+  unlocks with the Recover token, the role with nothing to disclose.
+- The DEF CON Demo Labs materials (runbook, talk script, deck) are revised to
+  v4 to match the settled product model: the operator supplies both the
+  material they would disclose and the material they would withhold, and the
+  restricted credential destroys under coercion rather than fabricating a
+  false disclosure. The demo walkthrough now includes recovering with the
+  object absent, refused after ten seconds — without that contrast, a
+  successful recovery alone does not demonstrate that the object cue gates
+  anything.
 
 - The DEF CON Demo Labs materials described a TUI that no longer exists. The
   runbook, the talk script and slide 24 of the deck all documented one command


### PR DESCRIPTION
Self-caught mistake in #174.

## What happened

The 0.4.0 backfill's `Edit` call replaced the `[Unreleased]` section's heading and its first `### Fixed` heading line, then inserted new content - but its `old_string` only matched through the `### Fixed` heading itself, not the bullets that used to follow it. Those original bullets (four script fixes, plus "Expert controls are no longer a one-way trip") were never removed; they just ended up sitting after the newly-inserted content instead, dragging the original `### Changed` heading down with them and leaving two `### Changed` headings and four duplicated Fixed bullets in the merged CHANGELOG.

## The fix

Removes the newly-written duplicate bullets (keeping the original, more detailed wording for the four script fixes), and merges the two orphaned `### Fixed` blocks and two `### Changed` headings into one of each. No content lost - every bullet from both the backfill and the pre-existing Unreleased section is still present exactly once, under the correct heading.

## Verification

`pytest` - 737 passed, 5 skipped, unchanged (CHANGELOG.md only). Verified by hand that every bullet present before this PR is still present exactly once after it, and that the `[0.3.0]` section and everything below it is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_