### PR TITLE
Bind the object cue to the object, not the scene behind it

### DIFF
--- a/src/phasmid/ai_gate.py
+++ b/src/phasmid/ai_gate.py
@@ -64,6 +64,11 @@ class AIGate:
         self._stop_event = threading.Event()
         self.lock = threading.Lock()
         self.latest_frame: Any | None = None
+        # The empty scene, held only between a capture_scene() and the
+        # capture_reference() that consumes it. Never persisted: it describes
+        # where the operator happened to be standing, not a credential.
+        self.scene_frame: Any | None = None
+        self.scene_gray: Any | None = None
         # generate_frames() is called by two independent, concurrent
         # consumers: the always-on background thread that keeps object-cue
         # matching live for the TUI, and a fresh call per WebUI /video_feed
@@ -340,16 +345,94 @@ class AIGate:
             return 1.0
         return 0.0
 
+    def capture_scene(self) -> tuple[bool, str]:
+        """Record the empty scene, with the object out of frame.
+
+        Binding an object needs to know what the view looks like without it.
+        ORB has no notion of objects; it describes whatever texture is in the
+        frame, so a reference captured straight from a tripod is mostly the wall
+        behind the object and matches that wall with the object taken away.
+        Measured before this existed: 414 reference keypoints, 189 inliers with
+        the object absent, and a *different* object matching just as well - the
+        cue was not discriminating anything.
+
+        Held in memory only, and consumed by the next :meth:`capture_reference`,
+        so a stale scene cannot quietly authorise a later binding.
+        """
+        with self.lock:
+            frame = None if self.latest_frame is None else self.latest_frame.copy()
+        if frame is None:
+            return False, text.AI_GATE_NO_FRAME
+
+        gray = self.matcher.to_gray(frame)
+        with self.lock:
+            self.scene_frame = frame
+            self.scene_gray = gray
+        return True, text.AI_GATE_SCENE_CAPTURED
+
+    @property
+    def scene_captured(self) -> bool:
+        with self.lock:
+            return self.scene_gray is not None
+
+    def discard_scene(self) -> None:
+        with self.lock:
+            self.scene_frame = None
+            self.scene_gray = None
+
     def capture_reference(self, mode: str) -> tuple[bool, str]:
         self._validate_mode(mode)
         if self.latest_frame is None:
             return False, text.AI_GATE_NO_FRAME
 
-        candidate_state = self._best_reference_state_from_recent_frames()
-        if candidate_state is None:
-            return False, text.AI_GATE_IMAGE_TOO_SIMPLE
+        with self.lock:
+            scene_frame = None if self.scene_frame is None else self.scene_frame.copy()
+            scene_gray = None if self.scene_gray is None else self.scene_gray.copy()
+        if scene_frame is None or scene_gray is None:
+            return False, text.AI_GATE_SCENE_NOT_CAPTURED
 
