### PR TITLE
Deactivate TUI ops duplicated by role-gated WebUI (#169 Phase 1) + demo doc refresh

### DIFF
--- a/docs/TUI_OPERATOR_CONSOLE.md
+++ b/docs/TUI_OPERATOR_CONSOLE.md
@@ -186,9 +186,28 @@ default Vessel directory and selected Vessel context are preserved.
 
 Press `e` from the Simple Operator screen to open the detailed operator
 console. It retains the selected Vessel and provides the previous detailed
-actions: Close, Delete, Create, Inspect, Face management, Audit, Doctor,
-Settings, Access Tokens, LUKS, and Help. Expert controls are for diagnostic
-and maintenance work, not the normal Protect/Open flow.
+actions: Close, Delete, Create, Face management, Settings, Access Tokens,
+LUKS, and Help. Expert controls are for diagnostic and maintenance work, not
+the normal Protect/Open flow.
+
+**Doctor and Inspect are deactivated here** (#169): each is fully duplicated
+by the role-gated WebUI (`/operator/doctor`, `/operator/inspect`), which
+calls the identical service function - and unlike the TUI, the WebUI
+enforces the store/recover role split #168 added. Anyone with physical TUI
+access has always had full access to every screen regardless of role, so
+continuing to offer these two from the TUI's own footer no longer matched
+the safer path. The bindings are hidden, not removed:
+`HomeScreen.check_action` returns `False` for them (the same mechanism
+already used to hide `l` LUKS while that layer is disabled), and the screens
+and their service calls are untouched underneath - this is a Phase 1
+deactivation, reversible by un-hiding the binding, with removal planned for
+Phase 2 once it has held up through rehearsal.
+
+**Audit is equally duplicated by `/operator/audit`, but deliberately stays
+visible** for now: the demo runbook drives it directly from this binding on
+stage, and hiding it would force a slower command-palette detour with no
+WebUI-side replacement for that beat yet. It follows the same Phase
+1/Phase 2 path once that changes.
 
 Press `escape` to return to the Simple Operator screen. The protected storage
 list is refreshed on return, so anything created or closed in Expert controls is
@@ -202,15 +221,13 @@ every other screen in the TUI. Use `escape` to go back.
 | Key | Action |
 |---|---|
 | `escape` | Back to the Simple Operator screen |
-| `o` | Open Vessel |
+| `o` | Open Vessel (Recover File / List Files / Remove File - see below) |
 | `x` | Close Vessel |
 | `delete` | Delete Vessel (scrambles the data, then removes the file) |
 | `c` | Create Vessel |
-| `i` | Inspect Vessel |
 | `f` | Face management |
 | `g` | Guided Help |
 | `a` | Audit View |
-| `d` | Doctor View |
 | `s` | Settings |
 | `t` | Access Tokens (issue/revoke the WebUI's store and recover role tokens) |
 | `l` | LUKS panel |
@@ -218,6 +235,26 @@ every other screen in the TUI. Use `escape` to go back.
 | `q` | Quit |
 | `r` | Refresh Vessel list (not shown in footer) |
 | `/` | About (not shown in footer) |
+
+**Deactivated, not removed** (#169 Phase 1 - duplicated by the role-gated
+WebUI, still reachable through the command palette): `d` Doctor View →
+`/operator/doctor`, `i` Inspect Vessel → `/operator/inspect`.
+
+### Open Vessel Screen
+
+`o` opens a Vessel already on disk. **Add File is deactivated** (#169):
+duplicated by the WebUI's role-gated `/store`, and the demo now registers
+both Faces there instead. **Recover File, List Files, and Remove File
+stay.** Recover is duplicated by `/retrieve` too - and the WebUI version is
+strictly better, since it shows the live camera feed while an object cue is
+presented, which this screen never could (#158) - but it is kept active
+here because it is the only *verified* way to demonstrate the object-absent
+refusal (the demo's central cue-not-key proof); the WebUI `/retrieve`
+equivalent has not been separately confirmed for that specific case. It
+will follow Add File into deactivation once that verification happens. The
+Operation selector reflects this: Add is missing, the other three remain;
+the underlying `add` code path is untouched, so restoring the option is a
+one-line revert.
 
 ## WebUI Integration (Exposed Mode)
 

--- a/docs/submissions/Phasmid_DEFCON_DemoLabs_PPTX_Changes_v0.4.0.md
+++ b/docs/submissions/Phasmid_DEFCON_DemoLabs_PPTX_Changes_v0.4.0.md
@@ -1,0 +1,163 @@
+# Phasmid_DEFCON_DemoLabs.pptx — 0.4.0 反映のための変更点まとめ
+
+**目的:** v0.4.0 に至るデモ変更（WebUI 中心の Bind/Operate、Issue #169 の TUI 非活性化）を
+`Phasmid_DEFCON_DemoLabs.pptx`（全26枚）に反映するための作業リスト。
+実際のスライド編集は手動で行う前提のため、**現状のテキストと変更後のテキストを対で示す**。
+対象は **Slide 23・24** のみ（他スライドは python-pptx でも本文を確認したが変更不要）。
+
+参照した確定情報の出どころ:
+- `docs/submissions/Phasmid_Demo_Runbook.md`（実機で全手順確認済み・最新の Step 0〜7 構成）
+- `docs/submissions/Phasmid_Talk_Script_30min.md`（v5 改訂済みの台本・Slide 24 該当セクション）
+- 公開アーティファクト「Phasmid — DEF CON Demo Labs Run-of-Show」（同じ Step 0〜7 に更新済み）
+
+---
+
+## Slide 23 — LIVE DEMO（章扉）
+
+### サブタイトル行（本文シェイプ）
+
+**現状:**
+```
+Create → Faces → Guided → Audit → WebUI → Silent Standby
+```
+
+**変更後:**
+```
+Create → Bind (WebUI) → Operate (WebUI) → Refuse → Audit → Silent Standby
+```
+
+理由: 現行の文言は「Faces」「Guided」など今のデモ動線と対応しない語を含む。
+Bind と Operate が WebUI で行われることを章扉の時点で示しておくと、Slide 24 で
+プロジェクタが切り替わることに観客が驚かない。
+
+### ノート（スピーカーノート）
+
+**現状のまま変更不要。** 「プロジェクタ入力をTUIへ切替」は Step 0/1 開始時の操作として
+引き続き正しい（切替はこの後の Step 1→2 と Step 3→4 の2箇所のみ）。
+
+---
+
+## Slide 24 — LIVE DEMO（本編）
+
+### サブタイトル（本文シェイプ）
+
+**現状:**
+```
+Real TUI — Local Disclosure Control
+```
+
+**変更後:**
+```
+Real TUI + local WebUI — Local Disclosure Control
+```
+
+理由: 本編は TUI 単独ではなく TUI と WebUI の両方を実際に操作する。単独表記のままだと
+壇上でブラウザに切り替えた瞬間、スライドの主張と矛盾して見える。
+
+### Walkthrough 箇条書き（本文シェイプ）
+
+**現状:**
+```
+Create a Vessel — deniable container
+Store a file with the object cue
+Recover with the object — it comes back
+Recover WITHOUT it — refused after 10 s
+Audit — free space, and what it won't judge
+Local WebUI over USB → Silent Standby
+```
+
+**変更後:**
+```
+Create a Vessel — deniable container (TUI)
+Bind two Faces via the local WebUI — object cue per Face (WebUI)
+Recover with the object — it comes back; a second, narrower session (WebUI)
+Recover WITHOUT it — refused after 10 s, back on the TUI
+Audit — free space, and what it won't judge (TUI)
+Silent Standby — the WebUI drops with it (TUI)
+```
+
+理由: 6行のうち3行（Bind・1回目のRecover・WebUI言及）が「見せるだけ」から
+「実際に壇上で操作する」に変わった。特に "Store a file" という表現は Add File を指すが、
+Add File は Issue #169 で TUI から非活性化済みで、実際には WebUI の Store 画面で行う —
+現状の文言のまま話すと事実と食い違う。
+
+### bottom bar 行（本文シェイプ）
+
+**現状:**
+```
+bottom bar  Open · New · Guided · Expert · Quit · WebUI   (Expert adds Audit · Doctor)
+```
+
+**変更後:**
+```
+bottom bar  Open · New · Guided · Expert · Quit · WebUI   (Expert adds Audit — Doctor/Inspect moved off the footer, #169)
+```
+
+理由: Issue #169 の実装で、Expert フッタから **Doctor** と **Inspect** の2キーを非活性化した
+（フッタからは消えるが、コマンドパレット経由では引き続き到達できる — 削除ではなく非活性化）。
+**Audit はあえて残した**（本デモの Step 5 でキー1つで直接使うため）。現状の文言のまま
+"Expert adds Audit · Doctor" と言うと、壇上のフッタに Doctor が映らないため観客と食い違う。
+
+### スピーカーノート
+
+**現状:**
+```
+[19:20 / ~7:00] LIVE DEMO  ★中心
+EN (最小限・手を動かしながら): "This is the real TUI — Local Disclosure Control. I create
+a vessel. I store a file while holding the object in front of the camera. I recover it
+with the object — it comes back. Now watch: same file, same password, same everything,
+only the object is gone. Ten seconds, and it refuses. That is what 'the cue gates the
+operation' means. Then Audit — note what it does not claim. Then the local web
+interface, and Silent Standby."
+JA: 詳細手順は別紙 Phasmid_Demo_Runbook（8ステップ）を参照。Step 3b（物体なしで失敗）が
+本番の山。ここで必ず間を取る。成功例だけでは cue≠key を何も証明していない。マウスは
+使わない（Tab/Enter）。端末幅123桁以上。Fill Free Space は実測4分なので壇上では実行しない。
+失敗時は録画へ切替。約7分で切り上げ、Q&Aに15分残す。
+```
+
+**変更後:**
+```
+[19:20 / ~7:30] LIVE DEMO  ★中心
+EN (最小限・手を動かしながら): "This is the real system — the TUI handles prepare, refuse,
+and disclose; the local WebUI, reached over USB, handles bind and operate. I'll create a
+vessel here. Then I switch to the browser, log in with a store-scoped token, and register
+two Faces — each one bound to an everyday object in front of the camera. I'll open one
+back with the correct object — it comes back, and I'll show you a second, narrower
+session that can never reach Face setup at all. Then I switch back here and do the
+important part: same file, same password, same everything — only the object is gone.
+Ten seconds, and it refuses. That is what 'the cue gates the operation' means. Then
+Audit — and notice what it doesn't claim. Then Silent Standby."
+JA: 詳細手順は別紙 Phasmid_Demo_Runbook（8ステップ、合計 ~7:30）を参照。Step 2〜3
+（Bind・Operate）は WebUI、Step 4（物体なしで失敗）は TUI に戻す — 本番の山はここ。
+物体なしの対比が無ければ cue≠key は何も証明していない。プロジェクタ切替は Step 1→2 と
+Step 3→4 の1往復のみ。マウスは使わない（Tab/Enter）。端末幅124桁以上（#169 の
+Doctor/Inspect 非活性化でフッタが縮み、閾値が123→124桁に変わった点に注意）。
+Fill Free Space は実測4分なので壇上では実行しない。失敗時は録画へ切替。
+約7分半で切り上げ、Q&Aに15分残す。
+```
+
+理由: 台本 v5（`Phasmid_Talk_Script_30min.md`）の Slide 24 セクションと歩調を合わせる。
+主な変更点は次の3つ:
+1. "I store a file" → WebUI での Bind（Face 2つの登録）に置き換え。Add File は #169 で
+   非活性化済みのため、この表現をそのまま使うと壇上の操作と一致しない。
+2. Step 番号を「Step 3b」から**「Step 4」**へ統一（ランブック・台本と同じ番号体系）。
+3. 端末幅の閾値を **123桁→124桁**に修正（Doctor/Inspect 非活性化でフッタの項目数が
+   1つ減ったことによる — ランブック §9 参照）。
+
+---
+
+## 変更不要なスライド（確認済み）
+
+Slide 1〜22、25、26 の本文・ノートを python-pptx で確認したが、TUI/WebUI の役割分担や
+Issue #169 に関わる記述は含まれていない（Slide 16 の "Operate through CLI, TUI, or local
+WebUI" のような一般論の記述は今回の変更と矛盾しないため据え置き）。
+
+---
+
+## 反映後の確認
+
+編集後、以下で本ファイルとの整合を再確認できる:
+- `docs/submissions/Phasmid_Demo_Runbook.md` §1（タイミング表）・Step 2〜4
+- `docs/submissions/Phasmid_Talk_Script_30min.md` Slide 24 セクション（本ドキュメントの
+  「変更後」はこのファイルの記述とほぼ同一の文言）
+- 公開アーティファクト「Phasmid — DEF CON Demo Labs Run-of-Show」

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -1,13 +1,14 @@
 # Phasmid — Live Demo 実施細部要領 / Demo Runbook
 
-**対象:** DEF CON Demo Labs 本番の実機デモ（Deck Slide 24）。プレゼン30分のうち**約7分**を割り当て、**Q&A/交流15分を必ず確保**する。
-**画面:** 実TUI（Local Disclosure Control）が本編。ローカルWebUI は Step 5 のローカル境界の提示にのみ使う（Store/Retrieve は本編と同じ Vessel を操作するが、この統合経路は壇上ではまだ実機で通しておらず、判定が物体キュー照合に依存しCIでは検証できないため本編には含めない）。
+**対象:** DEF CON Demo Labs 本番の実機デモ（Deck Slide 24）。プレゼン30分のうち**約7分半**を割り当て、**Q&A/交流15分を必ず確保**する。
+**画面:** TUI（Local Disclosure Control）で Prepare・Refuse・Disclose を、**ローカルWebUI で Bind・Operate（登録・復元）** を行う。プロジェクタ切替は **Step 2→3 と Step 4 の手前の1往復のみ**。
 
 > **情報の確度について**
 > - **本書は 0.4.0 実機（Pi Zero 2 W / Raspberry Pi OS Trixie）で全手順を通した結果に基づく。** 〔要確認〕は原則として解消済み。実機で確認していない項目のみ §9 末尾に明示する。
-> - **前版からの重要な変更:** Step 2 の画面が違っていた（Faces ではなく Open Vessel の `Add File`）。Step 4 の参照先が違っていた（Operator Log ではなく Audit）。Step 3b（物体なしでの失敗）を新設した。Fill Free Space は**実測4分のため壇上から外した**。**囮ファイルは運用者が用意する**ものとし、生成機能は空き領域の填充に位置づけ直した。
-> - **WebUI の Store/Retrieve は Vessel 経路に統一済み。** かつては TUI が `*.vessel`、WebUI が別の `vault.bin` を操作しており話が繋がらなかったが、現在は両者とも `resolve_web_vessel()` が解決した同じ Vessel を `VesselWorkflowService` 経由で操作する（Vessel 未登録時のみ旧 `vault.bin` にフォールバック）。Doctor の Dummy Profile 助言は、既定パスの存在有無ではなく `PHASMID_DUMMY_PROFILE_DIR` / `PHASMID_DUMMY_CONTAINER_PATH` が設定されているかどうかで判定するよう変更し、未設定端末での永久警告を解消した（#157）。運用者が自分の素材を指させれば分量を報告する。
-> - **注意:** 0.1.4 までは起動直後が Expert 相当の単層画面だった。それ以前の手順書のキー順は**そのままでは通らない**。
+> - **前版からの重要な変更（Issue #169・Phase 1 実装済み）:** TUI の **Add File** と Expert 画面の **Doctor・Inspect を非活性化**した — いずれも役割別トークンで保護された WebUI（`/store`、`/operator/doctor`、`/operator/inspect`）と完全に重複するため。**Recover File と Audit はあえて非活性化していない** — Recover File は cue≠key の否定証明（Step 4）を実証できる唯一の検証済み経路であり、Audit は本デモ Step 5 でキー1つで直接使う。どちらも WebUI 側の同等機能が今回のセッションでは十分に検証・統合されていないため、対応する WebUI 移行が済むまで TUI に残した。**削除ではなく非活性化** — 内部のサービス呼び出し・画面コードはそのまま残しており、リハーサルで問題が出れば1行で復元できる。
+> - **デモ構成もこれに合わせて改訂した。** Step 2「Bind」と Step 3「Operate（正しい物体での復元）」を **WebUI の Store/Retrieve 画面**に移した — 登録・復元の統合経路は実機で検証済み。**Step 4「物体を完全に外して失敗させる」は引き続き TUI の Recover File で行う**（この否定証明は今回のセッションでは WebUI 側で再検証していない。本番前に一度試すことを推奨。§9 末尾参照）。
+> - **Expert フッタの安全端末幅が 145→124 桁に下がった**（Doctor/Inspect の非活性化でフッタの項目数が減ったため。Audit は残っているので115桁までは下がらない）。
+> - **囮ファイルは運用者が用意する**ものとし、生成機能は空き領域の填充に位置づけ直している（v4 からの変更点、引き続き有効）。
 
 ---
 
@@ -21,29 +22,27 @@
 | **壇上で Fill Free Space を実行** | 64 MiB / 15% で**実測約4分**。枠は1:20 | **事前に埋めておき**、壇上では **Inspect Free Space** のみ |
 | **囮ファイルをツールに作らせる** | 生成される填充物は汎用ファイルであり、開示材料としての真実味がない | **囮は運用者が用意する。** 真のファイルによく似た偽ファイルを自分で保存する |
 | **素の `phasmid` で起動** | libcamera のログがTUIを破壊する／WebUIがラップトップから見えない／トークンが毎回変わる／`Ctrl+S` が効かないことがある | **`scripts/pi_zero2w/run_demo_console.sh`** を使う |
-| **成功例だけを見せる** | 物体キューが効いていることの証明にならない。観客にはただのパスワード復号に見える | **物体なしの失敗を必ず見せる**（Step 3b） |
+| **成功例だけを見せる** | 物体キューが効いていることの証明にならない。観客にはただのパスワード復号に見える | **物体なしの失敗を必ず見せる**（Step 4） |
+| **TUI で Add File を探す** | #169 で非活性化済み。Operation セレクタには Recover File・List Files・Remove File しか出ない | **Bind（Face登録）は WebUI** で行う。復元は Step 3 が WebUI、Step 4 は TUI の Recover File のまま |
 
 ---
 
-## 1. 制約と時間予算 / Constraints & budget（合計 ~7:00）
+## 1. 制約と時間予算 / Constraints & budget（合計 ~7:30）
 
 | # | フェーズ | 目安 | 画面 | 対応スライド概念 |
 |---|---|---|---|---|
 | 0 | オリエンテーション | 0:20 | TUI Simple | TUIホーム提示 |
 | 1 | Vessel 作成（Create） | 0:50 | TUI Simple | Prepare |
-| 2 | 物体キュー登録（Bind） | 1:10 | TUI | Bind（cue≠key） |
-| 3a | 復元 成功（Operate） | 0:40 | TUI | Operate |
-| 3b | **復元 失敗（物体なし）** | 0:40 | TUI | **★cue≠key の証明** |
-| 4 | Audit（空き領域と境界） | 0:50 | TUI Expert | 誠実性の可視化 |
-| 5 | WebUI（ローカル境界） | 0:40 | WebUI | ローカル境界 |
+| 2 | Bind — Face 1・Face 2 登録 | 1:30 | **WebUI**（store トークン） | Bind（cue≠key の準備） |
+| 3 | Operate — 復元 成功／役割の境界 | 0:50 | **WebUI**（store・recover トークン） | Operate |
+| 4 | **復元 失敗（物体なし）** | 0:50 | TUI | **★★cue≠key の証明** |
+| 5 | Audit（空き領域と境界） | 0:50 | TUI Expert | 誠実性の可視化 |
 | 6 | Silent Standby | 1:20 | TUI | Disclose / 山場 |
 | 7 | ラップ | 0:10 | TUI Simple | 締め |
 
-> **時計運用:** 開始 ~19:20。**26:00 を超えたら残手順を口頭要約**して締めへ。
-> **Step 3b は新設。** 物体の有無だけを変えた対比がなければ、cue≠key は実証されない。
-> **Step 2〜3b は TUI で行う。** WebUI の Store/Retrieve は本編と同じ Vessel を操作するが、
-> 統合経路を壇上ではまだ実機で通しておらず、判定が物体キュー照合に依存しCIでは検証できないため、
-> デモ本編には含めない（§4 Step 2 の注記を参照）。
+> **時計運用:** 開始 ~19:20。**26:00 を超えたら Step 2〜3 を口頭要約**して締めへ。
+> **プロジェクタ切替は1往復だけ。** Step 1 の終わりに TUI→ブラウザへ、Step 3 の終わりにブラウザ→TUI へ。以降 Step 4〜7 は切替なし。
+> **Step 4 は cue≠key の唯一の実証。** 物体の有無だけを変えた対比がなければ実証にならない。
 
 ---
 
@@ -52,12 +51,14 @@
 ### T-30分（設営時）
 
 - [ ] 実機（Pi Zero 2 W + カメラ + 三脚）を卓上に設置、電源・給電確認。
-- [ ] 表示系: TUIを映す経路と、**ラップトップのブラウザを映す経路**の両方を確保。**入力切替キーを把握**（Step 2〜4 はすべてTUIなので切替は不要。切り替えるのは Step 4→5 でTUIからブラウザへ、Step 5→6 でTUIに戻す1箇所のみ）。
-- [ ] **端末幅を145桁以上にする**（`tput cols` で確認）。これを下回ると Expert フッタから
+- [ ] 表示系: TUIを映す経路と、**ラップトップのブラウザを映す経路**の両方を確保。**入力切替キーを把握**（切り替えるのは Step 1→2 でTUIからブラウザへ、Step 3→4 でTUIに戻す1箇所のみ）。
+- [ ] **端末幅を124桁以上にする**（`tput cols` で確認）。これを下回ると Expert フッタから
       `w WebUI` が**無言で消える** — 露出したWebUIを引っ込めるキーが画面から失われる。
       省略記号は出ないので、狭いことに気付けない（→ §9）。
 - [ ] カメラのピント・画角・照明を確認（物体が安定認識される距離に三脚固定）。
 - [ ] **デモ用プロファイルで初期化**（実運用の秘匿データは載せない）。
+- [ ] **前回デモの Vessel が残っていれば `delete`（Delete Vessel）で完全に削除**してから
+      新規作成する。物体キューの残留は Vessel 新規作成時に自動でクリアされる（0.4.0）。
 - [ ] **起動は必ず次のスクリプトで:**
       ```bash
       cd ~/Phasmid && bash scripts/pi_zero2w/run_demo_console.sh
@@ -65,25 +66,26 @@
       `LIBCAMERA_LOG_LEVELS` / `PHASMID_WEBUI_EXPOSE_GADGET` /
       `PHASMID_STORE_TOKEN` / `PHASMID_RECOVER_TOKEN` /
       `PHASMID_RECOGNITION_MODE=demo` と `stty -ixon` を設定する。**素の起動では
-      デモが成立しない**（→ §0）。
-- [ ] **【重要】囮ファイルを自分で用意し、開示する Face に保存しておく。**
-      真のファイルによく似た、公開して差し支えない偽ファイルを1つ作る
-      （例: 同種の書式・同程度の分量の下書き）。`o` → `Add File` で
-      **開示用 Face（face_a）** に、**偽ファイル用パスフレーズ**で保存する。
-      **ツールに囮を生成させない。** 生成される填充物は空き領域を埋めるだけで、
-      開示材料にはならない。
-- [ ] 真のファイルを **face_b** に、**真ファイル用パスフレーズ**と
-      **破壊用パスフレーズ**で保存しておく。用意するパスフレーズは3つ:
-      真の復号用・真の破壊用・偽の復号用。
+      デモが成立しない**（→ §0）。役割トークンが1つでも発行されると
+      `PHASMID_WEB_TOKEN` は `/unlock` に受理されなくなる点に注意。
+- [ ] **【重要】囮ファイルと真のファイルを自分で用意しておく。** 真のファイルによく似た、
+      公開して差し支えない偽ファイルを1つ作る（例: 同種の書式・同程度の分量の下書き）。
+      **どちらも Step 2 で WebUI から保存する** — TUI の `Add File` は #169 で
+      非活性化済みなので使わない（`Recover File` は Step 4 のために引き続き有効）。
+- [ ] 用意するパスフレーズは3つ: 真の復号用・真の破壊用・偽の復号用。
 - [ ] （任意）**Fill Free Space を事前実行**（約4分）。空き領域を埋め、
       容器が不自然に空でないようにする。経過時間が表示され画面は固まらない。
 - [ ] ラップトップのブラウザで `http://10.12.194.1:8000/unlock` を開き、
-      **Recoverトークン**（既定 `phasmid-demo-recover-token`）を入力して
-      **Homeまで進めた状態でタブを用意**。Step 5は見せるだけで操作しないので、
-      壇上に出す面はStore/Maintenanceリンクの出ないRecoverロールにしておく。
+      **store トークン**（既定 `phasmid-demo-store-token`）で **Home まで進めた
+      タブを1つ**、**recover トークン**（既定 `phasmid-demo-recover-token`）で
+      **Home まで進めたタブをもう1つ**、それぞれ用意してブックマーク。
       ※ `phasmid-pi.local` は使わない。**IPアドレス直指定**。
 - [ ] **バックアップ録画**（全手順を通した2〜3分クリップ）を再生機に用意し**頭出し**。
 - [ ] 予備電源／ケーブル。会場ネットワークは不要（WebUIはUSBガジェット面のみ）。
+- [ ] **本番前に確認すること（推奨・時間があれば）:** Step 4「物体を完全に外して
+      失敗させる」を WebUI Retrieve でも一度試しておく。成功すれば Step 4 も WebUI
+      側に統合でき、TUI への切り戻しが不要になり切替が0往復になる。今回のセッションでは
+      時間の都合でこの1点だけ未検証のまま残した。
 
 ### T-5分（登壇直前）
 
@@ -91,18 +93,19 @@
 - [ ] **`! SYSTEM: n WARN` は Simple 画面には出ない**（Expert専用）。内容を確認したい場合は
       `e` を押し、**確認後 `Esc` で Simple に戻しておくこと。**
 - [ ] WARN の内訳を把握（→ §6）。すべてホスト自身の事実。質問された場合の答えを用意。
-- [ ] デモ用パスフレーズ／物体プロップを手元に。**実秘匿は使わない**。
+- [ ] デモ用パスフレーズ／物体プロップ（2つ、区別できるもの）を手元に。**実秘匿は使わない**。
 - [ ] Silent Standby は **`Ctrl+S`**（既定）。復帰は **`Ctrl+R`** または **`Esc`**。
       **フッタに出ないので指で覚えておく。**
+- [ ] **WebUI はまだ起動しない。** Step 2 で初めて `w` を押す。
 
 ---
 
 ## 3. 初期状態 & リセット / Initial state & reset
 
 - **初期状態:** Simple Operator 画面。Vessels は空（`No protected storage found.`）。
-- **囮と真のファイル:** **運用者が用意した2ファイルを保存済みの Vessel を別途用意しておく。**
-  Step 1 で作る Vessel は空のままでよく、Step 2〜4 では準備済みの方を使う。
-  **囮をツールに生成させないこと。壇上で空き領域の填充も実行しないこと。**
+- **Step 1 で作る Vessel はそのまま Step 2〜6 で使う。** 物体キューは Vessel 新規作成時に
+  自動でクリーンな状態から始まるので、以前のように `rm .state/store.bin .state/lock.bin`
+  を手動で行う必要はない。
 - **各サイクル後リセット:** §8 を実施。
 
 ---
@@ -119,7 +122,7 @@
 - **画面期待:** `PHASMID` ロゴ、`PROTECTED STORAGE` テーブル、下部バーは
   `o Open / n New / g Guided / e Expert / q Quit / w WebUI` の6項目。
 - **注意:** この最小面こそが coercion-aware 設計の一部である旨を一言で。Slide 14 の Silent Standby に伏線として繋がる。
-- **注意（旧版の誤り）:** **`! SYSTEM: n WARN` はこの画面には出ない。** 誠実性の話は Step 4 で行う。
+- **注意（旧版の誤り）:** **`! SYSTEM: n WARN` はこの画面には出ない。** 誠実性の話は Step 5 で行う。
 
 ### Step 1 — Create a Vessel（0:50｜Prepare｜TUI Simple）
 
@@ -130,9 +133,12 @@
 - **画面期待:** `PROTECTED STORAGE` に新規Vesselが出現。
   **下段のパネルが `Choose an action:` に変わること**（空状態メッセージが消える）。
 - **注意:** Vessel を作ると **Face が2つ自動生成される**（`face_a` / `face_b`、ともに `available`）。
+  新しい Vessel は物体キューも自動でクリーンな状態から始まる（0.4.0）。
   **Create Face を押す必要はない。デモ手順に含めない。**
 - **任意:** `e` → `i`（Inspect）で `Header absent` / `Magic Bytes absent` /
   `Entropy high / random-like (8.00 bits/byte)` を見せると Slide 19 の直接的裏付けになる。
+  （`i` は #169 で Expert フッタからは非活性化済みだが、コマンドパレット経由では
+  引き続き到達できる。フッタで見せたい場合は先に §9 の非活性化一覧を確認すること。）
 - **【重要】サイズは既定のままにしない。** 作成はコンテナ全体を乱数で埋める。
   512 MiB を指定すると Pi Zero 2 W では**書き込みに時間がかかり、枠の0:50に収まらない**。
   実機では 512 MiB 指定で**プロセスが OOM kill された**（2026-07-29）。原因は
@@ -140,59 +146,61 @@
   チャンク書き込みに修正済み。修正後もサイズなりの時間はかかるため、**壇上は `64M`**。
 - **失敗時:** 作成が滞れば既存デモVesselを **`o` (Open)** して以降を継続。
 
-### Step 2 — Object cue: Bind（1:10｜Bind, ★cue≠key｜TUI）
+### Step 2 — Bind: WebUI で Face 1・Face 2 を登録（1:30｜★BIND・切替①｜WebUI）
 
-> **重要（保管層は統一済み）:** WebUI の Store/Retrieve は現在、TUI と同じ Vessel 経路を通る。
->
-> | 経路 | 操作対象 |
-> |---|---|
-> | TUI `o` Open Vessel | `*.vessel`（`VesselWorkflowService`） |
-> | **WebUI Store / Retrieve** | **同じ `*.vessel`**（`resolve_web_vessel()` が解決した Vessel に対し `VesselWorkflowService` を呼ぶ。Vessel 未登録時のみ旧 `vault.bin` にフォールバック） |
-> | TUI Audit / Inspect | `*.vessel` |
->
-> **旧版時点では TUI と WebUI が別レイヤ（`*.vessel` / `vault.bin`）を操作していた。**
-> 現在は統一済みで、WebUI で保存すれば
-> Step 1 で作った Vessel に反映され、Step 4 の Audit にも現れる。
->
-> それでも **Step 2〜3b は必ず TUI で行うこと。** 理由は保管層が分離しているからではない。
-> 統合経路（WebUIがVesselを操作する現在の動作）を壇上ではまだ実機で通しておらず、
-> Store/Retrieve の判定はどちらの経路でも物体キュー照合に依存するため、CIでは検証できない
-> ——この2点による。
->
-> 旧版が `f` (Faces) と記載していたのは誤り。Faces 画面はラベルと可信性プロファイルの
-> 管理画面で、カメラに一切関与しない。物体キューを扱うのは `o` Open Vessel の
-> `Add File` である（`capture_reference=True` を渡す唯一の経路）。
+> **重要（#169・TUI の Add File は非活性化済み）:** TUI の Operation セレクタには
+> **Recover File・List Files・Remove File しか出ない。** Face の登録は **WebUI の Store 画面**で行う。
+> Store/Retrieve は Step 1 で作った Vessel と同じものを操作する（`resolve_web_vessel()` が
+> 解決した Vessel に対し `VesselWorkflowService` を呼ぶ。Vessel 未登録時のみ旧
+> `vault.bin` にフォールバック）。
 
-- **操作:** **`o`（Open）** → `Y` → Operation を **`Add File`** に変更
-  （Select はフォーカスして `Enter` → `↓` → `Enter`）→ **Input file** にファイルパス →
-  **Passphrase** と **Restricted recovery passphrase** → **物体をカメラの前に配置** →
-  `Tab` で `Run Operation` → `Enter`。
-- **画面期待:** `Stored N,NNN bytes in travel.vessel.`
-  `VESSEL STATUS` の `Face Files` が増える。
-- **発話（EN）:** "Now the object cue. I hold an everyday object in front of the camera while I store this file. Remember: this is a **cue, not a key**. It gates the operation; it is not the encryption key. A photograph of it unlocks nothing."
-- **注意:** **TUI はカメラ映像も一致状態も表示しない**（→ #158）。この段階では観客に
-  何が起きているか見えない。**だから Step 3b の対比が必須**である。
+- **操作:** TUI で **`w`** → プロジェクタをラップトップのブラウザへ切替 → 事前ブックマークの
+  `/unlock` タブに **`store` トークン**を入力 → **Store** 画面。Step 1「Choose the entry」で
+  **Entry 1** を選択 → ファイル選択 → パスワード入力 → **物体Aをカメラの前に配置** →
+  `Capture access object` → `Protect file`。続けて Step 1 を **Entry 2** に切り替え →
+  別ファイル → 別パスワード → **物体Bに差し替えて** `Capture access object` → `Protect file`。
+- **画面期待:** カメラプレビューに `Object cue matched` / `STABLE MATCH` の一致表示。
+  Entry を切り替えるたびに `Access object: Not captured` にリセットされる。
+  `Protect file` 成功で緑のトースト。
+- **発話（EN）:** "Now I switch to the browser — this device also serves a local WebUI, and I'm logged in with a token scoped to the store role. I register two Faces here. For each one, I hold an everyday object in front of the camera. Remember: this is a **cue, not a key**. It gates the operation; it is not the encryption key. A photograph of it unlocks nothing."
+- **注意:** **Entry を切り替えたら必ず物体も差し替える**こと — 同じ物体を両方の Face に
+  使おうとすると `Object binding failed` で拒否される（cue≠key を壊さないための安全装置。
+  実機で確認済み）。
 - **失敗時:** 認識が不安定なら距離/照明を微調整。起動スクリプトの既定
   `PHASMID_RECOGNITION_MODE=demo` で確定的に見せられる。
 
-### Step 3a — 復元 成功（0:40｜Operate｜TUI）
+### Step 3 — Operate: 復元 成功、そして役割の境界（0:50｜WebUI）
 
-- **操作:** **`o`（Open）** → `Y` → Operation は **`Recover File`**（既定）→
-  **Output file** にパス → **Passphrase** → **物体をカメラの前に配置** → `Run Operation`。
-- **画面期待:** `Recovered N,NNN bytes to <path>.`（緑）
-- **発話（EN）:** "Same object, correct password — the file comes back."
+- **操作:** 同じ `store` トークンのタブで **Retrieve** 画面へ。Face 1 の物体を提示 →
+  パスワード入力 → `Open protected file`。続けて、事前に別タブで **`recover` トークン**
+  で解錠しておいたウィンドウを一瞬提示 — ナビに `Store` / `Maintenance` へのリンクが
+  **一切無い**ことを指す。
+- **画面期待:** 緑のトーストで復元成功。`recover` タブのナビは `Home` / `Retrieve` /
+  `Lock` だけ。
+- **発話（EN）:** "Same object, correct password — the file comes back. And here's a second, narrower session, logged in with a different, role-scoped token. It can decrypt and destroy. It can never reach Face setup at all."
+- **注意:** 本編で WebUI の Store/Retrieve を実際に使うのはここまで。**次はプロジェクタを
+  TUI に戻して**、最も強い対比（物体を完全に外す）を見せる — これが往復の折り返し。
 
-### Step 3b — 復元 失敗（0:40｜★cue≠key の証明｜TUI）
+### Step 4 — 復元 失敗（0:50｜★★cue≠key の証明｜TUI）
 
-> **本書で最も重要なステップ。旧版には存在しなかった。**
+> **本書で最も重要なステップ。**
 > 成功例だけでは物体キューが効いていることを**何も証明していない**。観客には
 > 「パスワードを打ったらファイルが出た」としか見えない。**対比だけが証明になる。**
-> **実機で検証済み**（両側を確認）。
+> この仕組みは **TUI 経由でのみ実機再検証済み**（WebUI Retrieve での「物体なし→拒否」は
+> 今回のセッションでは未再検証 — 本番前に一度試すと Step 3 と地続きにでき、切替を
+> 0往復にできる。§2 の T-30 チェックリスト参照）。
 
-- **操作:** **物体をカメラの視野から外す**（退ける、または手で覆う）。
-  **他の項目は一切変えず**、もう一度 `Run Operation`。
+- **操作:** プロジェクタを TUI に戻す。**`o`（Open）** → `Y` → Operation は
+  **`Recover File`**（既定。#169 で `Add File` は選択肢から消えたが、`Recover File`
+  はこの Step 4 のために引き続き有効） → **Output file** にパス →
+  Face 1 と同じ **Passphrase** → **物体はカメラに見せない**（最初から視野の外、
+  または手で覆う）→ `Run Operation`。
 - **画面期待:** 約10秒後、赤で **`Open Vessel / no bound object matched`**。
   出力ファイルは作られない。
+- **将来的な改善案（未実施）:** WebUI Retrieve でも同じ「物体なし→拒否」を
+  一度確認できれば、Step 4 も Step 3 と同じ WebUI タブで完結させ、TUI への
+  切り戻しを不要にできる（切替を0往復にできる。§2 の「本番前に確認すること」参照）。
+  それまでは TUI の `Recover File` を非活性化しない。
 - **発話（EN）:** "Same file. Same password. Same everything — only the object is gone. The device waits ten seconds for a match, does not get one, and refuses. That is what 'the cue gates the operation' means — and notice it tells you almost nothing about *why* it failed. That is deliberate."
 - **注意:** **ここで間を取る。** これが cue≠key の唯一の実証である。
   可能なら**この直後に物体を戻して再実行し、成功させる**。
@@ -205,10 +213,11 @@
   この値は復号の入力そのもの（`_read_face_namespace` に渡る）なので、
   **照合を迂回して復元することはできない。**
 
-### Step 4 — Audit: 空き領域と、ツールが判定しないこと（0:50｜誠実性の可視化｜TUI Expert）
+### Step 5 — Audit: 空き領域と、ツールが判定しないこと（0:50｜誠実性の可視化｜TUI Expert）
 
-- **操作:** **`e`（Expert）→ `a`（Audit）**。
-  **`Free Space Filler` セクション**を指す。
+- **操作:** **`e`（Expert）→ `a`（Audit）**。`a` は #169 の非活性化対象から
+  意図的に外している — 本 Step でキー1つで直接使うため。**`Free Space Filler`
+  セクション**を指す。
 - **画面期待:**
   ```
   Free Space Filler
@@ -227,31 +236,14 @@
   `PHASMID_DUMMY_CONTAINER_PATH` が未設定なら `not configured` を返すだけであり、
   空き領域の実測値は Vessel を反映する Audit 画面が担う）。可信性ではなく空き領域の
   話として、**Audit 画面を指すこと。**
-- **任意:** **`d`（Doctor）を開いてよい。** 未設定の助言が警告を出さなくなったので、
+- **任意:** **`d`（Doctor）を開いてよい**（同じくフッタからは非活性化済みだが
+  コマンドパレット経由で到達できる）。未設定の助言が警告を出さなくなったので、
   残る警告はこのホスト自身の事実だけになった（→ §6）。「ツールが自分の動作環境を
   正直に報告する」実例として使える。
 
-### Step 5 — Local WebUI（0:40｜ローカル境界｜WebUI）
-
-> **役割を限定すること。** WebUI の Store/Retrieve は本編と同じ Vessel を操作するようになったが、
-> **この統合経路は壇上ではまだ実機で通していない**ため、
-> **ここでファイルを保存したり復元したりしてはいけない。** このステップは**「同じ操作面が
-> ローカル境界の内側にも用意されている」ことを見せるだけ**に留める。
-
-- **操作:** TUI で **`w`** を押して起動。プロジェクタをラップトップのブラウザに切替、
-  事前に `/unlock` を通しておいたタブを提示。**画面を見せるだけで操作はしない。**
-- **画面期待:** ブラウザ上部に赤帯
-  `WEBUI ACTIVE — INTERFACE IS EXPOSED — ACCESS FROM TRUSTED NETWORK ONLY`。
-  TUI 側にも `WEBUI ACTIVE AT http://10.12.194.1:8000 - PRESS [w] TO RETRACT`。
-- **発話（EN）:** "The same device also serves a local web interface — bound to loopback by default. Reaching it from a tethered laptop over USB is an explicit opt-in that binds only the USB interface, and it still needs an access token. It never touches a network. Both ends say plainly that the interface is exposed."
-- **注意:** **`w` を押して30秒以内に `Ctrl+S` を押さないこと。** 起動通知には
-  アクセストークンが含まれており、表示中に Standby へ入るとトークンが秘匿画面に残る。
-  修正済みだが、余裕を持って進めること。
-- **失敗時:** 起動が遅ければ口頭説明に留め、TUIへ戻る（時間優先）。
-
 ### Step 6 — Silent Standby（1:20｜★Disclose 山場｜TUI）
 
-- **操作:** プロジェクタをTUIに戻す。**`Ctrl+S`** を押下。復帰は **`Ctrl+R`** または **`Esc`**。
+- **操作:** **`Ctrl+S`** を押下。復帰は **`Ctrl+R`** または **`Esc`**。
 - **注意（キーの所在）:** `Ctrl+S` はフッタに表示されない設計。**指で覚えておくこと。**
   起動スクリプトが `stty -ixon` を実行しているので、ターミナルのフロー制御（XOFF）に
   食われることはない。**素の起動だと押しても無反応になりうる。**
@@ -267,14 +259,14 @@
   [ Re-authenticate to continue ]
   ```
   フッタは `^r Re-authenticate` のみ。
-- **WebUI も同時に落ちる。** ラップトップのブラウザを再読込すると接続が切れていることを
-  見せられる（**これを演出に使う**）。復帰後に
+- **WebUI も同時に落ちる。** Step 2〜3 で開いた2つのブラウザタブを再読込すると接続が
+  切れていることを見せられる（**これを演出に使う**）。復帰後に
   「WebUI was retracted when standby engaged.」の通知が出る。
 - **Standby 発動時に未消化のトースト通知も消える。** WebUI 起動時の通知は30秒表示で、
   本文に**アクセスURLとトークンが入っている**。これを消さないと、秘匿画面のはずの
   Standby 画面にトークンが平文で残る。実機で一度再現し、修正済み。
   Standby 画面のフッタから `w WebUI` も消える（封緘中に再露出させないため）。
-- **発話（EN）:** "Now the moment it's built for. One hotkey — **Silent Standby**. The sensitive surface drops away. And it is not just this screen: the web interface goes down with it, so a laptop tethered to this device loses access at the same instant. Recovery needs re-authentication. I'm not hiding from forensics — I'm buying **time** and **uncertainty**."
+- **発話（EN）:** "Now the moment it's built for. One hotkey — **Silent Standby**. The sensitive surface drops away. And it is not just this screen: the web interface goes down with it, so a laptop tethered to this device loses access at the same instant — including the two browser tabs I just used. Recovery needs re-authentication. I'm not hiding from forensics — I'm buying **time** and **uncertainty**."
 - **注意:** **本デモの山。** ゆっくり、間を取る。倫理（Slide 21）に接続して締める。
 - **失敗時:** 遷移が出なければ録画の該当箇所を提示。「これが唯一の"魔法に見える"部分。実体はStateマシンです」と補足。
 
@@ -292,11 +284,11 @@
   "The design points stand either way." と明言し、Prepare→Bind→Operate→Disclose を録画上で辿る。
 - **認識不安定:** 起動スクリプトの既定が `demo` モード。それでも不安定なら
   `coercion_safe` の低信頼→ダミー経路を**設計意図として逆手に説明**。
-- **WebUI がラップトップから見えない:** `PHASMID_WEBUI_EXPOSE_GADGET=1` が効いているか、
-  URLが **`10.12.194.1:8000`（IP直指定）** かを確認。`127.0.0.1` と `phasmid-pi.local` は
-  ラップトップからは**到達しない**。最悪、**Step 5 を口頭説明のみに留めてスキップする**
-  （Step 1〜4・6・7 はWebUIに依存しないため影響を受けない）。
-- **時間超過:** 26:00 到達で Step 4 と Step 5 を飛ばし、**Step 3b と Step 6 だけは必ず見せる**。
+- **WebUI がラップトップから見えない、または不安定:** `PHASMID_WEBUI_EXPOSE_GADGET=1` が
+  効いているか、URLが **`10.12.194.1:8000`（IP直指定）** かを確認。`127.0.0.1` と
+  `phasmid-pi.local` はラップトップからは**到達しない**。**Step 2〜3（Bind・WebUI 部分）を
+  口頭要約に切り替え、Step 0・1・4・5・6・7 は実機で続行**（これらは WebUI に依存しない）。
+- **時間超過:** 26:00 到達で Step 2〜3 を口頭要約に切り替え、**Step 4 と Step 6 だけは必ず見せる**。
 
 ---
 
@@ -338,12 +330,14 @@ CLI の Vessel 既定名と同一であるため、パス存在で判定する�
 
 ## 8. 終了後リセット / Teardown（次サイクル・次回のため）
 
-- [ ] デモVesselを削除/初期化。
+- [ ] Expert Home で **`delete`（Delete Vessel）** してデモ用 Vessel を完全に削除。
+      次サイクルの Vessel 新規作成時に物体キューも自動でクリーンな状態になるため、
+      以前必要だった手動の `rm .state/store.bin .state/lock.bin` は不要。
 - [ ] **次サイクル用に囮ファイルを保存し直す。** 空き領域の填充（約4分）まで戻す場合は、
       填充済みVesselを複数用意しておき差し替える。
 - [ ] Silent Standby を `active` に復帰（`Ctrl+R`）。
 - [ ] WebUIプロセス停止（`w`、またはinactivity auto-kill 10分待機）。
-- [ ] ブラウザタブを `/unlock` 済みの状態に戻す。
+- [ ] ブラウザタブ（store・recover 両方）を `/unlock` 済みの状態に戻す。
 - [ ] カメラ画角・三脚位置を再固定。
 
 ---
@@ -357,7 +351,13 @@ CLI の Vessel 既定名と同一であるため、パス存在で判定する�
 | 画面 | フッタ |
 |---|---|
 | `SimpleHomeScreen`（起動時） | `o` Open · `n` New · `g` Guided · `e` Expert · `q` Quit · `w` WebUI |
-| `HomeScreen`（`e` の後） | `Esc` Back · `o` · `x` · `c` · `i` · `f` · `g` · `a` · `d` · `s` · `l` · `?` · `q` · `w` |
+| `HomeScreen`（`e` の後、#169適用後） | `Esc` Back · `o` · `x` · `delete` · `c` · `f` · `g` · `a` · `s` · `t` · `l` · `?` · `q` · `w` |
+
+`d`（Doctor）と `i`（Inspect）は #169 でフッタから非活性化されたため、上表には
+含まれない。`a`（Audit）はあえて残した — Step 5 でキー1つで直接使うため。
+`HomeScreen.check_action` が `False` を返すことでフッタから消えるが（LUKS 非活性時と
+同じ仕組み）、対応する `action_doctor` / `action_inspect_vessel` メソッド自体は
+変更しておらず、コマンドパレット経由では引き続き到達できる。
 
 `Ctrl+S` が Silent Standby、`Ctrl+R` / `Esc` が復帰。`show=False` なのでフッタに出ない。
 `w` はアプリ全体のバインド（`tui/app.py`）で、どの画面からも効く。**ただし standby 中は
@@ -373,12 +373,14 @@ Standby ホットキーの既定は `config.py` の `PHASMID_STANDBY_HOTKEY`（�
   `passphrase` → `restricted-passphrase` → `target-occupancy`（既定 `15%`）→
   `inspect-` / `generate-` / `clear-plausibility-btn`
 - `OpenVesselScreen`（`o`）: `vessel-path` → `operation-select`
-  （`Add File` / `List Files` / `Recover File` / `Remove File`、既定 `Recover File`）→
+  （**`Recover File` / `List Files` / `Remove File`、既定 `Recover File`** — #169 で
+  `Add File` だけを Select の選択肢から外した。`Recover File` は Step 4 の cue≠key
+  証明のために残している。内部の `add` コードパスはそのまま残しており、選択肢に
+  戻すだけで復元できる）→
   `passphrase` → `open-btn`。**`face-select` / `input-file` / `restricted-passphrase` は
-  `Add File` と `Remove File` の時だけ表示される**（`Recover File` / `List Files` では
-  非表示。どちらの面が開いたかはパスフレーズと object cue から解決されるので、画面上で
-  面を選ばせない — 選ばせること自体が「面が2つある」ことを漏らしてしまうため）。
-  `output-file` は `Recover File` の時だけ表示される。
+  `Remove File` の時だけ表示される**（`List Files` では非表示。どちらの面が開いたかは
+  パスフレーズと object cue から解決されるので、画面上で面を選ばせない — 選ばせること
+  自体が「面が2つある」ことを漏らしてしまうため）。
 - `SettingsScreen`（`s`）: `vessel-dir`, `output-dir`, `container-size`, `theme`,
   `recent-tracking`, `compact-banner`, `save-btn`。**認識モードのUIは存在しない**
   （`PHASMID_RECOGNITION_MODE` は環境変数のみ。既定 `strict`、
@@ -399,8 +401,8 @@ Vessel を作ると **Face が2つ自動生成される**（`face_a` / `face_b`�
 
 | 経路 | 操作対象 | 根拠 |
 |---|---|---|
-| TUI `o` Open Vessel（Add/Recover/List/Remove） | `*.vessel` | `VesselWorkflowService` |
-| TUI Audit / Inspect | `*.vessel` | `AuditService` / `InspectionService` |
+| TUI `o` Open Vessel（Recover/List/Remove。Addは#169で非活性化） | `*.vessel` | `VesselWorkflowService` |
+| TUI Audit（フッタに残存） / Doctor・Inspect（#169でフッタ非活性化、パレットからは到達可） | `*.vessel` | `AuditService` / `DoctorService` / `InspectionService` |
 | **WebUI Store / Retrieve** | **同じ `*.vessel`**（`resolve_web_vessel()` が解決） | `web_server.py` が `VesselWorkflowService().add_payload` / `.retrieve_payload` を呼ぶ。Vessel 未登録時のみ `vault.bin` にフォールバック |
 
 `web_server.py` は現在 `VesselWorkflowService` と
@@ -409,23 +411,23 @@ TUI が使うのと同じ Vessel に対して動作する（Vessel が1つも登
 従来どおり `vault.bin` を使う）。`operator_inspect` はアップロードされたファイルを
 読むだけで、デバイス上の Vessel には触れない点は変わらない。
 
-**旧版時点では両経路が別レイヤ（TUI=`*.vessel` / WebUI=`vault.bin`）を操作していた。**
-Doctor の Dummy Profile 助言は、`PHASMID_DUMMY_PROFILE_DIR` /
-`PHASMID_DUMMY_CONTAINER_PATH` が空でない値に設定されているかどうかで判定するよう
-変更した（#157）。既定パスの存在有無では判定しない — コンテナ側の既定値 `vault.bin`
-は CLI の Vessel 既定名と同一のため、パス存在で判定すると一度でもファイルを保管した
-全端末で警告が復活してしまう。運用者がどちらかの変数で自分の素材を指させれば、
-検査はその分量を報告する。現時点でWebUIを本編から外している理由は保管層の分離ではなく、統合経路を壇上では
-まだ実機で通していないことと、Store/Retrieve の判定がどちらの経路でも物体キュー照合に
-依存しCIでは検証できないこと、の2点である。
+**Bind/Operate は実機で WebUI 経由の統合経路を検証済み（0.4.0）**
+
+Face 1・Face 2 の登録から復元まで、WebUI の Store/Retrieve 画面だけで完結する流れを
+実機で確認した（本ドキュメントの Step 2〜3 はこの結果を反映している）。ただし
+「物体を完全に外して失敗させる」という Step 4 の否定証明は、今回のセッションでは
+**TUI 経由でのみ再検証済み**で、WebUI 経由では未検証のまま残っている。
 
 **物体キューが実際に効いていることの根拠**
 
-`Add File`（`capture_reference=True`）で参照画像を登録し、`Recover File` は
+WebUI の `Capture access object`（Store画面）で参照画像を登録し、Retrieve は
 `collect_auth_sequence()` → `wait_for_reference_match(timeout=10.0)` で照合する。
-不一致なら `match_none` が返り `ValueError("no bound object matched")` になる。
+不一致なら `match_none` が返り復元が拒否される。
 一致トークンは `_read_face_namespace` の入力そのものなので、**照合を迂回した復元は
-成立しない。** ただし**TUIはこの過程を一切表示しない**（→ Step 3b の失敗対比が必須である理由）。
+成立しない。** TUI 経由の Recover File（#169 では非活性化せず残した）も同じ照合
+ロジックを使うが、**この過程を一切表示しない**（→ #158。WebUI は `STABLE MATCH`
+バッジとライブ映像でこれを表示できるが、Step 4 の「物体なし→拒否」自体は WebUI 側で
+まだ再検証していないため、この否定証明そのものは引き続き TUI で行う）。
 
 **性能実測（Pi Zero 2 W）**
 
@@ -445,8 +447,10 @@ Dummy Profile 助言が未設定時に警告しなくなった結果（#157）�
 事実のみ**になった: `/tmp` world-writable、Swap、Compressed swap の3件（この開発
 コンテナでは1件）。zram と swap を無効化すれば1件まで下がる。
 
-**最小端末幅: 145桁**（#160 で確定、#168 の `t Tokens` 追加で123→133、
-Delete Vessel追加で133→145に更新）
+**最小端末幅: 124桁**（#160 で確定、#168 の `t Tokens` 追加で123→133、
+Delete Vessel追加で133→145、#169 の Doctor/Inspect 非活性化で145→124に更新。
+Audit はフッタに残したため、Doctor/Audit/Inspect すべてを非活性化した場合の115桁までは
+下がっていない）
 
 フッタのセルは端末幅に応じて詰められず、**固定座標に配置されてはみ出した分は
 描画されない**。省略記号も出ないので、**フッタが不完全であることは画面から分からない。**
@@ -456,22 +460,27 @@ Delete Vessel追加で133→145に更新）
 
 | 幅 | Expert フッタ |
 |---|---|
-| 145桁以上 | 全項目表示 |
-| 144桁以下 | `w WebUI` が画面外 |
-| 135桁以下 | `q Quit` も画面外 |
-| 127桁以下 | `? Help` も画面外 |
-| 119桁以下 | `t Tokens` も画面外 |
-| 109桁以下 | `s Settings` も画面外 |
+| 124桁以上 | 全項目表示 |
+| 115〜123桁 | `w WebUI` が画面外 |
+| 107〜114桁 | `q Quit` も画面外 |
+| 99〜106桁 | `? Help` も画面外 |
+| 89〜98桁 | `t Tokens` も画面外 |
+| 77〜88桁 | `s Settings` も画面外 |
+| 68〜76桁 | `a Audit` も画面外 |
 
-**投影端末は145桁以上を確保すること。** T-30 の設営時に確認する。
+**投影端末は124桁以上を確保すること。** T-30 の設営時に確認する。
 `l LUKS` は LUKS 無効時（既定）に非表示になったため、閾値は131桁から123桁へ下がった
-（#160）。#168 で `t Tokens` バインディングを追加したことで133桁へ上がり、
-Delete Vessel（`delete`キー）バインディング追加で145桁へさらに上がった。
+（#160）。#168 で `t Tokens` バインディングを追加したことで133桁へ、
+Delete Vessel（`delete`キー）バインディング追加で145桁へ上がったが、
+#169 で Doctor・Inspect の2バインディングをフッタから非活性化したことで124桁へ
+下がった（Audit は意図的に残したため、3つとも非活性化した場合の115桁までは下がらない）。
 回帰テスト `test_expert_footer_shows_every_binding_at_the_documented_minimum_width`
-が両側から固定しているので、バインディングを追加すると失敗して本表の更新を促す。
+が両側から固定しているので、バインディングを追加・削除すると失敗して本表の更新を促す。
 
 **未検証項目**
 
-- なし（本節の項目はすべて実機または回帰テストで確定済み）。
+- Step 4「物体を完全に外して失敗させる」を WebUI Retrieve 経由で行った場合の挙動。
+  ロジックは TUI と共通（`wait_for_reference_match` を経由）だが、今回のセッションでは
+  WebUI 経由でのこの特定のケースを直接は再確認していない。本番前に一度試すことを推奨。
   #157（Doctor の Dummy Profile 助言が既定パス判定のため未設定端末で永久に警告していた
-  問題）は本改訂で解決済み。残る既知の未解決事項は #158（TUI の照合表示）のみ。
+  問題）は解決済み。残る既知の未解決事項は #158（TUI の照合表示）のみ。

--- a/docs/submissions/Phasmid_Talk_Script_30min.md
+++ b/docs/submissions/Phasmid_Talk_Script_30min.md
@@ -2,6 +2,7 @@
 
 **Deck:** Phasmid_DEFCON_DemoLabs.pptx（全26枚 / 各スライドに同内容のスピーカーノート埋め込み済み）
 **Presenter:** Makoto Sugita (Mr.Rabbit / 01rabbit)
+**改訂 v5（0.4.0）:** Slide 24 のデモ構成を、実機で検証済みの WebUI 中心の Bind/Operate に更新。**Step 2「Bind」と Step 3「Operate（正しい物体での復元）」は WebUI**（役割別トークン: store / recover）で行い、**Step 4「物体なしでの失敗」だけを TUI に残す**（この否定証明はWebUI側で今回のセッションでは未再検証のため）。プロジェクタ切替は Step 1→2 と Step 3→4 の**1往復のみ**に抑制。Issue #169（TUI の Add File・Doctor・Inspect を非活性化、WebUIと重複するため）を反映し、Slide 24 の手順表と Q&A の一部を更新。
 **改訂 v4:** 製品モデルの確定を反映。**囮ファイルはツールが作らない — 利用者が用意する。** 生成機能は「空き領域の填充」へ降格し、Slide 14・21・22 の記述を差し替え。**強要下では開示しない**（制限パスフレーズは破壊資格であり取出資格ではない）ことを Slide 21 で明言。**パスフレーズは3つ**（真の復号／真の破壊／偽の復号）を Slide 12 に明示。Slide 24 のデモ手順を実機ランブック（8ステップ）と一致させ、**Step 3b（物体なしでの失敗）** を山場として新設。**ステッカーは未作成のため Slide 25・26 の言及を削除**し、卓上デモへの導線に差し替え。
 > 旧 v3: 実装（silent_brick／purge／emergency_daemon）と整合させ、Slide 6・21 の「破壊しない」記述を撤回。核心を「**Phasmid destroys, but never fabricates**（破壊はする／偽造・隠蔽はしない）」へ変更し、owner-triggered destruction の存在と §2232 リスクを開示。
 > 旧 v2: 軍歴＝着想源＋inverse framing（Slide 2）、REAL CASE(2026)（Slide 4）、国境事案 Q&A を追加。
@@ -27,7 +28,7 @@
 | 機構 | 12 Pillars → 16 Flow | 08:50–13:50 |
 | 内部・実機 | 17 Tech → 20 Guards | 13:50–17:05 |
 | 倫理・限界 | 21 Ethics → 22 Scope | 17:05–19:05 |
-| **デモ（全TUI・8ステップ）** | 23 Divider → 24 Demo | 19:05–26:20 |
+| **デモ（TUI+WebUI・8ステップ、切替は1往復）** | 23 Divider → 24 Demo | 19:05–26:20 |
 | 締め | 25 Quick start → 26 Closing | 26:20–~27:30 |
 | **Q&A・卓上デモ・交流** | — | ~27:30–45:00 |
 
@@ -85,7 +86,7 @@
 
 ## [09:40] Slide 13 — The object is a cue, not a key　★見せ場
 **EN:** "Here's the fun part. You show an everyday **object** to the camera to operate the access gate — nothing to type, nothing that looks like a secret. But this is the part people get wrong, so let me be clear: the object is a **cue, not a key**. It drives operation and policy checks. It is **not** the encryption key. A photo of the object unlocks nothing. The crypto stays with Argon2id and AES-GCM — the object just decides whether you get to act. **And you'll watch this fail live in a few minutes** — same file, same password, no object."
-**JA:** ゆっくり。cue≠key を二度言う。手元の物体を掲げると効果的。**最後の一文で Step 3b を予告する。** 実証を約束しておくとデモの山が強くなる。
+**JA:** ゆっくり。cue≠key を二度言う。手元の物体を掲げると効果的。**最後の一文で Step 4 を予告する。** 実証を約束しておくとデモの山が強くなる。
 
 ## [11:00] Slide 14 — Coercion-safe delaying　★製品モデルの核心
 **EN:** "This is what makes it coercion-*safe*. **Silent Standby** — a hotkey drops the sensitive UI into a harmless state; recovery needs re-auth. Then the material itself, and I want to be exact about this: **the file you would hand over is one *you* wrote and stored yourself**, before any coercion. **Phasmid does not manufacture your cover story.** A generated dataset would not survive five minutes of questioning by someone holding your passport — realism has to come from your own material, not from my random-text generator. What the tool *does* offer is a **filler** that occupies free space, so an otherwise empty container doesn't read as empty. That's a volume problem, and volume is something software can actually solve. And **context profiles** — travel, field engineer, researcher — tell you what 'normal' should look like, so you know what to prepare. In coercion-safe mode, a low-confidence match routes to the disclosure face instead of failing loudly. The goal isn't magic invisibility — it's **uncertainty and delay**."
@@ -127,30 +128,30 @@
 **EN:** "Alright — live demo."
 **JA:** 呼吸を整え実機へ。プロジェクタ入力をTUIへ切替。**バックアップ録画の頭出しを確認。**
 
-## [19:20] Slide 24 — Live demo（実TUI）　★中心 / 約7分
-**EN（最小限・手を動かしながら）:** "This is the real TUI — **Local Disclosure Control**. I'll **create a vessel**. I'll **store a file** while holding an everyday object in front of the camera. I'll **recover it** with the object — it comes back. Then watch this: **same file, same password, same everything — only the object is gone.** Ten seconds, and it refuses. That is what 'the cue gates the operation' means. Then **Audit** — and notice what it *doesn't* claim. Then the local **WebUI** over USB, and **Silent Standby**. Watch the bottom bar."
+## [19:20] Slide 24 — Live demo（TUI + WebUI）　★中心 / 約7分半
+**EN（最小限・手を動かしながら）:** "This is the real system — the **TUI** handles prepare, refuse, and disclose; the local **WebUI**, reached over USB, handles bind and operate. I'll **create a vessel** here. Then I switch to the browser, log in with a store-scoped token, and **register two Faces** — each one bound to an everyday object in front of the camera. I'll open one back with the correct object — it comes back, and I'll show you a second, narrower session that can never reach Face setup at all. Then I switch back here and do the important part: **same file, same password, same everything — only the object is gone.** Ten seconds, and it refuses. That is what 'the cue gates the operation' means. Then **Audit** — and notice what it *doesn't* claim. Then **Silent Standby**. Watch the bottom bar."
 
-**JA デモ手順:** 詳細は別紙 **`docs/submissions/Phasmid_Demo_Runbook.md`（8ステップ）** に従う。要点のみ：
+**JA デモ手順:** 詳細は別紙 **`docs/submissions/Phasmid_Demo_Runbook.md`（8ステップ、合計 ~7:30）** に従う。要点のみ：
 
-| # | 手順 | 目安 | 要点 |
-|---|---|---|---|
-| 0 | オリエンテーション | 0:20 | Simple 画面の6キーを指す。最小面も coercion-aware 設計の一部 |
-| 1 | `n` Create Vessel | 0:50 | ヘッダなし・マジックバイトなし |
-| 2 | `o` Open → **Add File**（物体を構える） | 1:10 | **Faces 画面ではない。** カメラを使うのは Add File だけ |
-| 3a | `o` Open → Recover（物体あり） | 0:40 | "Same object, correct password — the file comes back." |
-| **3b** | **Recover（物体なし）→ 約10秒後に失敗** | 0:40 | **★本デモの証明。ここで必ず間を取る。** 可能なら物体を戻して往復させる |
-| 4 | `e` → `a` Audit | 0:50 | `Free Space Filler` を指す。**判定しないことを誇る** |
-| 5 | `w` WebUI（見せるだけ） | 0:40 | 露出バナーを両端で見せる。**操作はしない** |
-| 6 | `Ctrl+S` Silent Standby | 1:20 | **山場。** WebUI も同時に落ちる。ゆっくり |
-| 7 | `Esc` で復帰・ラップ | 0:10 | Prepare→Bind→Operate→Disclose を一言で |
+| # | 手順 | 目安 | 画面 | 要点 |
+|---|---|---|---|---|
+| 0 | オリエンテーション | 0:20 | TUI | Simple 画面の6キーを指す。最小面も coercion-aware 設計の一部 |
+| 1 | `n` Create Vessel | 0:50 | TUI | ヘッダなし・マジックバイトなし |
+| 2 | Bind — Face 1・Face 2 登録 | 1:30 | **WebUI**（store） | **プロジェクタ切替①。** カメラを使うのはここだけ。物体は Face ごとに差し替える |
+| 3 | Operate — 復元成功／役割の境界 | 0:50 | **WebUI**（store・recover） | recover トークンには Store/Maintenance への導線が無いことを見せる |
+| 4 | **復元 失敗（物体なし）** | 0:50 | TUI | **プロジェクタ切替②。★本デモ唯一の証明。** ここで必ず間を取る。可能なら物体を戻して往復させる |
+| 5 | `e` → `a` Audit | 0:50 | TUI Expert | `Free Space Filler` を指す。**判定しないことを誇る** |
+| 6 | `Ctrl+S` Silent Standby | 1:20 | TUI | **山場。** WebUI も同時に落ちる。ゆっくり |
+| 7 | `Esc` で復帰・ラップ | 0:10 | TUI | Prepare→Bind→Operate→Disclose を一言で |
 
 **JA 注意:**
 - **マウスは使わない。** SSH越しではクリックが Textual に届かない。`Tab` / `Enter` のみ。
-- **端末幅123桁以上。** 下回ると Expert フッタから `w WebUI` が無言で消える。
+- **端末幅124桁以上。** 下回ると Expert フッタから `w WebUI` が無言で消える。
+- **プロジェクタ切替は1往復だけ。** Step 1→2 でTUIからブラウザへ、Step 3→4 でブラウザからTUIへ。以降は切替なし。
 - **`Fill Free Space` は壇上で実行しない**（実測約4分）。事前に埋めておき `Inspect` のみ。
-- **囮ファイルは事前に自分で用意し保存しておく。** 壇上でツールに生成させない。
-- **成功例だけを見せない。** Step 3b の対比が無ければ cue≠key は何も証明していない。
-- **7分で切り上げ、Q&Aに15分以上を残す。** 26:00 を超えたら残手順を口頭要約。失敗時は録画へ切替し設計点を口頭補強。
+- **囮ファイルは事前に自分で用意しておく。** 壇上でツールに生成させない。保存自体は Step 2 の WebUI で行う（#169 で TUI の `Add File` は非活性化済み）。
+- **成功例だけを見せない。** Step 4 の対比が無ければ cue≠key は何も証明していない。
+- **7分半で切り上げ、Q&Aに15分以上を残す。** 26:00 を超えたら Step 2〜3 を口頭要約。失敗時は録画へ切替し設計点を口頭補強。
 
 ## [26:20] Slide 25 — Quick start
 **EN:** "Want to try it? Clone the repo, cd in, run `./phasmid` — first run sets up a venv and opens the console. Research software, Apache-2.0. Evaluate it locally, in field-test conditions — not as production protection."
@@ -171,11 +172,11 @@
 - **「LUKSとの関係は?」** → TUIのLUKS連携に触れつつ、Phasmidは*開示制御の層*でありFDEの代替ではない（Slide 6・22）。
 - **「否認可能性は?」** → データ存在の否認は*部分的*、完全否認は*非主張*（Slide 22）。
 - **「押収後、本当に守れるのか?」** → ホスト侵害・カーネル奪取は*対象外*（Slide 8）。増やすのは不確実性と時間（Slide 21）。
-- **「object-cueは生体認証/鍵?」** → 否。*cueであってkeyではない*（Slide 13）。壇上で失敗を実演済み（Step 3b）。
+- **「object-cueは生体認証/鍵?」** → 否。*cueであってkeyではない*（Slide 13）。壇上で失敗を実演済み（Step 4）。
 - **「囮ファイルはツールが作るのか?」** → **否。利用者が用意する。** *"The tool has no idea what a believable version of your life looks like. You do. What it generates is filler for free space — that's a volume problem, and it says so. It never claims the filler is what you hand over."*（Slide 14・22）
 - **「plausibility score は何を測っているのか?」** → **空き領域の占有率であって、説得力ではない。** Audit も Doctor も**分量しか報告しない**。旧版はこれを可信性として表示していたが、判定できないものを判定しているように見えるため撤去した。
 - **「強要されてパスワードを言わされたら?」** → 渡すのは**偽ファイル用のパスフレーズ**で、自分で用意した囮が開く。**制限（duress）パスフレーズは破壊資格であり、開示はしない。** 偽の中身を自動生成して差し出す経路は**意図的に持っていない**——それは偽造だから（Slide 21）。
-- **「WebUIとTUIで見えるものが違うのでは?」** → **保管層は統一済み。** 以前は TUI が `*.vessel`、WebUI が別の `vault.bin` を操作していたが、現在は両者とも同じ Vessel を操作する。ただし**デモ本編では WebUI で保存・復元しない**——統合経路を壇上でまだ実機検証しておらず、判定が物体キュー照合に依存するため CI でも検証できないため。
+- **「WebUIとTUIで見えるものが違うのでは?」** → **保管層は統一済み。** 以前は TUI が `*.vessel`、WebUI が別の `vault.bin` を操作していたが、現在は両者とも同じ Vessel を操作する。**デモ本編でも Step 2・3 は実際に WebUI で Face 登録と復元を行っており**、実機で検証済み。唯一まだ WebUI 側で再検証していないのは Step 4 の「物体なし→拒否」という否定証明1点だけで、それだけは引き続き TUI の `Recover File` で行っている。"The only piece I haven't re-confirmed through the browser yet is the negative case — object completely absent. Everything else you saw tonight, store and retrieve both, ran through the same WebUI."
 - **「法的に問題は?」** → 偽造・改ざん・隠蔽（fabricate/forge/hide）は*行わない*。一方 **owner-triggered の破壊（silent-brick／purge）は実装されており、法的に危険**（§2232型）。合法性は管轄依存であり助言はしない（Slide 21）。
 - **「あの国境の duress-wipe 訴追事案をどう見る?」** → *"That case turns on a destructive act. Phasmid actually **includes** owner-triggered destruction — silent-brick and purge — so this risk applies directly to anyone who uses it. I'm not going to pretend otherwise, and I'm not going to advise using it against lawful process. Legality is jurisdiction-dependent, this is a research prototype, and I won't comment on an active prosecution or give legal advice. The design principle is that Phasmid destroys but never fabricates."* 個別事案の是非・政治的背景には立ち入らない。破壊機能の存在は隠さず、利用者リスクとして開示する。
 
@@ -184,4 +185,4 @@
 - **巻いている（-3分以上）:** Slide 8・14・21 を丁寧に。デモで Audit と Doctor を実演拡張。
 - **デモ不調:** 章扉（23）で頭出しした録画へ即切替。「設計点は録画でも成立する」と明言し、口頭で Prepare→Bind→Operate→Disclose を辿る。
 - **物体認識が不安定:** 起動スクリプトの既定は `demo` モード。それでも不安定なら `coercion_safe` の低信頼→開示面ルートを**設計意図として逆手に説明**する。
-- **時計運用:** 19:20 でデモ開始、**26:00 を超えたら残手順を口頭要約**して締めへ。**Step 3b と Step 6 だけは何があっても見せる。** 45:00 厳守。
+- **時計運用:** 19:20 でデモ開始、**26:00 を超えたら Step 2〜3 を口頭要約**して締めへ。**Step 4 と Step 6 だけは何があっても見せる。** 45:00 厳守。

--- a/src/phasmid/tui/screens/home.py
+++ b/src/phasmid/tui/screens/home.py
@@ -231,6 +231,17 @@ class HomeScreen(OperatorScreen):
         self._run_startup_checks()
         self._log("Vessel list refreshed.")
 
+    # Duplicated by the role-gated WebUI (#169): Doctor -> /operator/doctor
+    # and Inspect -> /operator/inspect call the identical service function.
+    # Hidden here rather than removed - a fast, low-risk revert (Phase 1:
+    # deactivate, delete once stable) - the action_* methods below are
+    # untouched and still reachable from the command palette, same as the
+    # LUKS precedent. Audit is equally duplicated by /operator/audit but
+    # stays visible: the demo runbook's Step 5 drives it directly from this
+    # binding, and hiding it would force a slower command-palette detour on
+    # stage with no benefit until that beat moves to the WebUI too.
+    _WEBUI_DUPLICATED_ACTIONS = ("doctor", "inspect_vessel")
+
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         # Footer cells sit at fixed offsets, so anything past the terminal
         # width is simply not drawn - and `w` (WebUI), an app-level binding
@@ -241,6 +252,8 @@ class HomeScreen(OperatorScreen):
         # Textual treats False as "disabled and not shown"; None would keep
         # the cell and only grey it out, which would not free any columns.
         if action == "luks_panel" and PHASMID_LUKS_MODE.strip().lower() == "disabled":
+            return False
+        if action in self._WEBUI_DUPLICATED_ACTIONS:
             return False
         return True
 

--- a/src/phasmid/tui/screens/open_vessel.py
+++ b/src/phasmid/tui/screens/open_vessel.py
@@ -34,6 +34,11 @@ class OpenVesselScreen(OperatorScreen):
         text-style: italic;
         padding: 1 0;
     }
+    OpenVesselScreen #webui-redirect-note {
+        color: $text-muted;
+        text-style: italic;
+        padding: 0 0 1 0;
+    }
     OpenVesselScreen #open-btn {
         margin-top: 2;
         width: 100%;
@@ -44,8 +49,18 @@ class OpenVesselScreen(OperatorScreen):
         ("Disclosure Face 1", "face_a"),
         ("Disclosure Face 2", "face_b"),
     ]
+    # Add File is deactivated here (#169): fully duplicated by the WebUI's
+    # role-gated /store, and the current demo flow registers both Faces there
+    # instead. The "add" code path below is deliberately left in place rather
+    # than deleted - restoring the option is a one-line revert.
+    #
+    # Recover File stays active, unlike the issue's suggested scope: it is
+    # the only *verified* way to demonstrate the object-absent refusal (the
+    # demo's central cue-not-key proof) - the WebUI /retrieve equivalent has
+    # not been separately confirmed for that specific case. Deactivate it
+    # once that verification happens; until then, removing it here would
+    # break the live demo's most important beat with no tested fallback.
     _OPERATION_OPTIONS = [
-        ("Add File", "add"),
         ("List Files", "list"),
         ("Recover File", "retrieve"),
         ("Remove File", "remove"),
@@ -82,6 +97,12 @@ class OpenVesselScreen(OperatorScreen):
             [(label, val) for label, val in self._OPERATION_OPTIONS],
             id="operation-select",
             value="retrieve",
+        )
+        yield Static(
+            "Add File now runs through the WebUI's Store page (store role) - "
+            "see Access Tokens. This screen still handles Recover File, "
+            "List Files, and Remove File.",
+            id="webui-redirect-note",
         )
         yield Label("Input file (store)", classes="field-label", id="input-file-label")
         yield Input(placeholder="Path to local file or stored name", id="input-file")

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2213,13 +2213,15 @@ def test_expert_footer_shows_every_binding_at_the_documented_minimum_width():
     the runbook to be updated rather than silently going stale.
 
     Raised from 123 to 133 when `t` (Access Tokens, #168) was added, then to
-    145 when `delete` (Delete Vessel) was added.
+    145 when `delete` (Delete Vessel) was added, then lowered to 124 when
+    Doctor and Inspect were hidden from the footer (#169 - duplicated by the
+    role-gated WebUI; Audit stays visible, see check_action).
     """
     import asyncio
 
     from textual.widgets._footer import FooterKey
 
-    MIN_WIDTH = 145
+    MIN_WIDTH = 124
 
     async def offscreen_at(width: int) -> list[str]:
         from phasmid.tui.app import PhasmidApp
@@ -2267,6 +2269,50 @@ def test_luks_binding_is_hidden_while_the_luks_layer_is_disabled():
         assert screen.check_action("luks_panel", ()) is True
 
     assert screen.check_action("open_vessel", ()) is True
+
+
+def test_doctor_and_inspect_bindings_are_hidden_duplicated_by_webui():
+    """Doctor and Inspect are fully duplicated by the role-gated WebUI (#169).
+
+    Both call the identical service function (run_doctor_checks,
+    inspect_vessel) as /operator/doctor and /operator/inspect. Deactivate-
+    first, per the issue: hidden from the footer via check_action, same as
+    the LUKS precedent, but the action_* methods are untouched and still
+    reachable (e.g. the command palette).
+
+    Audit is equally duplicated by /operator/audit but deliberately stays
+    visible: the demo runbook drives it directly from this binding, and the
+    WebUI has not replaced that beat yet.
+    """
+    from phasmid.tui.screens.home import HomeScreen
+
+    screen = HomeScreen.__new__(HomeScreen)
+
+    assert screen.check_action("doctor", ()) is False
+    assert screen.check_action("inspect_vessel", ()) is False
+    assert screen.check_action("audit", ()) is True
+    assert screen.check_action("open_vessel", ()) is True
+    assert callable(screen.action_doctor)
+    assert callable(screen.action_audit)
+    assert callable(screen.action_inspect_vessel)
+
+
+def test_open_vessel_screen_deactivates_add_file_only(monkeypatch):
+    """Add File is duplicated by /store (#169); Recover File is not removed.
+
+    Add is deactivated - the demo now registers both Faces through the
+    WebUI's Store page instead. Recover File stays: it is the only verified
+    way to demonstrate the object-absent refusal, the demo's central
+    cue-not-key proof, since the WebUI /retrieve equivalent has not been
+    separately confirmed for that specific case. Deactivated here rather
+    than removed: _attempt_open's "add" branch is untouched, so restoring
+    the option is a one-line revert.
+    """
+    from phasmid.tui.screens.open_vessel import OpenVesselScreen
+
+    option_ids = {value for _, value in OpenVesselScreen._OPERATION_OPTIONS}
+    assert option_ids == {"list", "retrieve", "remove"}
+    assert "add" not in option_ids
 
 
 def test_standby_clears_pending_notifications(monkeypatch):


### PR DESCRIPTION
## Summary

- Implements Issue #169 Phase 1 (deactivate, don't remove yet): hides **Add File** from the Open Vessel operation selector and **Doctor**/**Inspect** from the Expert footer, since all three are fully duplicated by the role-gated WebUI (`/store`, `/operator/doctor`, `/operator/inspect`).
- **Recover File** and **Audit** deliberately stay active/visible: Recover File is the only verified way to demo the object-absent refusal (the demo's central cue≠key proof), and Audit drives the demo's Step 5 directly with no WebUI replacement wired in yet. This is a risk-calibrated subset of the issue's suggested scope, documented inline everywhere it matters.
- Everything hidden is **deactivated, not removed** — the underlying service calls (`_attempt_open`'s `"add"` branch, `action_doctor`, `action_inspect_vessel`) and screens are untouched, so restoring is a one-line revert. Both remain reachable via the command palette.
- Recomputes the Expert footer's minimum safe terminal width (145 → 124 columns) now that two footer bindings are gone, and updates the regression test that pins the width from both sides.
- Rewrites `docs/submissions/Phasmid_Demo_Runbook.md` and `docs/submissions/Phasmid_Talk_Script_30min.md` around the WebUI-centric Bind/Operate flow already verified live on hardware this session (role-scoped `store`/`recover` tokens), keeping only the object-absent refusal on the TUI, with a single projector round-trip (TUI → WebUI after Step 1, WebUI → TUI before Step 4).
- Adds `docs/submissions/Phasmid_DEFCON_DemoLabs_PPTX_Changes_v0.4.0.md`: a precise before/after text summary (read directly from the current `.pptx` via python-pptx) for manually updating Slides 23–24 of the deck to match.
- Updates `docs/TUI_OPERATOR_CONSOLE.md` to describe the deactivated bindings and the Open Vessel screen's reduced operation set.

## Test plan

- [x] `python -m pytest -q` — 739 passed, 5 skipped
- [x] `black --check` / `ruff check` on all changed Python files — clean
- [x] `pytest tests/test_terminology.py tests/test_docs_and_templates.py` — 17 passed (doc/terminology consistency)
- [x] Manual: confirmed via `HomeScreen.check_action` that `doctor`/`inspect_vessel` return `False` (hidden) and `audit`/`open_vessel` return `True` (unchanged)
- [x] Manual: confirmed `OpenVesselScreen._OPERATION_OPTIONS` no longer includes `"add"` while `"retrieve"`/`"remove"`/`"list"` remain


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_