### PR TITLE
Bind the captured object to the entry the operator chose

### DIFF
--- a/src/phasmid/templates/store.html
+++ b/src/phasmid/templates/store.html
@@ -195,7 +195,14 @@
     });
 
     captureButton.addEventListener('click', async () => {
-        const body = new URLSearchParams({ replace: 'false' });
+        // Bind to the entry the operator chose in step 1. Without this the
+        // server falls back to whichever entry is currently matched or first
+        // unbound, while /store below honours the selector - so picking Entry 2
+        // first would put the object on Entry 1 and the file on Entry 2.
+        const body = new URLSearchParams({
+            replace: 'false',
+            entry_hint: document.getElementById('entryHint').value || '',
+        });
         const res = await apiFetch('/register_key', { method: 'POST', body });
         const data = await res.json();
         if (data.overwrite_required) document.getElementById('overwritePanel').classList.remove('hidden');

--- a/tests/test_docs_and_templates.py
+++ b/tests/test_docs_and_templates.py
@@ -21,6 +21,34 @@ class DocsAndTemplateTests(unittest.TestCase):
         self.assertIn("Metadata detection and reduction are best-effort.", store)
         self.assertNotIn("complete metadata removal", store.lower())
 
+    def test_store_template_captures_the_empty_scene_before_the_object(self):
+        """Binding an object needs the view without it.
+
+        ORB describes whatever texture is in the frame, so a reference taken
+        straight from a tripod is mostly the wall behind the object and matches
+        that wall once the object is taken away - the cue opened with the object
+        hidden. The two-shot flow is what makes the template describe the
+        object, so the page has to offer the scene shot and gate the object shot
+        behind it.
+        """
+        store = read_text("src/phasmid/templates/store.html")
+        self.assertIn("/register_scene", store)
+        self.assertIn("Capture empty scene", store)
+        self.assertIn('id="captureButton" disabled', store)
+
+    def test_store_template_binds_the_object_to_the_chosen_entry(self):
+        """The capture has to name the entry the operator picked.
+
+        `/register_key` falls back to whichever entry is currently matched or
+        first unbound, while `/store` honours the selector. With the hint
+        missing, choosing Entry 2 first put the object on Entry 1 and the file
+        on Entry 2 - two faces, each holding half of a pair.
+        """
+        store = read_text("src/phasmid/templates/store.html")
+        capture_call = store.split("captureButton.addEventListener")[1]
+        register_key_body = capture_call.split("/register_key")[0]
+        self.assertIn("entry_hint", register_key_body)
+
     def test_readme_links_field_operational_docs(self):
         readme = read_text("README.md")
         self.assertIn("Quick Start in 60 seconds", readme)


### PR DESCRIPTION
Found while diagnosing an operator report of the "Advanced: replace an existing protected space" panel appearing during setup.

## The bug

The capture button posts to `/register_key` **without an entry hint**, so the server falls back to whichever entry is currently matched or first unbound:

```python
entry_id = (
    entry_hint
    if entry_hint in ENTRY_TO_MODE
    else _matched_entry() or _first_unbound_entry()
)
```

`/store` *does* honour the selector from step 1. So the two can disagree: choosing **Entry 2 before Entry 1** binds the object to Entry 1 and stores the file under Entry 2 — each face holding half of a pair, and neither able to open.

The selector was added in 0.4.0 precisely so an operator could set up Entry 1 and Entry 2 deliberately "rather than depending on whichever entry the camera happens to match". The capture path never got the message.

This is the exact flow the demo uses: two files, two passwords, two objects, one per entry.

## The fix

Send `entry_hint` from the capture handler. The select's values are already entry ids (`entry_1` / `entry_2`), which is what `ENTRY_TO_MODE` expects.

A side benefit for the reported symptom: with an explicit hint, an operator whose entries are both already bound now gets `ENTRY_ALREADY_BOUND` — which names the problem — instead of falling through to the replacement panel, which reads like data loss is imminent when the operator only wanted to re-register.

## Tests

Both the scene step and this hint live in JavaScript that the Python suite otherwise never executes, which is how the omission survived. Two template assertions pin them:

- `test_store_template_captures_the_empty_scene_before_the_object` — the page offers `/register_scene` and the object button starts disabled
- `test_store_template_binds_the_object_to_the_chosen_entry` — the `/register_key` call inside the capture handler carries `entry_hint`

The second parses the capture handler specifically rather than searching the whole file, so the `entry_hint` in the `<select>` markup cannot satisfy it.

## Test plan

- [x] `python -m unittest discover -s tests` — OK, 630 (what CI runs)
- [x] `python -m pytest -q` — 768 passed, 5 skipped
- [x] `black --check` / `ruff check` / `mypy src` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_