-        return self._commit_reference(mode, candidate_state)
+        with self.lock:
+            frame = None if self.latest_frame is None else self.latest_frame.copy()
+        if frame is None:
+            return False, text.AI_GATE_NO_FRAME
+
+        mask = self.matcher.object_mask(scene_gray, self.matcher.to_gray(frame))
+        if mask is None:
+            # Either nothing changed enough to be an object, or so much did that
+            # the camera or the lighting moved instead. Both are the operator's
+            # to fix, and both are reported rather than silently bound.
+            covered = self._changed_area_ratio(scene_gray, frame)
+            if covered > self.matcher.max_object_area_ratio:
+                return False, text.AI_GATE_SCENE_CHANGED
+            return False, text.AI_GATE_OBJECT_NOT_DISTINCT
+
+        candidate_state = self._best_object_reference_state(scene_frame)
+        if candidate_state is None:
+            return False, text.AI_GATE_OBJECT_NOT_DISTINCT
+
+        # The negative test. Restricting where the template comes from is the
+        # fix; proving it no longer answers to the empty scene is what stops the
+        # same defect shipping again unnoticed.
+        if self.matcher.explains_frame(candidate_state, scene_gray):
+            return False, text.AI_GATE_OBJECT_IS_THE_SCENE
+
+        committed = self._commit_reference(mode, candidate_state)
+        if committed[0]:
+            self.discard_scene()
+        return committed
+
+    def _changed_area_ratio(self, scene_gray: Any, frame: Any) -> float:
+        try:
+            difference = cv2.absdiff(scene_gray, self.matcher.to_gray(frame))
+            _, binary = cv2.threshold(
+                difference, self.matcher.object_mask_threshold, 255, cv2.THRESH_BINARY
+            )
+            total = float(binary.shape[0] * binary.shape[1])
+            if total <= 0:
+                return 0.0
+            return float(np.count_nonzero(binary)) / total
+        except cv2.error:
+            return 0.0
 
     def register_reference_from_image_bytes(
         self, mode: str, payload: bytes
@@ -429,19 +512,28 @@ class AIGate:
 
         return True, text.AI_GATE_OBJECT_MATCHED
 
-    def _best_reference_state_from_recent_frames(self) -> dict[str, Any] | None:
+    def _best_object_reference_state(self, scene_frame: Any) -> dict[str, Any] | None:
+        """Best masked candidate across several frames.
+
+        Sampling more than one frame is what makes capture survive motion blur
+        and a refocus on real hardware; the previous whole-frame version did the
+        same and the robustness is worth keeping. What changed is that each
+        candidate is now built only from the region that differs from
+        *scene_frame*, so none of them describe the background.
+        """
         candidates = []
         for _ in range(self.REFERENCE_CAPTURE_SAMPLES):
             with self.lock:
                 frame = None if self.latest_frame is None else self.latest_frame.copy()
-            state = self._reference_state_from_image(frame)
+            state = self.matcher.object_reference_state(scene_frame, frame)
             if state is not None:
                 candidates.append(state)
             time.sleep(0.12)
 
         if not candidates:
             return None
-        return max(candidates, key=lambda state: len(state["kp"]))
+        best = max(candidates, key=lambda state: len(state["kp"]))
+        return cast(dict[str, Any], best)
 
     def get_status(self) -> dict[str, Any]:
         camera_status = self.camera.status()

--- a/src/phasmid/cli.py
+++ b/src/phasmid/cli.py
@@ -114,9 +114,23 @@ def _wait_for_reference_match(timeout=REFERENCE_MATCH_TIMEOUT, expected_mode=Non
 
 
 def _register_reference_key(mode):
+    # The empty view first. ORB describes whatever texture is in the frame, so a
+    # reference taken straight from a fixed camera is mostly the scene behind
+    # the object and answers to that scene with the object taken away. Knowing
+    # what the view looks like without the object is what makes the template
+    # describe the object.
     info(
-        f"Position the bound object for [bold]{display_mode_label(mode)}[/bold], "
-        "then press [bold]Enter[/bold] to capture."
+        "First, clear the frame: take the object [bold]out[/bold] of view and "
+        "leave the camera still, then press [bold]Enter[/bold]."
+    )
+    input()
+    scene_ok, scene_msg = gate.capture_scene()
+    if not scene_ok:
+        return False, scene_msg
+
+    info(
+        f"Now position the bound object for [bold]{display_mode_label(mode)}[/bold] "
+        "in front of that same view, then press [bold]Enter[/bold] to capture."
     )
     input()
 
@@ -1279,12 +1293,17 @@ def _run_store_command(args) -> int:
             "The captured object will be stored as the local access cue for this entry."
         )
         if getattr(args, "passphrase_file", None):
-            info("Position the bound object in view. Capture will begin automatically.")
-            try:
-                svc.capture_reference_for_mode(selected_mode)
-            except RuntimeError as exc:
-                error(str(exc))
-                return 1
+            # Binding an object needs a shot of the view without it, and this
+            # path assumes the object is already in frame - there is no moment
+            # at which the scene is empty. Refusing is the honest outcome: the
+            # alternative is a template built from the background, which is the
+            # defect this flow exists to avoid.
+            error(
+                "Object binding needs the empty view first, so it cannot run "
+                "unattended. Re-run without --passphrase-file to bind "
+                "interactively, or bind from the WebUI Store page."
+            )
+            return 1
         else:
             reg_success, msg = _register_reference_key(selected_mode)
             if not reg_success:

--- a/src/phasmid/object_cue_matcher.py
+++ b/src/phasmid/object_cue_matcher.py
@@ -9,6 +9,19 @@ import numpy as np
 class ObjectCueMatcher:
     """ORB-based object-cue matching isolated from camera and UI concerns."""
 
+    # Per-pixel intensity change, after histogram equalisation, that counts as
+    # "this part of the frame is not the scene any more". Low enough to catch a
+    # matte object against a similar-toned background, high enough to ignore
+    # sensor noise and the small exposure drift between two consecutive frames.
+    OBJECT_MASK_THRESHOLD = 30
+
+    # The masked region has to look like something placed in the scene. Below
+    # the floor there is nothing to describe; above the ceiling the whole view
+    # changed, which means the camera moved or the lighting did, and the diff no
+    # longer isolates an object.
+    MIN_OBJECT_AREA_RATIO = 0.01
+    MAX_OBJECT_AREA_RATIO = 0.60
+
     def __init__(
         self,
         *,
@@ -16,11 +29,29 @@ class ObjectCueMatcher:
         min_frame_descriptors: int,
         min_good_matches: int,
         min_inliers: int,
+        object_mask_threshold: int | None = None,
+        min_object_area_ratio: float | None = None,
+        max_object_area_ratio: float | None = None,
     ) -> None:
         self.min_reference_keypoints = min_reference_keypoints
         self.min_frame_descriptors = min_frame_descriptors
         self.min_good_matches = min_good_matches
         self.min_inliers = min_inliers
+        self.object_mask_threshold = (
+            self.OBJECT_MASK_THRESHOLD
+            if object_mask_threshold is None
+            else object_mask_threshold
+        )
+        self.min_object_area_ratio = (
+            self.MIN_OBJECT_AREA_RATIO
+            if min_object_area_ratio is None
+            else min_object_area_ratio
+        )
+        self.max_object_area_ratio = (
+            self.MAX_OBJECT_AREA_RATIO
+            if max_object_area_ratio is None
+            else max_object_area_ratio
+        )
         self.orb = cast(Any, cv2).ORB_create(nfeatures=1000)
         self.bf = cv2.BFMatcher(cv2.NORM_HAMMING)
 
@@ -57,6 +88,96 @@ class ObjectCueMatcher:
             "pts": self._reference_corners(h, w),
             "path": None,
         }
