### PR TITLE
Keep the test suite out of the operator's real Phasmid config directory

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,7 @@ if _repo_root_str not in sys.path:
 # treats as "nothing registered". Tests that want a real target set the
 # variable themselves; tests that want the registry branch pop it.
 import os  # noqa: E402
+import tempfile  # noqa: E402
 
 import pytest  # noqa: E402
 
@@ -38,3 +39,30 @@ def _isolate_web_vessel_target():
             os.environ.pop("PHASMID_WEB_VESSEL", None)
         else:
             os.environ["PHASMID_WEB_VESSEL"] = previous
+
+
+# The same problem one level up: the Vessel registry itself lives in the
+# config directory, so a test that builds a VesselService without an override
+# reads and rewrites the operator's real `vessel_registry.json`. On a machine
+# where Phasmid is actually used, a test run mutates their registry, and
+# Vessels registered there leak into unrelated assertions - which is exactly
+# how a stale registry from a previous session turned into five failures in
+# test_web_server and test_scenarios that pointed at a purge call rather than
+# at the real cause.
+#
+# TestCase-based suites isolate this in setUp, but module-level test functions
+# have no setUp to hang it on, so it is done here for every test. A test that
+# wants a specific config directory still sets the variable itself; the
+# per-test patches nest on top of this one.
+@pytest.fixture(autouse=True)
+def _isolate_config_dir():
+    previous = os.environ.get("PHASMID_CONFIG_DIR")
+    with tempfile.TemporaryDirectory() as isolated:
+        os.environ["PHASMID_CONFIG_DIR"] = os.path.join(isolated, "config")
+        try:
+            yield
+        finally:
+            if previous is None:
+                os.environ.pop("PHASMID_CONFIG_DIR", None)
+            else:
+                os.environ["PHASMID_CONFIG_DIR"] = previous

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -48,6 +48,24 @@ def read_repo_text(path):
 
 
 class RestrictedFlowScenarioTests(unittest.TestCase):
+    def setUp(self):
+        # Same reason as WebServerBoundaryTests: the restricted-route
+        # scenarios reach active_vault(), which resolves through the Vessel
+        # registry, so an unisolated run depends on the Vessels registered on
+        # the machine rather than on the scenario definitions.
+        self._isolated_dirs = tempfile.TemporaryDirectory()
+        root = self._isolated_dirs.name
+        self._isolated_env = mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_CONFIG_DIR": os.path.join(root, "config"),
+                "PHASMID_STATE_DIR": os.path.join(root, "state"),
+            },
+        )
+        self._isolated_env.start()
+        self.addCleanup(self._isolated_dirs.cleanup)
+        self.addCleanup(self._isolated_env.stop)
+
     def tearDown(self):
         web_server._rate_limit.clear()
         web_server._restricted_sessions.clear()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -741,9 +741,17 @@ def test_frontend_clears_unavailable_on_camera_feed_load():
 # ---------------------------------------------------------------------------
 
 
-def test_profile_config_path_uses_platformdirs():
+def test_profile_config_path_uses_platformdirs(monkeypatch):
+    """The unoverridden default, so this one opts out of the isolation.
+
+    Every other test runs with `PHASMID_CONFIG_DIR` pointed at a temporary
+    directory (see the root conftest) to keep the operator's real registry out
+    of the suite. This test exists to check the fallback that applies when no
+    override is set, so it has to remove it first.
+    """
     from phasmid.services.profile_service import config_dir
 
+    monkeypatch.delenv("PHASMID_CONFIG_DIR", raising=False)
     p = config_dir()
     assert isinstance(p, Path)
     assert "phasmid" in str(p).lower()

--- a/tests/test_vessel_workflow_service.py
+++ b/tests/test_vessel_workflow_service.py
@@ -18,7 +18,37 @@ from phasmid.services.inspection_service import InspectionService
 from phasmid.services.vessel_workflow_service import VesselWorkflowService
 
 
-class VesselWorkflowServiceTests(unittest.TestCase):
+class IsolatedPhasmidDirs:
+    """Keeps a test run out of the developer's real Phasmid directories.
+
+    Tests here set `PHASMID_STATE_DIR` per case but the Vessel registry lives
+    in the *config* directory, so without this they read and rewrite the real
+    `vessel_registry.json`. On a machine where Phasmid is actually used that
+    means a test run mutates the operator's own registry - and, in the other
+    direction, Vessels registered there leak into unrelated assertions
+    elsewhere in the suite.
+
+    Env-level rather than patching `config_dir`: the override is the first
+    thing that function consults, so this covers every code path into the
+    registry, including ones that never see the `_patch_registry_dir` helper.
+    """
+
+    def setUp(self):
+        super().setUp()
+        isolated = tempfile.TemporaryDirectory()
+        self.addCleanup(isolated.cleanup)
+        env = mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_CONFIG_DIR": os.path.join(isolated.name, "config"),
+                "PHASMID_STATE_DIR": os.path.join(isolated.name, "state"),
+            },
+        )
+        env.start()
+        self.addCleanup(env.stop)
+
+
+class VesselWorkflowServiceTests(IsolatedPhasmidDirs, unittest.TestCase):
     def _patch_registry_dir(self, tmpdir: str):
         return mock.patch.object(vessel_service_mod, "config_dir", lambda: Path(tmpdir))
 
