### PR TITLE
Say the object is missing instead of offering to replace an entry

### DIFF
--- a/src/phasmid/strings.py
+++ b/src/phasmid/strings.py
@@ -17,6 +17,10 @@ RESTRICTED_CONFIRMATION_RETRY = (
 )
 
 NO_OPEN_LOCAL_ENTRY = "No open local entry is available."
+ENTRY_OBJECT_NOT_PRESENT = (
+    "That entry is already set up. Hold its access object in front of the "
+    "camera until it matches, then save again."
+)
 NO_OPEN_LOCAL_ENTRY_WITH_REPLACEMENT = (
     "No open local entry is available. Confirm replacement to continue."
 )

--- a/src/phasmid/templates/store.html
+++ b/src/phasmid/templates/store.html
@@ -78,7 +78,7 @@
             <section class="step-card">
                 <div class="step-head">
                     <span class="step-number">✓</span>
-                    <div><h3>Protect the file</h3><p class="step-help">The button becomes available when the file, password, and access object are all ready.</p></div>
+                    <div><h3>Protect the file</h3><p class="step-help">The button becomes available when the file, password, and access object are all ready. <strong>Keep the object in front of the camera while you save</strong> — the cue is checked again at that moment, not just at capture.</p></div>
                 </div>
                 <div class="ready-summary" aria-live="polite">
                     <div class="ready-row"><span>File</span><strong id="selectedFileName">Not selected</strong></div>

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -602,6 +602,25 @@ def _matched_entry():
     return None
 
 
+def _entry_needs_its_object_presented(entry_hint) -> bool:
+    """Whether the chosen entry was refused only because its object is not in view.
+
+    `_select_entry_for_store` returns nothing for two very different reasons,
+    and conflating them sent an operator toward the replacement panel - a
+    destructive path - when all they had to do was hold their object up again.
+    With a valid hint there is only one way to reach None: the entry exists and
+    is bound, and the camera is not currently matching it.
+
+    This surfaced the moment the cue started requiring the object. While the
+    reference template was the whole frame, the background satisfied the live
+    match on its own, so this branch was effectively unreachable.
+    """
+    if entry_hint not in ENTRY_TO_MODE:
+        return False
+    mode = ENTRY_TO_MODE[entry_hint]
+    return bool(_raw_gate_status().get("registered_modes", {}).get(mode))
+
+
 def _select_entry_for_store(entry_hint=None, overwrite=False):
     """Resolve which entry a store operation targets.
 
@@ -1063,6 +1082,11 @@ async def store(
             entry_hint=entry_hint, overwrite=overwrite
         )
         if entry_id is None:
+            if _entry_needs_its_object_presented(entry_hint):
+                # Deliberately no `overwrite_required`: nothing is in the way,
+                # so offering to replace an entry here would invite an operator
+                # to destroy the very thing they are trying to add to.
+                return {"error": text.ENTRY_OBJECT_NOT_PRESENT}
             return {
                 "error": text.NO_OPEN_LOCAL_ENTRY_WITH_REPLACEMENT,
                 "overwrite_required": True,

--- a/tests/test_docs_and_templates.py
+++ b/tests/test_docs_and_templates.py
@@ -49,6 +49,17 @@ class DocsAndTemplateTests(unittest.TestCase):
         register_key_body = capture_call.split("/register_key")[0]
         self.assertIn("entry_hint", register_key_body)
 
+    def test_store_template_says_the_object_is_rechecked_on_save(self):
+        """The cue is verified again when the file is written, not only at capture.
+
+        With the reference template covering the whole frame the background
+        satisfied that live check by itself, so nobody had to know. Now that the
+        object is actually required, putting it down after capturing and then
+        pressing save fails - and the page has to say so before it happens.
+        """
+        store = read_text("src/phasmid/templates/store.html")
+        self.assertIn("Keep the object in front of the camera while you save", store)
+
     def test_readme_links_field_operational_docs(self):
         readme = read_text("README.md")
         self.assertIn("Quick Start in 60 seconds", readme)


### PR DESCRIPTION
Reported from the device: capturing an object, then pressing **Protect file** with the object no longer in front of the camera, produced

> No open local entry is available. Confirm replacement to continue.

and opened the "Advanced: replace an existing protected space" panel.

**Both halves of that were wrong.** An entry *was* available, and replacement permanently removes the entry the operator was in the middle of adding to — a destructive path offered as the remedy for having put an object down.

## Cause

`_select_entry_for_store` returns `None` for two unrelated reasons and the handler treated them as one:

```python
if entry_hint in ENTRY_TO_MODE:
    if not registered_modes[mode]: return entry_hint, True
    if overwrite:                  return entry_hint, True
    if _matched_entry() == entry_hint: return entry_hint, False
    return None, False          # bound, but its object is not in view
...
return None, False              # genuinely no free entry
```

With a valid entry hint only the first is reachable, so the two are cleanly separable.

## Why it surfaced now

The store path re-checks the cue at save time, not only at capture — `_matched_entry()` reads the live match state. While the reference template covered the whole frame, **the background satisfied that check on its own**, so an operator could capture, put the object down, and still save. The check existed but never fired.

It fires now, which is the correct behaviour and the point of #184. So the message has to explain it, and the page has to say so *before* it happens.

## Changes

- `/store` distinguishes the two cases. The object-missing case returns `ENTRY_OBJECT_NOT_PRESENT` — "That entry is already set up. Hold its access object in front of the camera until it matches, then save again." — and **deliberately omits `overwrite_required`**, so the replacement panel stays closed.
- The Protect step on the store page now states the requirement up front: *"Keep the object in front of the camera while you save — the cue is checked again at that moment, not just at capture."*
- `_select_entry_for_store` keeps its two-tuple return; the reason is derived by a small helper, so the seven existing call sites in `tests/test_web_server.py` are untouched.

## Test plan

- [x] `python -m unittest discover -s tests` — OK, 631 (what CI runs)
- [x] `python -m pytest -q` — 769 passed, 5 skipped
- [x] `black --check` / `ruff check` / `mypy src` — clean
- [x] New `test_store_template_says_the_object_is_rechecked_on_save`

Operationally this is also a runbook item: the demo's Step 2 has to keep the object up through the save, not just through the capture. That doc update is queued with the rest of the two-shot changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_