+
+    def object_mask(self, background_gray, object_gray):
+        """Where the object frame differs from the scene behind it.
+
+        Descriptor-level subtraction was the obvious approach and is not good
+        enough: introducing the object shifts the global histogram, so
+        `equalizeHist` remaps the background too and hundreds of background
+        keypoints survive with descriptors just different enough to look novel.
+        Masking by pixel difference asks the question directly instead — which
+        part of the frame changed when the object was held up — and hands that
+        region to ORB, which takes a mask natively.
+
+        Assumes the camera does not move between the two frames. That is the
+        tripod setup the demo uses, and the setup whose fixed background caused
+        the original defect.
+
+        Returns None when the change is too small to be an object, or so large
+        that the whole scene moved rather than something being placed in it.
+        """
+        if background_gray is None or object_gray is None:
+            return None
+        if background_gray.shape != object_gray.shape:
+            return None
+
+        difference = cv2.absdiff(background_gray, object_gray)
+        _, binary = cv2.threshold(
+            difference, self.object_mask_threshold, 255, cv2.THRESH_BINARY
+        )
+        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+        binary = cv2.morphologyEx(binary, cv2.MORPH_OPEN, kernel)
+        binary = cv2.morphologyEx(binary, cv2.MORPH_CLOSE, kernel)
+
+        # connectivity is keyword-only in practice: passing 8 positionally lands
+        # it in the `labels` output slot, not connectivity.
+        count, labels, stats, _ = cv2.connectedComponentsWithStats(
+            binary, connectivity=8
+        )
+        if count <= 1:
+            return None
+        # Largest component excluding the background label at index 0.
+        largest = 1 + int(np.argmax(stats[1:, cv2.CC_STAT_AREA]))
+        mask = np.where(labels == largest, 255, 0).astype(np.uint8)
+
+        frame_area = float(binary.shape[0] * binary.shape[1])
+        covered = float(np.count_nonzero(mask)) / frame_area
+        if covered < self.min_object_area_ratio:
+            return None
+        if covered > self.max_object_area_ratio:
+            return None
+        return mask
+
+    def object_reference_state(self, background_image, object_image):
+        """Reference template built only from the region the object occupies.
+
+        Returns None when no usable object region is found, or when too few
+        keypoints fall inside it — the honest outcome for an object that does
+        not stand out from what is behind it. Callers must still run the
+        capture-time negative test in :meth:`explains_frame`; this restricts
+        *where* the template comes from, and that check proves it worked.
+        """
+        if background_image is None or object_image is None:
+            return None
+
+        background_gray = self.to_gray(background_image)
+        object_gray = self.to_gray(object_image)
+        mask = self.object_mask(background_gray, object_gray)
+        if mask is None:
+            return None
+
+        kp, des = self.orb.detectAndCompute(object_gray, mask)
+        if not kp or len(kp) < self.min_reference_keypoints or des is None:
+            return None
+
+        h, w = object_gray.shape
+        return {
+            "kp": kp,
+            "des": des,
+            "shape": (h, w),
+            "pts": self._reference_corners(h, w),
+            "path": None,
+        }
+
+    def explains_frame(self, ref_state, frame_gray) -> bool:
+        """Whether *ref_state* still matches a frame it must not match.
+
+        Used as the capture-time negative test: a template that answers to the
+        background is refused rather than stored, so the defect cannot ship
+        silently the way it did before.
+        """
+        return self.match_reference_state(ref_state, frame_gray) is not None
 
     def reference_state_from_arrays(self, des, kp_data, shape):
         kp = [

--- a/src/phasmid/services/access_cue_service.py
+++ b/src/phasmid/services/access_cue_service.py
@@ -48,6 +48,17 @@ class AccessCueService:
     def sequence_for_mode(self, mode, length=1):
         return self.gate.sequence_for_mode(mode, length=length)
 
+    def capture_scene(self):
+        """Record the empty scene that the next capture_reference subtracts."""
+        return self.gate.capture_scene()
+
+    @property
+    def scene_captured(self):
+        return self.gate.scene_captured
+
+    def discard_scene(self):
+        self.gate.discard_scene()
+
     def capture_reference(self, mode):
         return self.gate.capture_reference(mode)
 

--- a/src/phasmid/strings.py
+++ b/src/phasmid/strings.py
@@ -72,6 +72,21 @@ AI_GATE_CUES_TOO_SIMILAR = "Access cues are too similar"
 AI_GATE_NO_MATCH = "No object cue match"
 AI_GATE_PRESENT_OBJECT = "Present a bound object to continue"
 AI_GATE_IMAGE_TOO_SIMPLE = "Image too simple. Use a textured object."
+AI_GATE_SCENE_NOT_CAPTURED = (
+    "Capture the empty scene first, with the object out of frame."
+)
+AI_GATE_SCENE_CAPTURED = "Empty scene captured. Now hold the object in front of it."
+AI_GATE_OBJECT_NOT_DISTINCT = (
+    "Object does not stand out from the scene behind it. "
+    "Fill more of the frame, or use a plainer background."
+)
+AI_GATE_SCENE_CHANGED = (
+    "Too much of the view changed. Keep the camera still and only add the object."
+)
+AI_GATE_OBJECT_IS_THE_SCENE = (
+    "Rejected: the cue still matches the empty scene, so the background "
+    "would open it without the object. Re-capture."
+)
 AI_GATE_IMAGE_UNREADABLE = "Image file could not be read. Use a standard image format."
 AI_GATE_NO_FRAME = "No frame."
 AI_GATE_SAVE_FAILED = "Failed to save reference template."

--- a/src/phasmid/templates/store.html
+++ b/src/phasmid/templates/store.html
@@ -65,12 +65,14 @@
             <section class="step-card camera-step">
                 <div class="step-head">
                     <span class="step-number">4</span>
-                    <div><h3>Set the physical access object</h3><p class="step-help">Place the object clearly in view, then capture it. Use an object you can reliably present again.</p></div>
+                    <div><h3>Set the physical access object</h3><p class="step-help">Two shots, in this order. First the empty view with the object <em>out</em> of frame, so the camera knows what the scene looks like without it. Then the object held in front of that same scene. Keep the camera still between the two.</p></div>
                 </div>
                 {{ ui.camera_preview() }}
                 <div class="actions" style="margin-top:14px;">
-                    <button type="button" class="secondary" id="captureButton">Capture access object</button>
+                    <button type="button" class="secondary" id="sceneButton">1 · Capture empty scene</button>
+                    <button type="button" class="secondary" id="captureButton" disabled>2 · Capture access object</button>
                 </div>
+                <p class="step-help" id="sceneHelp" style="margin-top:10px;">Without the empty scene the object cannot be told apart from the background, and the background would open the file on its own.</p>
             </section>
 
             <section class="step-card">
@@ -156,11 +158,26 @@
 
     protectFile.addEventListener('change', updateReadiness);
     passwordInput.addEventListener('input', updateReadiness);
+    const sceneButton = document.getElementById('sceneButton');
+    const captureButton = document.getElementById('captureButton');
+    const sceneHelp = document.getElementById('sceneHelp');
+    let sceneCaptured = false;
+
+    function updateSceneState() {
+        captureButton.disabled = !sceneCaptured;
+        sceneHelp.textContent = sceneCaptured
+            ? 'Empty scene recorded. Now hold the object in front of that same view and capture it.'
+            : 'Without the empty scene the object cannot be told apart from the background, and the background would open the file on its own.';
+    }
+
     document.getElementById('entryHint').addEventListener('change', () => {
         // Switching entries mid-setup must not carry over a capture done for
         // the previous one - each entry needs its own object presented and
-        // captured before it can be protected.
+        // captured before it can be protected. The scene shot goes with it: the
+        // server consumes it on a successful bind, so a new entry starts over.
         accessObjectCaptured = false;
+        sceneCaptured = false;
+        updateSceneState();
         updateReadiness();
     });
 
@@ -169,14 +186,30 @@
         updateReadiness();
     }
 
