### PR TITLE
Surface and disarm the settings that destroy a Face during a read

### DIFF
--- a/docs/TUI_OPERATOR_CONSOLE.md
+++ b/docs/TUI_OPERATOR_CONSOLE.md
@@ -480,6 +480,20 @@ Checks performed:
 | Swap status | Best effort; Linux only |
 | Terminal scrollback | Info notice only |
 | Debug logging | Warns if `PHASMID_DEBUG` is set |
+| Automatic destruction | Warns if a retrieval will destroy the Face it did not open — `PHASMID_DURESS_MODE` on, or `PHASMID_PURGE_CONFIRMATION` off |
+
+**Automatic destruction is worth calling out.** Both settings make an ordinary
+retrieval overwrite the other Face's bytes, silently and irreversibly: with
+`PHASMID_DURESS_MODE` on, opening the first Face purges the other, and with
+`PHASMID_PURGE_CONFIRMATION` off, *any* successful retrieval does. Neither is
+visible while operating, so an operator who armed one weeks ago has no other
+reminder. It is reported as a warning rather than an error because the owner may
+have armed it deliberately (see
+[THREAT_MODEL.md](THREAT_MODEL.md), Coercion-Safe Delaying) — the point is that
+it should never be a surprise. `scripts/pi_zero2w/run_demo_console.sh` forces
+both to their safe values and prints a warning when it overrides an inherited
+one, because a demo that opens both Faces in sequence would otherwise delete the
+protected Face while showing the disclosure one.
 
 Required disclaimer shown at the end of every Doctor run:
 

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -68,6 +68,10 @@
       `PHASMID_RECOGNITION_MODE=demo` と `stty -ixon` を設定する。**素の起動では
       デモが成立しない**（→ §0）。役割トークンが1つでも発行されると
       `PHASMID_WEB_TOKEN` は `/unlock` に受理されなくなる点に注意。
+      **`PHASMID_DURESS_MODE=0` / `PHASMID_PURGE_CONFIRMATION=1` も強制的に設定される**
+      — どちらも「読んだだけ」の復元で開いていない側の Face を破壊するため、
+      両面を順に開く本デモでは継承された値が致命的になる。継承値を上書きした場合は
+      起動時に警告が出る。TUI の Doctor でも `Automatic Destruction` として確認できる。
 - [ ] **【重要】囮ファイルと真のファイルを自分で用意しておく。** 真のファイルによく似た、
       公開して差し支えない偽ファイルを1つ作る（例: 同種の書式・同程度の分量の下書き）。
       **どちらも Step 2 で WebUI から保存する** — TUI の `Add File` は #169 で

--- a/scripts/pi_zero2w/run_demo_console.sh
+++ b/scripts/pi_zero2w/run_demo_console.sh
@@ -34,6 +34,13 @@
 #       There is no UI for this; it is environment-only. `demo` keeps object
 #       recognition deterministic under stage lighting.
 #
+#   PHASMID_DURESS_MODE / PHASMID_PURGE_CONFIRMATION
+#       Forced to their safe values, not merely defaulted. Both can make an
+#       ordinary retrieval destroy the Face it did not open, and the demo
+#       opens both Faces in sequence, so an inherited setting would delete the
+#       protected Face while showing the disclosure one. Doctor reports this
+#       too ("Automatic Destruction").
+#
 # Usage:
 #   bash scripts/pi_zero2w/run_demo_console.sh
 #
@@ -58,6 +65,27 @@ export PHASMID_STORE_TOKEN="${PHASMID_STORE_TOKEN:-phasmid-demo-store-token}"
 export PHASMID_RECOVER_TOKEN="${PHASMID_RECOVER_TOKEN:-phasmid-demo-recover-token}"
 export PHASMID_RECOGNITION_MODE="${PHASMID_RECOGNITION_MODE:-demo}"
 
+# The two settings that can destroy a Face as a side effect of reading one.
+# Forced rather than defaulted, because an inherited value is exactly the
+# failure this prevents: the demo opens the first Face and then the second, so
+# with PHASMID_DURESS_MODE on, showing the disclosure Face silently purges the
+# protected one and the next step has nothing left to open. Same outcome with
+# PHASMID_PURGE_CONFIRMATION off, for any successful retrieval. `${VAR:-0}`
+# would preserve an inherited 1 and leave the trap armed, so these override
+# and say so; an operator who genuinely wants the duress path can export it
+# again after this script, deliberately.
+for _unsafe in PHASMID_DURESS_MODE PHASMID_PURGE_CONFIRMATION; do
+    _want=0
+    [[ "$_unsafe" == PHASMID_PURGE_CONFIRMATION ]] && _want=1
+    _had="${!_unsafe-}"
+    if [[ -n "$_had" && "$_had" != "$_want" ]]; then
+        echo "WARNING: $_unsafe=$_had would let a retrieval destroy the other Face." >&2
+        echo "         Forcing $_unsafe=$_want for this demo run." >&2
+    fi
+    export "$_unsafe=$_want"
+done
+unset _unsafe _want _had
+
 # Ctrl+S is the Silent Standby hotkey. It is also the terminal's traditional
 # XOFF, and a terminal with flow control enabled swallows it before the app
 # ever sees it - the hotkey would simply appear dead on stage. Disable flow
