### PR TITLE
docs: bring the architecture docs up to what 0.4.0 actually built

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,23 +168,26 @@ Design concept: structured institutional UI with terminal-first aesthetics.
 Theme: `phasmid-dark` (`primary=#00d7af`, `background=#0d0d0d`, `success=#87d700`).
 
 Key TUI-only responsibilities (do not replicate these in WebUI):
-- Vessel creation, listing, and file-system operations via `VesselService`
+- Vessel lifecycle: creation and deletion via `VesselWorkflowService.create_vessel()` / `.delete_vessel()`; listing via `VesselService`. The WebUI operates only on a Vessel that already exists (store/retrieve); it never creates or deletes one.
+- Role-scoped WebUI access token issuance and revocation (`AccessTokenScreen` / `AccessTokenService`) — requires a live USB gadget interface, so granting either role happens with the operator's hands on the device
 - Profile and settings persistence via `ProfileService`
 - WebUI lifecycle control (start/stop/auto-kill) via `WebUIService`
 - Secure passphrase input (terminal prompt, not browser field)
 
 ### WebUI, API Routes, and Restricted Actions
 
-Use this context for changes involving FastAPI routes, Web mutation token, restricted confirmation, hidden routes, Field Mode, face lock sessions, store/retrieve routes, maintenance routes, emergency routes, response headers, or neutral download filenames:
+Use this context for changes involving FastAPI routes, Web mutation token, restricted confirmation, hidden routes, role-scoped access tokens (store/recover), Field Mode, face lock sessions, store/retrieve routes, maintenance routes, emergency routes, response headers, or neutral download filenames:
 
 - `src/phasmid/web_server.py`
 - `src/phasmid/templates/`
+- `src/phasmid/services/access_token_service.py`
+- `src/phasmid/services/vessel_workflow_service.py` (the WebUI operates on a Vessel through this same service the TUI uses)
 - `src/phasmid/restricted_actions.py`
 - `src/phasmid/capabilities.py`
 - `src/phasmid/emergency_daemon.py`
 - `src/phasmid/bridge_ui.py`
 - `docs/SPECIFICATION.md`, especially sections 7, 8, and 9
-- `docs/THREAT_MODEL.md`
+- `docs/THREAT_MODEL.md`, "WebUI Access Roles"
 - `tests/test_web_server.py` and related tests
 
 ### CLI Behavior

--- a/docs/JANUS_EIDOLON_SYSTEM.md
+++ b/docs/JANUS_EIDOLON_SYSTEM.md
@@ -8,17 +8,20 @@ The architecture separates visible disclosure from protected local state under p
 
 JES is a local-only storage architecture. It is intended to support:
 
-- local encrypted container storage in `vault.bin`
+- local encrypted container storage in operator-created Vessel (`*.vessel`) containers, each implementing one instance of the two-slot model; `vault.bin` remains as a legacy single-container fallback for deployments that have not created a Vessel
 - password-based recovery
 - local access-key mixing
 - object-cue guided access flows
 - restricted local update paths with explicit confirmation
+- role-scoped WebUI sessions, so a session limited to decrypt/destroy never carries the ability to set up or view either slot's credentials
 
 JES does not change the project's research-software boundary. It does not imply certified classified-data handling, covert communication, deniability guarantees, remote control, or protection against compromised hosts.
 
 ## Core Model
 
 The Janus System uses a two-slot container layout. One slot supports ordinary visible disclosure, and the other protects additional local state behind separate conditions. The implementation keeps normal WebUI and CLI surfaces neutral and avoids exposing internal slot semantics during routine use.
+
+An operator may hold more than one Vessel at a time, each an independent instance of the two-slot layout; the model does not require a single container for the lifetime of a deployment. Vessel lifecycle (creation, deletion) is deliberately kept to the local operator console rather than any remotely reachable surface.
 
 The architecture depends on separation of conditions rather than on misleading UI language. Quiet user-visible surfaces, local state separation, typed restricted confirmation, and controlled local access-path invalidation are all part of that design.
 

--- a/docs/PHASMID_ARCHITECTURE.md
+++ b/docs/PHASMID_ARCHITECTURE.md
@@ -10,11 +10,21 @@ Two-slot architecture overview: vessel structure, disclosure faces, local key ma
 
 Phasmid is organized into a few narrow local layers:
 
-1. CLI and WebUI entry points coordinate local operations without exposing internal disclosure structure in normal capture-visible flows.
-2. Restricted-action policy checks enforce confirmation, timing, and capability requirements for sensitive local updates.
-3. The cryptographic core manages `vault.bin`, key derivation, container layout, record encryption, and local access-key mixing.
+1. The TUI operator console, CLI, and WebUI entry points coordinate local operations without exposing internal disclosure structure in normal capture-visible flows. The TUI console owns Vessel lifecycle (creation and deletion); the WebUI and TUI both operate on an already-created Vessel day to day (store, retrieve). See "Vessel Model" below.
+2. Restricted-action policy checks, and role-scoped WebUI access tokens (store vs. recover), enforce confirmation, timing, and capability requirements for sensitive local updates and for which WebUI surfaces a given session can reach at all.
+3. The cryptographic core manages Vessel containers (`*.vessel`) and the legacy single-container `vault.bin` fallback, key derivation, container layout, record encryption, and local access-key mixing.
 4. Local state modules manage typed state, attempt limiting, object-cue material, and optional audit records.
 5. Deployment and review documents define the operating boundary for field evaluation and appliance hardening.