@@ -1027,7 +1057,7 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class WebAndConsoleShareStorageTests(unittest.TestCase):
+class WebAndConsoleShareStorageTests(IsolatedPhasmidDirs, unittest.TestCase):
     """The WebUI and the operator console must act on the same container.
 
     They did not: the console worked on Vessels while `web_server` held a
@@ -1146,7 +1176,7 @@ class WebAndConsoleShareStorageTests(unittest.TestCase):
                 )
 
 
-class RetrievalSelectionTests(unittest.TestCase):
+class RetrievalSelectionTests(IsolatedPhasmidDirs, unittest.TestCase):
     """Which file an unnamed retrieval returns.
 
     The WebUI never names a file, so whatever this picks is what the operator

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import os
 import sys
+import tempfile
 import time
 import unittest
 import urllib.parse
@@ -26,6 +27,29 @@ GADGET_BIND = "10.55.0.1"
 
 
 class WebServerBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        # Point the config and state directories at a temporary location for
+        # the duration of each test. Several cases here go through
+        # active_vault() -> resolve_web_container() -> resolve_web_vessel(),
+        # which reads the Vessel registry, so without this they depend on
+        # whatever Vessels happen to be registered on the machine running
+        # them - a developer who actually uses Phasmid would see this class
+        # fail against their own data, with an assertion about a purge call
+        # that says nothing about the real cause. resolve_web_vessel's own
+        # docstring names that dependency; this removes it.
+        self._isolated_dirs = tempfile.TemporaryDirectory()
+        root = self._isolated_dirs.name
+        self._isolated_env = mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_CONFIG_DIR": os.path.join(root, "config"),
+                "PHASMID_STATE_DIR": os.path.join(root, "state"),
+            },
+        )
+        self._isolated_env.start()
+        self.addCleanup(self._isolated_dirs.cleanup)
+        self.addCleanup(self._isolated_env.stop)
+
     def tearDown(self):
         web_server._rate_limit.clear()
         web_server._restricted_sessions.clear()


### PR DESCRIPTION
## Summary

Running the suite on a machine where Phasmid is actually used corrupted, and was corrupted by, the real `~/.config/phasmid/vessel_registry.json`. Both directions are fixed.

**Inbound.** A stale registry left from an earlier session made five cases in `test_web_server.py` and `test_scenarios.py` fail with `purge.assert_called_once_with("dummy")` — an assertion that says nothing about the actual cause. `active_vault()` resolves through `resolve_web_vessel()`, which reads the registry, so those tests silently depended on whichever Vessels happened to be registered on the machine. `resolve_web_vessel`'s own docstring names that dependency.

**Outbound.** Seven module-level tests in `test_tui.py` rewrote that registry as a side effect of a test run.

The root cause in both cases: tests here already set `PHASMID_STATE_DIR` per case, but the registry lives in the **config** directory, which nothing was overriding.

## Changes

- `test_web_server.py` / `test_scenarios.py`: `setUp` isolating both directories for each test in the classes that reach the registry.
- `test_vessel_workflow_service.py`: an `IsolatedPhasmidDirs` mixin applied to all three test classes. Env-level rather than extending the existing `_patch_registry_dir` helper, because the env override is the first thing `config_dir()` consults, so it covers paths that never see the helper.
- `conftest.py`: an autouse fixture, sitting alongside the one that already does exactly this for `PHASMID_WEB_VESSEL` — the same problem one level down. Module-level test functions have no `setUp` to hang isolation on, so this catches them and any added later.
- `test_profile_config_path_uses_platformdirs` checks the *unoverridden* default, so it now drops the variable explicitly rather than being defeated by the fixture.

## Test plan

Verified by restoring the stale 11-vessel registry and running the full gate with it in place:

- [x] `python -m unittest discover -s tests` — OK, 615 tests (this is what CI runs)
- [x] `python -m unittest discover -s tests_optional` — OK
- [x] `python -m pytest -q` — 753 passed, 5 skipped, 69 subtests
- [x] `black --check` / `ruff check` / `mypy src` — clean
- [x] The real registry is **byte-identical** after all of the above
- [x] Confirmed the five failures reproduce on `origin/main` with the stale registry present, and disappear with it removed — so they were environmental, not a regression

Not reproducible in CI, which starts from a clean runner. This only ever bit local runs, which is why it went unnoticed.

## Known remaining, deliberately not fixed

Three writes into the repo-relative, gitignored `.state/` remain: `lock.bin`, `store.bin`, `signal.key`. They come from module-level singletons constructed at import time — `access_cue_service` (`access_cue_service.py:73`) and web_server's `vault` (`web_server.py:116`) — so no `setUp` can redirect them; addressing it means restructuring those singletons. Results do not depend on it: the suite is green with or without `.state` present. Out of scope here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_