@@ -71,6 +99,7 @@ echo "  recognition mode : $PHASMID_RECOGNITION_MODE"
 echo "  webui gadget     : $PHASMID_WEBUI_EXPOSE_GADGET (press w to expose)"
 echo "  store token      : $PHASMID_STORE_TOKEN"
 echo "  recover token    : $PHASMID_RECOVER_TOKEN"
+echo "  auto-destroy     : off (duress=$PHASMID_DURESS_MODE, purge confirm=$PHASMID_PURGE_CONFIRMATION)"
 echo "  libcamera logs   : $LIBCAMERA_LOG_LEVELS"
 echo
 echo "Operate by keyboard. Mouse clicks do not reach the app over SSH:"

--- a/src/phasmid/services/doctor_service.py
+++ b/src/phasmid/services/doctor_service.py
@@ -18,6 +18,8 @@ from ..config import (
     dummy_min_size_mb,
     dummy_occupancy_warn,
     dummy_profile_dir,
+    duress_mode_enabled,
+    purge_confirmation_required,
     state_dir,
 )
 from ..dummy_profile_eval import evaluate_dummy_profile, human_bytes
@@ -264,6 +266,48 @@ def _check_debug_logging() -> DoctorCheck:
         name="Debug Logging",
         level=DoctorLevel.OK,
         message="Debug logging is not enabled",
+    )
+
+
+def _check_auto_purge_configuration() -> DoctorCheck:
+    """Whether an ordinary retrieval will destroy the Face it did not open.
+
+    Two settings arm that, and neither is visible while operating: with
+    `PHASMID_DURESS_MODE` on, opening the first Face purges the other one, and
+    with `PHASMID_PURGE_CONFIRMATION` off, *any* successful retrieval does. In
+    both cases the destruction is silent and irreversible - a retrieval that
+    looks like it only read something has actually overwritten the other Face's
+    bytes. An operator who set either weeks ago has no way to be reminded of it
+    except here.
+
+    Reported as WARN rather than an error: this is a capability the owner may
+    have armed deliberately (docs/THREAT_MODEL.md, Coercion-Safe Delaying), and
+    the point is that it should never be a surprise.
+    """
+    armed = []
+    if duress_mode_enabled():
+        armed.append(
+            "PHASMID_DURESS_MODE is on, so opening the first Face destroys the other"
+        )
+    if not purge_confirmation_required():
+        armed.append(
+            "PHASMID_PURGE_CONFIRMATION is off, so any successful retrieval "
+            "destroys the Face it did not open"
+        )
+    if armed:
+        return DoctorCheck(
+            name="Automatic Destruction",
+            level=DoctorLevel.WARN,
+            message=(
+                "Retrieval will destroy data without asking: "
+                + "; ".join(armed)
+                + ". Irreversible."
+            ),
+        )
+    return DoctorCheck(
+        name="Automatic Destruction",
+        level=DoctorLevel.OK,
+        message="Retrieval will not destroy the other Face without explicit confirmation",
     )
 
 
@@ -807,6 +851,7 @@ def run_doctor_checks(output_dir: str | None = None) -> DoctorResult:
         _check_swap(),
         _check_scrollback(),
         _check_debug_logging(),
+        _check_auto_purge_configuration(),
     ]
 
     return DoctorResult(checks=checks)

--- a/tests/test_doctor_service.py
+++ b/tests/test_doctor_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 import tempfile
+import unittest
 from contextlib import contextmanager
 from unittest import mock
 
@@ -156,3 +157,41 @@ def test_a_fresh_host_warns_only_about_genuine_host_facts():
         c.name in {"Temporary Directory", "Swap", "Compressed Swap", "Shell History"}
         for c in warns
     ), [c.name for c in warns]