+
+## Vessel Model
+
+A Vessel (`*.vessel`) is the concrete, operator-facing container that implements the Janus Eidolon two-slot model: each Vessel holds exactly two disclosure Faces (`face_a`/`face_b`, shown as Entry 1/Entry 2 in the WebUI), each independently protected by its own passphrase and physical object cue. An operator can create and hold more than one Vessel at a time; `VesselWorkflowService` is the shared entry point both the TUI and the WebUI use for all Vessel and Face operations (create, delete, store, retrieve, list, remove).
+
+Vessel lifecycle is a TUI-only responsibility: the TUI creates a Vessel and its Faces, and Delete Vessel (TUI Expert Home) is the only path that permanently scrambles and removes a Vessel file, freeing its disk space, when an operator is finished with it. This is deliberate, not incidental — a Vessel is a self-contained container the operator carries a specific mental model of ("this is the thing I made and will eventually delete"), and folding creation or deletion into the WebUI would blur that boundary for a surface designed to be exposed over a USB gadget link. The WebUI's role is limited to operating on a Vessel that already exists: registering a Face's credentials (store role) and decrypting or destroying (recover role).
+
+The physical-object cue store is a device-wide singleton (`AIGate` / `access_cue_service`), not scoped to any single Vessel. Two consequences follow: a cue registered for one Vessel is still "known" after that Vessel closes, so an operator who reuses the same pair of physical objects across several Vessels does not have to re-register them each time; and a Vessel's own creation clears the cue store, since a brand-new Vessel's Faces are unbound and a cue left over from a deleted or unrelated Vessel would otherwise make the very first Store attempt on it look already bound to someone else's object.
+
+`vault.bin` remains as a legacy, non-Vessel fallback: a WebUI deployment that has never had a Vessel created for it falls back to a single unnamed container at that path, preserving compatibility with the original pre-Vessel single-container model. New deployments should create a Vessel through the TUI rather than relying on this fallback.
 
 ## Naming Boundary
 
@@ -35,6 +45,7 @@ The architecture preserves these constraints:
 - object cues are operational access cues, not cryptographic secrets
 - an experimental lightweight local object model may contribute neutral status signals to object-cue policy, but it is disabled by default and is not cryptographic material
 - hidden routes are UX concealment, not access control
+- role-scoped WebUI access tokens (store, recover) are real access control, separate from route hiding: a recover-role session cannot reach Face setup, Store, Maintenance, or any restricted-passphrase field regardless of whether it can guess a hidden route's path
 - restricted actions require server-side checks and explicit confirmation
 - Field Mode reduces exposure but is not a security boundary
 


### PR DESCRIPTION
## What happened

`docs/PHASMID_ARCHITECTURE.md`, `docs/JANUS_EIDOLON_SYSTEM.md`, and `AGENTS.md`'s Canonical Source Map still described the pre-Vessel, pre-role-token system: a single `vault.bin` container, CLI/WebUI named as the only entry points, and no mention anywhere of the TUI-owns-lifecycle / WebUI-operates-on-it split this session settled on, or of role-scoped WebUI access tokens (`store`/`recover`) at all — even though both are now the core of how the product actually works (0.4.0, just released).

## The fix

- **`docs/PHASMID_ARCHITECTURE.md`**: adds a "Vessel Model" section — multiple `*.vessel` containers can coexist, `VesselWorkflowService` is the shared entry point both TUI and WebUI use, Vessel creation/deletion is TUI-only, the physical-object cue store is a device-wide singleton (not per-Vessel) and why `create_vessel()` clears it, and `vault.bin` is now a legacy fallback rather than the primary container. Names the TUI console as a layer-1 entry point alongside CLI/WebUI. Adds role-scoped access tokens to the security-boundary list as real access control, distinct from route hiding.
- **`docs/JANUS_EIDOLON_SYSTEM.md`**: Scope and Core Model now describe Vessel containers as the concrete implementation of the two-slot model, note an operator can hold more than one Vessel, and mention role-scoped WebUI sessions; `vault.bin` demoted to legacy fallback language.
- **`AGENTS.md`**: Canonical Source Map's TUI-only-responsibilities list now names `VesselWorkflowService` (not just `VesselService`) and Vessel deletion, plus the Access Tokens screen; the WebUI section's file list adds `access_token_service.py` and `vessel_workflow_service.py`.

## Verification

`pytest` - 737 passed, 5 skipped, unchanged (docs only). `tests/test_docs_and_templates.py::test_architecture_docs_define_jes_and_phasmid_boundary` and `tests/test_terminology.py` both still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_