-    document.getElementById('captureButton').addEventListener('click', async () => {
+    sceneButton.addEventListener('click', async () => {
+        const res = await apiFetch('/register_scene', { method: 'POST' });
+        const data = await res.json();
+        sceneCaptured = !data.error;
+        updateSceneState();
+        toast(data.status || data.error || 'Empty scene capture finished.', data.error ? 'error' : '');
+    });
+
+    captureButton.addEventListener('click', async () => {
         const body = new URLSearchParams({ replace: 'false' });
         const res = await apiFetch('/register_key', { method: 'POST', body });
         const data = await res.json();
         if (data.overwrite_required) document.getElementById('overwritePanel').classList.remove('hidden');
-        if (!data.error) activateSaveButton();
+        if (!data.error) {
+            activateSaveButton();
+            // The server consumed the scene shot on a successful bind, so the
+            // next entry has to start from its own empty view.
+            sceneCaptured = false;
+            updateSceneState();
+        }
         toast(data.status || data.error || 'Access object capture finished.', data.error ? 'error' : '');
     });
+
+    updateSceneState();
 
     async function selectedFileFormData() {
         const file = protectFile.files[0];

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -636,9 +636,28 @@ def _select_entry_for_store(entry_hint=None, overwrite=False):
     return None, False
 
 
+# Capture failures an operator has to act on, rather than gate internals to
+# mask. The generic message below is the right answer for anything that could
+# describe a stored reference; these describe the frame the operator is holding
+# up right now, and withholding them just leaves someone pressing a button that
+# will never succeed. Reachable on the store page only, which the threat model
+# already treats as a safe environment.
+_ACTIONABLE_CAPTURE_MESSAGES = frozenset(
+    {
+        text.AI_GATE_SCENE_NOT_CAPTURED,
+        text.AI_GATE_SCENE_CHANGED,
+        text.AI_GATE_OBJECT_NOT_DISTINCT,
+        text.AI_GATE_OBJECT_IS_THE_SCENE,
+        text.AI_GATE_NO_FRAME,
+    }
+)
+
+
 def _capture_entry_binding(mode):
     success, message = access_cue_service.capture_reference(mode)
     if not success:
+        if message in _ACTIONABLE_CAPTURE_MESSAGES:
+            return False, message
         return False, "Object binding failed. Retry capture."
     return True, message
 
@@ -912,6 +931,34 @@ async def restricted_confirm(request: Request, confirmation: str = Form(...)):
     )
     audit_event("restricted_confirmation_accepted", source="web")
     return response
+
+
+@app.post(
+    "/register_scene",
+    dependencies=[
+        Depends(require_web_token),
+        Depends(require_ui_unlock),
+        Depends(require_store_role),
+    ],
+)
+async def register_scene(request: Request):
+    """Record the empty scene, with the object out of frame.
+
+    Binding an object needs to know what the view looks like without it: ORB
+    describes whatever texture is in the frame, so a reference taken straight
+    from a tripod is mostly the wall behind the object and matches that wall
+    with the object taken away. Held in memory and consumed by the next
+    `/register_key`, never persisted.
+    """
+    enforce_rate_limit(request)
+    # No-op when already running; the scene shot is often the first thing an
+    # operator does after opening the page, before any frame has been served.
+    access_cue_service.start()
+    success, message = access_cue_service.capture_scene()
+    if not success:
+        return {"error": message}
+    audit_event("access_scene_captured", entry="local_entry", source="web")
+    return {"status": message}
 
 
 @app.post(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,9 @@ class CLITests(unittest.TestCase):
         with (
             unittest.mock.patch("builtins.input", return_value=""),
             unittest.mock.patch.object(
+                cli.gate, "capture_scene", return_value=(True, "scene")
+            ) as capture_scene,
+            unittest.mock.patch.object(
                 cli.gate, "capture_reference", return_value=(True, "ok")
             ),
             unittest.mock.patch.object(
@@ -89,6 +92,9 @@ class CLITests(unittest.TestCase):
         ):
             success, message = cli._register_reference_key(cli.gate.MODES[0])
 
+        # The empty view has to be taken first, or the template is built from
+        # the background and answers to it with the object gone.
+        capture_scene.assert_called_once_with()
         self.assertTrue(success)
         self.assertEqual(message, "Object access cue registered.")
         self.assertNotRegex(

--- a/tests/test_object_cue_background.py
+++ b/tests/test_object_cue_background.py
@@ -1,0 +1,163 @@
+"""The object cue must gate on the object, not on the scene behind it.
+
+`reference_state_from_image` ran ORB over the whole frame with no mask, so a
+reference captured from a camera on a tripod was mostly the wall behind the
+object. Matching that template against the same wall with the object taken away
+still found inliers, so the demo's central claim - present the object or it
+refuses - did not hold on real hardware: it opened with the object hidden.
+
+Measured on the fixed scene these tests build: 414 reference keypoints, 189
+inliers with the object absent, and a *different* object matching at 184. The
+cue was not discriminating between objects at all; it was reading the room.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+import cv2
+import numpy as np
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from phasmid.object_cue_matcher import ObjectCueMatcher
+
+
+def _fixed_scene(seed: int = 3) -> np.ndarray:
+    """A textured, structured view - what a tripod actually points at.
+
+    Deliberately not random noise: noise is a pathological case for ORB and
+    would let a weaker fix look like it worked.
+    """
+    image = np.full((240, 320, 3), 60, np.uint8)
+    rng = np.random.default_rng(seed)
+    for _ in range(40):
+        x, y = int(rng.integers(0, 300)), int(rng.integers(0, 220))
+        w, h = int(rng.integers(10, 50)), int(rng.integers(10, 40))
+        colour = tuple(int(v) for v in rng.integers(40, 200, 3))
+        cv2.rectangle(image, (x, y), (x + w, y + h), colour, -1)
+    for i in range(0, 320, 17):
+        cv2.line(image, (i, 0), (i, 239), (90, 90, 90), 1)
+    cv2.putText(
+        image, "SHELF", (20, 220), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (200, 200, 200), 2
+    )
+    return image
+
+
+def _with_light_object(scene: np.ndarray) -> np.ndarray:
+    image = scene.copy()
+    cv2.rectangle(image, (120, 80), (200, 160), (250, 250, 250), -1)
+    cv2.circle(image, (160, 120), 25, (20, 20, 20), -1)
+    cv2.putText(
+        image, "MUG", (126, 150), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (10, 10, 10), 2
+    )
+    return image
+
+
+def _with_dark_object(scene: np.ndarray) -> np.ndarray:
+    image = scene.copy()
+    cv2.rectangle(image, (120, 80), (200, 160), (30, 30, 30), -1)
+    for i in range(6):
+        cv2.line(image, (124, 84 + i * 12), (196, 84 + i * 12), (240, 240, 240), 2)
+    cv2.putText(
+        image, "KEY", (128, 150), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (250, 250, 250), 2
+    )
+    return image
+
+
+def _matcher() -> ObjectCueMatcher:
+    return ObjectCueMatcher(
+        min_reference_keypoints=10,
+        min_frame_descriptors=10,
+        min_good_matches=10,
+        min_inliers=8,
+    )
+
+
+class ObjectCueBackgroundTests(unittest.TestCase):
+    def setUp(self):
+        self.matcher = _matcher()
+        self.scene = _fixed_scene()
+        self.object_frame = _with_light_object(self.scene)
+        self.other_object_frame = _with_dark_object(self.scene)
+        self.reference = self.matcher.object_reference_state(
+            self.scene, self.object_frame
+        )
+        self.assertIsNotNone(self.reference, "the object should be bindable")
+
+    def _matches(self, frame) -> bool:
+        return self.matcher.explains_frame(self.reference, self.matcher.to_gray(frame))
+
+    def test_the_empty_scene_does_not_open_the_cue(self):
+        """The defect, stated as a test. This is the demo's central claim."""
+        self.assertFalse(
+            self._matches(self.scene),
+            "the scene alone matched the cue - the background is the key again",
+        )
+
+    def test_the_bound_object_still_opens_the_cue(self):
+        """A fix that refuses everything would pass the test above for free."""
+        self.assertTrue(self._matches(self.object_frame))
+
+    def test_a_different_object_in_the_same_place_does_not_open_the_cue(self):
+        """The old whole-frame template matched this too, at 184 inliers."""
+        self.assertFalse(self._matches(self.other_object_frame))
+
+    def test_the_whole_frame_template_is_what_matched_the_scene(self):
+        """Pins the diagnosis, so a regression is recognisable rather than new.
+
+        Kept as a characterisation of the old path: `reference_state_from_image`
+        still exists for references registered from an image file, where there
+        is no scene frame to subtract. This asserts *why* it was wrong when fed
+        a tripod frame, which is the thing the mask fixes.
+        """
+        whole_frame = self.matcher.reference_state_from_image(self.object_frame)
+        self.assertIsNotNone(whole_frame)
+        self.assertTrue(
+            self.matcher.explains_frame(whole_frame, self.matcher.to_gray(self.scene)),
+            "if this stops matching, the diagnosis in this file needs revisiting",
+        )
+        self.assertGreater(len(whole_frame["kp"]), len(self.reference["kp"]))
+
+
+class ObjectMaskTests(unittest.TestCase):
+    def setUp(self):
+        self.matcher = _matcher()
+        self.scene = _fixed_scene()
+
+    def _mask(self, frame):
+        return self.matcher.object_mask(
+            self.matcher.to_gray(self.scene), self.matcher.to_gray(frame)
+        )
+
+    def test_the_mask_covers_the_object_and_not_the_frame(self):
+        mask = self._mask(_with_light_object(self.scene))
+        self.assertIsNotNone(mask)
+        covered = np.count_nonzero(mask) / float(mask.shape[0] * mask.shape[1])
+        self.assertGreater(covered, 0.01)
+        self.assertLess(covered, 0.30, "the mask spread beyond the object")
+
+    def test_an_unchanged_view_yields_no_object(self):
+        """Pressing capture without holding anything up must not bind."""
+        self.assertIsNone(self._mask(self.scene))
+
+    def test_a_view_that_changed_everywhere_is_refused(self):
+        """The camera moved, or the lights did - the diff no longer isolates."""
+        self.assertIsNone(self._mask(_fixed_scene(seed=99)))
+
+    def test_a_mismatched_frame_size_is_refused_rather_than_raising(self):
+        small = cv2.resize(self.scene, (160, 120))
+        self.assertIsNone(
+            self.matcher.object_mask(
+                self.matcher.to_gray(self.scene), self.matcher.to_gray(small)
+            )
+        )
+
+    def test_object_reference_state_refuses_without_a_scene(self):
+        self.assertIsNone(
+            self.matcher.object_reference_state(None, _with_light_object(self.scene))
+        )
+        self.assertIsNone(self.matcher.object_reference_state(self.scene, None))

--- a/tests_optional/test_ai_gate.py
+++ b/tests_optional/test_ai_gate.py
@@ -198,12 +198,22 @@ class AIGateTemplateTests(unittest.TestCase):
                 "pts": np.zeros((4, 1, 2), dtype=np.float32),
                 "path": None,
             }
+            # Binding needs the empty view first, so the scene shot has to be in
+            # place before capture_reference gets as far as the similarity check.
+            gate.scene_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+            gate.scene_gray = np.zeros((480, 640), dtype=np.uint8)
             with (
                 mock.patch.object(
+                    gate.matcher,
+                    "object_mask",
+                    return_value=np.ones((480, 640), np.uint8),
+                ),
+                mock.patch.object(
                     gate,
-                    "_best_reference_state_from_recent_frames",
+                    "_best_object_reference_state",
                     return_value=candidate,
                 ),
+                mock.patch.object(gate.matcher, "explains_frame", return_value=False),
                 mock.patch.object(gate, "_references_too_similar", return_value=True),
             ):
                 success, message = gate.capture_reference(gate.MODES[0])


### PR DESCRIPTION
Reported from the device: the cue showed as matched *before* the object was held up, and a recovery succeeded with the object hidden. Confirmed, and it is not a tuning problem.

## The defect

`reference_state_from_image` ran ORB over the whole frame with no mask, so a reference captured from a camera on a tripod described the room. Measured on a fixed synthetic scene (the one `tests/test_object_cue_background.py` builds):

| matched against | before | after |
|---|---|---|
| **the empty scene, object hidden** | **match, 189 inliers** | refused |
| the bound object | match, 401 | match, 146 |
| **a different object, same position** | **match, 184** | refused |

The third row is the part that matters most: the cue was not discriminating between objects at all. It was reading the room, and the demo's central claim — present the object or it refuses — did not hold on hardware.

## Why not descriptor subtraction, and why not a model

**Descriptor-level background subtraction** was the obvious fix and I implemented it first. It is not good enough: introducing the object shifts the global histogram, so `equalizeHist` remaps the background too and ~426 of 903 background keypoints survived with descriptors just different enough to look novel. The negative test passed for the wrong reason. Discarded.

**A classifier** answers "is there a mug in frame", which is a weaker question than "is this *my* mug", and it would sit on top of a template that still encoded the background. It belongs later, as a complement behind the existing `PHASMID_EXPERIMENTAL_OBJECT_MODEL` flag, not as the fix for this.

## What it does instead

Ask the question directly: capture the empty view first, diff it against the frame with the object in it, and hand that region to ORB **as a mask** — which ORB takes natively. The template then contains only what changed when the object was held up. The mask covers ~7% of the frame in the test scene.

Guards fall out of the same diff:
- too little change → not an object
- more than 60% → the camera or the lighting moved, not something placed in the scene
- **after building the template it is matched against the empty view and refused if it still answers to it** — this is what stops the defect shipping again unnoticed

Multi-frame sampling is kept (it survives motion blur and refocus on real hardware), now applied to masked candidates.

## Surfaces

- **WebUI store page** — the surface the demo uses. Two buttons, `1 · Capture empty scene` then `2 · Capture access object`, the second disabled until the first succeeds. New `POST /register_scene`. The scene is held in memory and consumed on a successful bind, so a stale scene cannot authorise a later binding and switching entries starts over.
- **Interactive CLI** — prompts for the empty view, then the object.
- **Unattended CLI (`--passphrase-file`)** — assumes the object is already in frame, so there is no empty-scene moment. It now refuses with an explanation rather than binding the background.
- **Registering from an uploaded image** — unchanged. There is no scene frame to subtract, so a photo that includes a room still carries the old weakness. Documented here rather than silently carried; a cropped photo of an object is fine.

Capture messages that describe the frame the operator is holding up right now (`scene not captured`, `object not distinct`, `scene changed`, `still matches the empty scene`) are surfaced instead of masked — they are instructions, not gate internals, and the store page is store-role only. Anything that could describe a *stored* reference still gets the generic message.

## Test plan

- [x] `python -m unittest discover -s tests` — OK, 637 (what CI runs)
- [x] `python -m unittest discover -s tests_optional` — OK
- [x] `python -m pytest -q` — 766 passed, 5 skipped
- [x] `black --check` / `ruff check` / `mypy src` — clean
- [x] New `tests/test_object_cue_background.py` — 9 tests: scene alone refused, bound object accepted, different object refused, mask covers the object and not the frame, unchanged view yields nothing, view-changed-everywhere refused, size mismatch refused rather than raising, missing scene refused, plus a characterisation of the whole-frame path so a regression reads as a regression rather than as news

**The existing suite passed untouched throughout.** That is the tell: there was no coverage of the camera capture path at all, which is why this reached hardware.

Also fixes a real defect mypy caught: `connectedComponentsWithStats(binary, 8)` put `8` in the `labels` output slot, not `connectivity`.

## Not in this PR

Docs, CHANGELOG, and an honest note in `NON_CLAIMS.md`/`THREAT_MODEL.md` about what the cue does and does not discriminate. `CLM-23` ("an operational access cue, not cryptographic key material") stays true either way — it was never claiming the discrimination that was missing.

Needs re-verification on the device before the demo relies on it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_