+
+
+class AutoDestructionCheckTests(unittest.TestCase):
+    """Doctor must surface the settings that destroy a Face during a read.
+
+    A TestCase rather than the module-level functions above, because CI runs
+    `python -m unittest discover`, which does not collect bare test functions -
+    a safety check nobody verifies on the way in is not much of a safety check.
+    """
+
+    def _check(self, **env: str):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with _isolated_host(tmpdir, **env):
+                result = run_doctor_checks()
+        return next(c for c in result.checks if c.name == "Automatic Destruction")
+
+    def test_reported_as_off_by_default(self):
+        check = self._check()
+        self.assertEqual(check.level, DoctorLevel.OK, check.message)
+
+    def test_duress_mode_is_surfaced_as_a_destruction_warning(self):
+        """With this on, opening the disclosure Face destroys the other one."""
+        check = self._check(PHASMID_DURESS_MODE="1")
+        self.assertEqual(check.level, DoctorLevel.WARN)
+        self.assertIn("PHASMID_DURESS_MODE", check.message)
+        self.assertIn("destroys the other", check.message)
+
+    def test_disabling_purge_confirmation_is_surfaced_too(self):
+        check = self._check(PHASMID_PURGE_CONFIRMATION="0")
+        self.assertEqual(check.level, DoctorLevel.WARN)
+        self.assertIn("PHASMID_PURGE_CONFIRMATION", check.message)
+
+    def test_both_settings_are_reported_together(self):
+        """Reporting only the first would leave the second armed after a fix."""
+        check = self._check(PHASMID_DURESS_MODE="1", PHASMID_PURGE_CONFIRMATION="0")
+        self.assertEqual(check.level, DoctorLevel.WARN)
+        self.assertIn("PHASMID_DURESS_MODE", check.message)
+        self.assertIn("PHASMID_PURGE_CONFIRMATION", check.message)


### PR DESCRIPTION
## The problem

Two settings make an ordinary retrieval overwrite the Face it did **not** open, silently and irreversibly:

- `PHASMID_DURESS_MODE` on → opening the first Face purges the other (`_maybe_auto_purge`)
- `PHASMID_PURGE_CONFIRMATION` off → *any* successful retrieval purges the other

Both default safe, and neither is visible while operating — so an operator who armed one weeks ago had no way to be reminded.

This became load-bearing with the reworked demo, which opens the disclosure Face and then the protected one **in sequence**. An inherited setting would delete the protected Face while showing the disclosure one, leaving the next step with nothing to open — a failure that reads as a broken demo rather than a configured one. The previous flow only ever opened a single Face, so it could not hit this.

## Changes

- **Doctor reports it** as `Automatic Destruction`. A warning rather than an error, because the owner may have armed it deliberately (THREAT_MODEL.md, Coercion-Safe Delaying) — the point is that it should never be a surprise. Both settings are reported together, so fixing one doesn't leave the other armed.
- **`run_demo_console.sh` forces both to safe values** and prints a warning when it overrides an inherited one. **Forced, not defaulted**: `${VAR:-0}` would preserve an inherited `1` and leave the trap armed, which is exactly the failure being prevented. An operator who genuinely wants the duress path can export it again afterwards, deliberately.
- Docs updated (`TUI_OPERATOR_CONSOLE.md` Doctor table + rationale, Demo Runbook pre-flight).

The new tests are a `TestCase` rather than the module-level functions the rest of `test_doctor_service.py` uses, because CI runs `unittest discover`, which doesn't collect bare test functions — a safety check nobody verifies on the way in isn't much of a safety check.

## Deliberately *not* changed: the neutral download filename

I was also asked to fix the fact that every retrieval downloads as `retrieved_payload.bin`, so two retrievals can't be told apart by name. **That one should stay as it is**, and I'd rather flag it than quietly change it:

`create_file_response` (`web_server.py:1415`) accepts `filename` and ignores it on purpose, and four tests pin that behaviour — including `test_x_result_filename_is_neutral_regardless_of_original_name`, which asserts that names like `classified_notes.txt` and `my_secret.docx` must **not** reach the response. THREAT_MODEL.md documents it too ("Response headers and download filenames for the NORMAL and RESTRICTED paths are structurally identical").

Using the real filename would put the stored file's name into the browser's download history and the laptop's download folder — content metadata that survives on disk, which is the capture-visible leak the design exists to prevent. The collision (`retrieved_payload(1).bin`) is a staging annoyance solvable by emptying the download folder beforehand; trading a documented anti-leak property for it would be a poor exchange. Both points are written up in the run-of-show instead, including that it makes a good honest answer if an attendee asks.

## Test plan

- [x] `python -m unittest discover -s tests` — OK, 619 tests (what CI runs; includes the 4 new ones)
- [x] `python -m unittest discover -s tests_optional` — OK
- [x] `python -m pytest -q` — 757 passed, 5 skipped
- [x] `black --check` / `ruff check` / `mypy src` — clean
- [x] `bash -n` on the script, plus behavioural check: hostile env (`DURESS=1 PURGE_CONFIRMATION=0`) is overridden with warnings on stderr; clean env is silent
- [x] Doctor verified `OK` by default, `WARN` naming the specific variable(s) for each setting and both together


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_