### PR TITLE
fix: make object capture work on a plain wall, and say why when it does not (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project follows SemVer-style release intent for documented interfaces.
   the change — measured at 0.96–1.00 for an object held up against 0.47 for a
   replaced view. The operator is told which of the two failures occurred, since
   "hold it closer" and "stop moving the camera" ask for opposite things. (#186)
+- Deleting the last Vessel left its bound-object templates behind. The
+  object-cue store is device-wide rather than scoped to a Vessel, so the next
+  Store attempt found an entry already bound to an object belonging to data
+  that no longer existed, and pushed the operator into the Replace confirmation
+  flow instead of letting them bind. `create_vessel` already cleared them for
+  this reason; `delete_vessel` now does too, but only when no Vessel is left to
+  own them. (#186)
 
 ## [0.5.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ## [Unreleased]
 
+### Fixed
+
+- Binding an access object failed on real hardware, and the failure was in the
+  two-shot capture added for #184, not in how the object was presented. The
+  scene and object frames were differenced after `cv2.equalizeHist`, which is a
+  *global* remap driven by each frame's own histogram: holding an object up
+  changes the mapping for the wall behind it too, so the difference stopped
+  describing the object. Measured on a plain wall, the equalised difference left
+  about an eighth of the object standing, and for a brighter object on the same
+  wall left nothing at all — capture was refused every time. The difference is
+  now taken on unequalised grayscale (`ObjectCueMatcher.to_diff_gray`), while
+  ORB still describes the equalised image so the template lives in the same
+  space as the frames it is later matched against. (#186)
+- A capture could be accepted when the whole view changed rather than an object
+  being placed in it. The area ceiling was applied to the largest connected
+  region, and a wholly different view of the same room still has a largest
+  region of object-like size. The ceiling now applies to the total changed area,
+  and a new `MIN_OBJECT_DOMINANCE` requires that one region account for most of
+  the change — measured at 0.96–1.00 for an object held up against 0.47 for a
+  replaced view. The operator is told which of the two failures occurred, since
+  "hold it closer" and "stop moving the camera" ask for opposite things. (#186)
+
 ## [0.5.0] - 2026-07-30
 
 > Closes a disclosure gap in local state and narrows the TUI to the operations

--- a/src/phasmid/ai_gate.py
+++ b/src/phasmid/ai_gate.py
@@ -68,7 +68,6 @@ class AIGate:
         # capture_reference() that consumes it. Never persisted: it describes
         # where the operator happened to be standing, not a credential.
         self.scene_frame: Any | None = None
-        self.scene_gray: Any | None = None
         # generate_frames() is called by two independent, concurrent
         # consumers: the always-on background thread that keeps object-cue
         # matching live for the TUI, and a fresh call per WebUI /video_feed
@@ -364,21 +363,18 @@ class AIGate:
         if frame is None:
             return False, text.AI_GATE_NO_FRAME
 
-        gray = self.matcher.to_gray(frame)
         with self.lock:
             self.scene_frame = frame
-            self.scene_gray = gray
         return True, text.AI_GATE_SCENE_CAPTURED
 
     @property
     def scene_captured(self) -> bool:
         with self.lock:
-            return self.scene_gray is not None
+            return self.scene_frame is not None
 
     def discard_scene(self) -> None:
         with self.lock:
             self.scene_frame = None
-            self.scene_gray = None
 
     def capture_reference(self, mode: str) -> tuple[bool, str]:
         self._validate_mode(mode)
@@ -387,8 +383,7 @@ class AIGate:
 
         with self.lock:
             scene_frame = None if self.scene_frame is None else self.scene_frame.copy()
-            scene_gray = None if self.scene_gray is None else self.scene_gray.copy()
-        if scene_frame is None or scene_gray is None:
+        if scene_frame is None:
             return False, text.AI_GATE_SCENE_NOT_CAPTURED
 
         with self.lock:
@@ -396,15 +391,20 @@ class AIGate:
         if frame is None:
             return False, text.AI_GATE_NO_FRAME
 
-        mask = self.matcher.object_mask(scene_gray, self.matcher.to_gray(frame))
+        # Raw grayscale for asking what changed, equalised grayscale for asking
+        # what ORB would match. Using the equalised image for the difference
+        # remaps the background along with the object and reports a third of the
+        # view as changed for an object covering an eighth of it.
+        scene_diff_gray = self.matcher.to_diff_gray(scene_frame)
+        mask = self.matcher.object_mask(
+            scene_diff_gray, self.matcher.to_diff_gray(frame)
+        )
         if mask is None:
-            # Either nothing changed enough to be an object, or so much did that
-            # the camera or the lighting moved instead. Both are the operator's
-            # to fix, and both are reported rather than silently bound.
-            covered = self._changed_area_ratio(scene_gray, frame)
-            if covered > self.matcher.max_object_area_ratio:
-                return False, text.AI_GATE_SCENE_CHANGED
-            return False, text.AI_GATE_OBJECT_NOT_DISTINCT
+            # Either nothing changed enough to be an object, or the change is
+            # spread across the view rather than concentrated in one thing held
+            # up - the camera or the lighting moved. Both are the operator's to
+            # fix, and both are reported rather than silently bound.
+            return False, self._why_no_object(scene_diff_gray, frame)
 
         candidate_state = self._best_object_reference_state(scene_frame)
         if candidate_state is None:
@@ -413,7 +413,8 @@ class AIGate:
         # The negative test. Restricting where the template comes from is the
         # fix; proving it no longer answers to the empty scene is what stops the
         # same defect shipping again unnoticed.
-        if self.matcher.explains_frame(candidate_state, scene_gray):
+        scene_match_gray = self.matcher.to_gray(scene_frame)
+        if self.matcher.explains_frame(candidate_state, scene_match_gray):
             return False, text.AI_GATE_OBJECT_IS_THE_SCENE
 
         committed = self._commit_reference(mode, candidate_state)
@@ -421,18 +422,24 @@ class AIGate:
             self.discard_scene()
         return committed
 
-    def _changed_area_ratio(self, scene_gray: Any, frame: Any) -> float:
+    def _why_no_object(self, scene_diff_gray: Any, frame: Any) -> str:
+        """Which of the two capture failures to show the operator.
+
+        Worth telling apart: "hold it closer" and "stop moving the camera" ask
+        for opposite things, and an operator given the wrong one will keep
+        making the capture worse.
+        """
         try:
-            difference = cv2.absdiff(scene_gray, self.matcher.to_gray(frame))
-            _, binary = cv2.threshold(
-                difference, self.matcher.object_mask_threshold, 255, cv2.THRESH_BINARY
+            covered, dominance = self.matcher.change_profile(
+                scene_diff_gray, self.matcher.to_diff_gray(frame)
             )
-            total = float(binary.shape[0] * binary.shape[1])
-            if total <= 0:
-                return 0.0
-            return float(np.count_nonzero(binary)) / total
         except cv2.error:
-            return 0.0
+            return text.AI_GATE_OBJECT_NOT_DISTINCT
+        if covered > self.matcher.max_object_area_ratio:
+            return text.AI_GATE_SCENE_CHANGED
+        if covered > 0.0 and dominance < self.matcher.min_object_dominance:
+            return text.AI_GATE_SCENE_CHANGED
+        return text.AI_GATE_OBJECT_NOT_DISTINCT
 
     def register_reference_from_image_bytes(
         self, mode: str, payload: bytes

--- a/src/phasmid/object_cue_matcher.py
+++ b/src/phasmid/object_cue_matcher.py
@@ -9,10 +9,10 @@ import numpy as np
 class ObjectCueMatcher:
     """ORB-based object-cue matching isolated from camera and UI concerns."""
 
-    # Per-pixel intensity change, after histogram equalisation, that counts as
-    # "this part of the frame is not the scene any more". Low enough to catch a
-    # matte object against a similar-toned background, high enough to ignore
-    # sensor noise and the small exposure drift between two consecutive frames.
+    # Per-pixel intensity change, on unequalised grayscale, that counts as "this
+    # part of the frame is not the scene any more". Low enough to catch a matte
+    # object against a similar-toned background, high enough to ignore sensor
+    # noise and the small exposure drift between two consecutive frames.
     OBJECT_MASK_THRESHOLD = 30
 
     # The masked region has to look like something placed in the scene. Below
@@ -21,6 +21,15 @@ class ObjectCueMatcher:
     # longer isolates an object.
     MIN_OBJECT_AREA_RATIO = 0.01
     MAX_OBJECT_AREA_RATIO = 0.60
+
+    # How much of the changed area the single largest region has to account for.
+    # Something placed in the scene changes one connected region; a scene that
+    # moved changes many scattered ones, and its largest region can still be
+    # object-sized. Measured: an object held up scores 0.96-1.00, a wholly
+    # different view of the same room 0.47. A hand and a cast shadow fragment
+    # the change somewhat, so this is set low enough to tolerate that - and
+    # when it is too strict the outcome is a visible refusal, not a bad binding.
+    MIN_OBJECT_DOMINANCE = 0.60
 
     def __init__(
         self,
@@ -32,6 +41,7 @@ class ObjectCueMatcher:
         object_mask_threshold: int | None = None,
         min_object_area_ratio: float | None = None,
         max_object_area_ratio: float | None = None,
+        min_object_dominance: float | None = None,
     ) -> None:
         self.min_reference_keypoints = min_reference_keypoints
         self.min_frame_descriptors = min_frame_descriptors
@@ -52,6 +62,11 @@ class ObjectCueMatcher:
             if max_object_area_ratio is None
             else max_object_area_ratio
         )
+        self.min_object_dominance = (
+            self.MIN_OBJECT_DOMINANCE
+            if min_object_dominance is None
+            else min_object_dominance
+        )
         self.orb = cast(Any, cv2).ORB_create(nfeatures=1000)
         self.bf = cv2.BFMatcher(cv2.NORM_HAMMING)
 
@@ -65,7 +80,20 @@ class ObjectCueMatcher:
         }
 
     def to_gray(self, image):
+        """Grayscale as ORB sees it, equalised for contrast."""
         return cv2.equalizeHist(cv2.cvtColor(image, cv2.COLOR_BGR2GRAY))
+
+    def to_diff_gray(self, image):
+        """Grayscale for comparing two frames of the same scene.
+
+        Deliberately *not* equalised. `equalizeHist` is a global remap driven by
+        the frame's own histogram, so holding an object up changes the mapping
+        for every background pixel too, and the difference between the two
+        frames stops describing the object. Measured on a mid-tone object
+        covering 13.7% of the view: the equalised difference reported 31.3%
+        changed, and :meth:`object_mask` refused the capture outright.
+        """
+        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
 
     def _reference_corners(self, h: int, w: int):
         points: Any = [[0, 0], [0, h - 1], [w - 1, h - 1], [w - 1, 0]]
@@ -89,16 +117,61 @@ class ObjectCueMatcher:
             "path": None,
         }
 
+    def change_binary(self, background_gray, object_gray):
+        """Cleaned-up map of which pixels differ between the two frames.
+
+        Both arguments must come from :meth:`to_diff_gray`. Returns None when
+        the two frames cannot be compared at all.
+        """
+        if background_gray is None or object_gray is None:
+            return None
+        if background_gray.shape != object_gray.shape:
+            return None
+
+        try:
+            difference = cv2.absdiff(background_gray, object_gray)
+        except cv2.error:
+            return None
+        _, binary = cv2.threshold(
+            difference, self.object_mask_threshold, 255, cv2.THRESH_BINARY
+        )
+        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+        binary = cv2.morphologyEx(binary, cv2.MORPH_OPEN, kernel)
+        return cv2.morphologyEx(binary, cv2.MORPH_CLOSE, kernel)
+
+    def change_profile(self, background_gray, object_gray) -> tuple[float, float]:
+        """(fraction of the view that changed, share held by its largest region).
+
+        Lets a caller say *why* :meth:`object_mask` refused without repeating
+        the pipeline: a large changed fraction means the view moved, and a low
+        dominance means the change is scattered rather than one thing placed in
+        front of the camera.
+        """
+        binary = self.change_binary(background_gray, object_gray)
+        if binary is None:
+            return 0.0, 0.0
+        frame_area = float(binary.shape[0] * binary.shape[1])
+        changed = float(np.count_nonzero(binary))
+        if frame_area <= 0 or changed <= 0:
+            return 0.0, 0.0
+        count, _, stats, _ = cv2.connectedComponentsWithStats(binary, connectivity=8)
+        if count <= 1:
+            return changed / frame_area, 0.0
+        largest = float(np.max(stats[1:, cv2.CC_STAT_AREA]))
+        return changed / frame_area, largest / changed
+
     def object_mask(self, background_gray, object_gray):
         """Where the object frame differs from the scene behind it.
 
+        Both arguments must come from :meth:`to_diff_gray`, not :meth:`to_gray`
+        — see that method for what equalisation does to a difference.
+
         Descriptor-level subtraction was the obvious approach and is not good
-        enough: introducing the object shifts the global histogram, so
-        `equalizeHist` remaps the background too and hundreds of background
-        keypoints survive with descriptors just different enough to look novel.
-        Masking by pixel difference asks the question directly instead — which
-        part of the frame changed when the object was held up — and hands that
-        region to ORB, which takes a mask natively.
+        enough: hundreds of background keypoints survive with descriptors just
+        different enough to look novel. Masking by pixel difference asks the
+        question directly instead — which part of the frame changed when the
+        object was held up — and hands that region to ORB, which takes a mask
+        natively.
 
         Assumes the camera does not move between the two frames. That is the
         tripod setup the demo uses, and the setup whose fixed background caused
@@ -107,18 +180,21 @@ class ObjectCueMatcher:
         Returns None when the change is too small to be an object, or so large
         that the whole scene moved rather than something being placed in it.
         """
-        if background_gray is None or object_gray is None:
-            return None
-        if background_gray.shape != object_gray.shape:
+        binary = self.change_binary(background_gray, object_gray)
+        if binary is None:
             return None
 
-        difference = cv2.absdiff(background_gray, object_gray)
-        _, binary = cv2.threshold(
-            difference, self.object_mask_threshold, 255, cv2.THRESH_BINARY
-        )
-        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
-        binary = cv2.morphologyEx(binary, cv2.MORPH_OPEN, kernel)
-        binary = cv2.morphologyEx(binary, cv2.MORPH_CLOSE, kernel)
+        frame_area = float(binary.shape[0] * binary.shape[1])
+        if frame_area <= 0:
+            return None
+        changed = float(np.count_nonzero(binary))
+        # Checked on the total, before picking a component. A view that changed
+        # everywhere still has a largest blob, and that blob can be small enough
+        # to pass for an object while describing a room that moved.
+        if changed / frame_area > self.max_object_area_ratio:
+            return None
+        if changed <= 0:
+            return None
 
         # connectivity is keyword-only in practice: passing 8 positionally lands
         # it in the `labels` output slot, not connectivity.
@@ -131,11 +207,10 @@ class ObjectCueMatcher:
         largest = 1 + int(np.argmax(stats[1:, cv2.CC_STAT_AREA]))
         mask = np.where(labels == largest, 255, 0).astype(np.uint8)
 
-        frame_area = float(binary.shape[0] * binary.shape[1])
-        covered = float(np.count_nonzero(mask)) / frame_area
-        if covered < self.min_object_area_ratio:
+        area = float(np.count_nonzero(mask))
+        if area / frame_area < self.min_object_area_ratio:
             return None
-        if covered > self.max_object_area_ratio:
+        if area / changed < self.min_object_dominance:
             return None
         return mask
 
@@ -147,16 +222,22 @@ class ObjectCueMatcher:
         not stand out from what is behind it. Callers must still run the
         capture-time negative test in :meth:`explains_frame`; this restricts
         *where* the template comes from, and that check proves it worked.
+
+        The two greyscales are not interchangeable: the mask is found on raw
+        intensity, where a difference means something moved, while the
+        descriptors are cut from the equalised image so they sit in the same
+        space as the live frames they are later matched against.
         """
         if background_image is None or object_image is None:
             return None
 
-        background_gray = self.to_gray(background_image)
-        object_gray = self.to_gray(object_image)
-        mask = self.object_mask(background_gray, object_gray)
+        mask = self.object_mask(
+            self.to_diff_gray(background_image), self.to_diff_gray(object_image)
+        )
         if mask is None:
             return None
 
+        object_gray = self.to_gray(object_image)
         kp, des = self.orb.detectAndCompute(object_gray, mask)
         if not kp or len(kp) < self.min_reference_keypoints or des is None:
             return None

--- a/src/phasmid/services/vessel_workflow_service.py
+++ b/src/phasmid/services/vessel_workflow_service.py
@@ -1434,6 +1434,15 @@ class VesselWorkflowService:
         vault.silent_brick()
         vessel.unlink()
         self._vessels.unregister(vessel)
+        # The object-cue store is a device-wide singleton, not scoped to a
+        # Vessel, so deleting the last Vessel used to leave its bound-object
+        # templates behind. The next Store attempt then found an entry that was
+        # already bound to an object belonging to data that no longer exists,
+        # and pushed the operator into the Replace confirmation flow instead of
+        # letting them bind. Only cleared when nothing is left to own them: with
+        # another Vessel still registered, those templates are still in use.
+        if not self._vessels.list_all():
+            access_cue_service.clear_references()
         return DeleteVesselResult(vessel_path=vessel, vessel_name=vessel_name)
 
     def store_file(

--- a/src/phasmid/strings.py
+++ b/src/phasmid/strings.py
@@ -17,6 +17,10 @@ RESTRICTED_CONFIRMATION_RETRY = (
 )
 
 NO_OPEN_LOCAL_ENTRY = "No open local entry is available."
+ENTRY_OBJECT_NOT_PRESENT = (
+    "That entry is already set up. Hold its access object in front of the "
+    "camera until it matches, then save again."
+)
 NO_OPEN_LOCAL_ENTRY_WITH_REPLACEMENT = (
     "No open local entry is available. Confirm replacement to continue."
 )

--- a/src/phasmid/templates/store.html
+++ b/src/phasmid/templates/store.html
@@ -78,7 +78,7 @@
             <section class="step-card">
                 <div class="step-head">
                     <span class="step-number">✓</span>
-                    <div><h3>Protect the file</h3><p class="step-help">The button becomes available when the file, password, and access object are all ready.</p></div>
+                    <div><h3>Protect the file</h3><p class="step-help">The button becomes available when the file, password, and access object are all ready. <strong>Keep the object in front of the camera while you save</strong> — the cue is checked again at that moment, not just at capture.</p></div>
                 </div>
                 <div class="ready-summary" aria-live="polite">
                     <div class="ready-row"><span>File</span><strong id="selectedFileName">Not selected</strong></div>

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -602,6 +602,25 @@ def _matched_entry():
     return None
 
 
+def _entry_needs_its_object_presented(entry_hint) -> bool:
+    """Whether the chosen entry was refused only because its object is not in view.
+
+    `_select_entry_for_store` returns nothing for two very different reasons,
+    and conflating them sent an operator toward the replacement panel - a
+    destructive path - when all they had to do was hold their object up again.
+    With a valid hint there is only one way to reach None: the entry exists and
+    is bound, and the camera is not currently matching it.
+
+    This surfaced the moment the cue started requiring the object. While the
+    reference template was the whole frame, the background satisfied the live
+    match on its own, so this branch was effectively unreachable.
+    """
+    if entry_hint not in ENTRY_TO_MODE:
+        return False
+    mode = ENTRY_TO_MODE[entry_hint]
+    return bool(_raw_gate_status().get("registered_modes", {}).get(mode))
+
+
 def _select_entry_for_store(entry_hint=None, overwrite=False):
     """Resolve which entry a store operation targets.
 
@@ -1063,6 +1082,11 @@ async def store(
             entry_hint=entry_hint, overwrite=overwrite
         )
         if entry_id is None:
+            if _entry_needs_its_object_presented(entry_hint):
+                # Deliberately no `overwrite_required`: nothing is in the way,
+                # so offering to replace an entry here would invite an operator
+                # to destroy the very thing they are trying to add to.
+                return {"error": text.ENTRY_OBJECT_NOT_PRESENT}
             return {
                 "error": text.NO_OPEN_LOCAL_ENTRY_WITH_REPLACEMENT,
                 "overwrite_required": True,

--- a/tests/test_docs_and_templates.py
+++ b/tests/test_docs_and_templates.py
@@ -49,6 +49,17 @@ class DocsAndTemplateTests(unittest.TestCase):
         register_key_body = capture_call.split("/register_key")[0]
         self.assertIn("entry_hint", register_key_body)
 
+    def test_store_template_says_the_object_is_rechecked_on_save(self):
+        """The cue is verified again when the file is written, not only at capture.
+
+        With the reference template covering the whole frame the background
+        satisfied that live check by itself, so nobody had to know. Now that the
+        object is actually required, putting it down after capturing and then
+        pressing save fails - and the page has to say so before it happens.
+        """
+        store = read_text("src/phasmid/templates/store.html")
+        self.assertIn("Keep the object in front of the camera while you save", store)
+
     def test_readme_links_field_operational_docs(self):
         readme = read_text("README.md")
         self.assertIn("Quick Start in 60 seconds", readme)

--- a/tests/test_object_cue_background.py
+++ b/tests/test_object_cue_background.py
@@ -68,6 +68,40 @@ def _with_dark_object(scene: np.ndarray) -> np.ndarray:
     return image
 
 
+#: The object below covers this fraction of the frame. Any mask worth calling
+#: an object mask has to land near it.
+PLAIN_ROOM_OBJECT_AREA = (215 - 100) * (175 - 60) / (240 * 320)
+
+
+def _plain_room(level: int = 110) -> np.ndarray:
+    """A wall, softly lit - the case that broke the equalised difference.
+
+    The textured scene above has enough extremes that equalisation stays roughly
+    stable when an object arrives. A plain wall does not: its histogram is
+    narrow, so an object shifts the mapping for every pixel in the frame at
+    once, and the difference between the two frames stops describing the object.
+    This is what a camera on a desk actually points at.
+    """
+    image = np.full((240, 320, 3), level, np.uint8)
+    rng = np.random.default_rng(11)
+    noise = rng.integers(-8, 9, (240, 320, 1), dtype=np.int16)
+    image = np.clip(image.astype(np.int16) + noise, 0, 255).astype(np.uint8)
+    cv2.line(image, (0, 190), (319, 186), (level - 25, level - 25, level - 25), 3)
+    return image
+
+
+def _held_up(scene: np.ndarray) -> np.ndarray:
+    """A dark, textured object held in front of the wall."""
+    image = scene.copy()
+    cv2.rectangle(image, (100, 60), (215, 175), (60, 60, 60), -1)
+    for i in range(5):
+        cv2.line(image, (104, 66 + i * 22), (211, 66 + i * 22), (0, 0, 0), 3)
+    cv2.putText(
+        image, "TAG", (110, 165), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (140, 140, 140), 2
+    )
+    return image
+
+
 def _matcher() -> ObjectCueMatcher:
     return ObjectCueMatcher(
         min_reference_keypoints=10,
@@ -123,14 +157,46 @@ class ObjectCueBackgroundTests(unittest.TestCase):
         self.assertGreater(len(whole_frame["kp"]), len(self.reference["kp"]))
 
 
+class PlainWallSceneTests(unittest.TestCase):
+    """The whole flow on the scene the demo actually runs against.
+
+    A camera on a desk pointed at a wall is the case that failed on real
+    hardware, and it is the one the demo depends on. The textured scene above
+    exercises the mask; this exercises binding and refusal end to end.
+    """
+
+    def setUp(self):
+        self.matcher = _matcher()
+        self.room = _plain_room()
+        self.held = _held_up(self.room)
+        self.reference = self.matcher.object_reference_state(self.room, self.held)
+
+    def test_the_object_binds_against_a_plain_wall(self):
+        self.assertIsNotNone(self.reference, "capture was refused on a plain wall")
+
+    def test_the_empty_wall_does_not_open_it(self):
+        self.assertFalse(
+            self.matcher.explains_frame(
+                self.reference, self.matcher.to_gray(self.room)
+            ),
+            "the wall alone opened the cue",
+        )
+
+    def test_the_object_opens_it(self):
+        self.assertTrue(
+            self.matcher.explains_frame(self.reference, self.matcher.to_gray(self.held))
+        )
+
+
 class ObjectMaskTests(unittest.TestCase):
     def setUp(self):
         self.matcher = _matcher()
         self.scene = _fixed_scene()
 
-    def _mask(self, frame):
+    def _mask(self, frame, scene=None):
+        scene = self.scene if scene is None else scene
         return self.matcher.object_mask(
-            self.matcher.to_gray(self.scene), self.matcher.to_gray(frame)
+            self.matcher.to_diff_gray(scene), self.matcher.to_diff_gray(frame)
         )
 
     def test_the_mask_covers_the_object_and_not_the_frame(self):
@@ -152,8 +218,44 @@ class ObjectMaskTests(unittest.TestCase):
         small = cv2.resize(self.scene, (160, 120))
         self.assertIsNone(
             self.matcher.object_mask(
-                self.matcher.to_gray(self.scene), self.matcher.to_gray(small)
+                self.matcher.to_diff_gray(self.scene), self.matcher.to_diff_gray(small)
             )
+        )
+
+    def test_an_object_on_a_plain_wall_is_found_whole(self):
+        """The case operators hit on real hardware, where capture kept failing.
+
+        The difference has to be taken on raw intensity. Nothing here is subtle
+        - a dark object on a light wall - and the mask should simply be the
+        object.
+        """
+        room = _plain_room()
+        mask = self._mask(_held_up(room), scene=room)
+        self.assertIsNotNone(mask, "the object was refused - is the diff equalised?")
+        covered = np.count_nonzero(mask) / float(mask.shape[0] * mask.shape[1])
+        self.assertAlmostEqual(covered, PLAIN_ROOM_OBJECT_AREA, delta=0.02)
+
+    def test_the_equalised_difference_loses_that_object(self):
+        """Pins the diagnosis, so a regression reads as one rather than as new.
+
+        `equalizeHist` is a global remap driven by the frame's own histogram, so
+        the object arriving changes the mapping for the wall too and the
+        difference stops describing the object. On this scene it leaves about an
+        eighth of the object standing: the template gets built from a sliver, or
+        - for a brighter object on the same wall - from nothing, and capture is
+        refused. That is the whole defect.
+        """
+        room = _plain_room()
+        mask = self.matcher.object_mask(
+            self.matcher.to_gray(room), self.matcher.to_gray(_held_up(room))
+        )
+        covered = 0.0
+        if mask is not None:
+            covered = np.count_nonzero(mask) / float(mask.shape[0] * mask.shape[1])
+        self.assertLess(
+            covered,
+            PLAIN_ROOM_OBJECT_AREA / 4,
+            "if this now covers the object, the note in to_diff_gray is stale",
         )
 
     def test_object_reference_state_refuses_without_a_scene(self):

--- a/tests/test_vessel_workflow_service.py
+++ b/tests/test_vessel_workflow_service.py
@@ -14,6 +14,7 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from phasmid.services import vessel_service as vessel_service_mod
+from phasmid.services import vessel_workflow_service as workflow_mod
 from phasmid.services.inspection_service import InspectionService
 from phasmid.services.vessel_workflow_service import VesselWorkflowService
 
@@ -1015,6 +1016,64 @@ class VesselWorkflowServiceTests(IsolatedPhasmidDirs, unittest.TestCase):
                 self.assertEqual(result.vessel_path, vessel_path.resolve())
                 self.assertFalse(vessel_path.exists())
                 self.assertIsNone(vessel_service_mod.get_vessel_record(vessel_path))
+
+    def test_deleting_the_last_vessel_releases_the_bound_object_cues(self):
+        """Otherwise the next Store finds an entry bound to deleted data.
+
+        The object-cue store is device-wide, not scoped to a Vessel. Deleting
+        the Vessel used to leave its templates behind, so binding an object to
+        a fresh Vessel hit "entry already has a bound object" and pushed the
+        operator into the Replace confirmation flow for data that no longer
+        existed - reported from hardware as capture refusing to work after a
+        delete.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            vessel_path = Path(tmpdir) / "travel.vessel"
+
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
+                svc = VesselWorkflowService()
+                svc.create_vessel(vessel_path, "8M")
+
+                with mock.patch.object(
+                    workflow_mod.access_cue_service, "clear_references"
+                ) as clear:
+                    svc.delete_vessel(vessel_path, confirmation="DELETE VESSEL")
+
+                clear.assert_called_once()
+
+    def test_deleting_one_of_two_vessels_keeps_the_cues_the_other_uses(self):
+        """A device-wide clear would take the surviving Vessel's bindings too."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            going = Path(tmpdir) / "going.vessel"
+            staying = Path(tmpdir) / "staying.vessel"
+
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"PHASMID_STATE_DIR": str(state_dir)},
+                    clear=False,
+                ),
+                self._patch_registry_dir(tmpdir),
+            ):
+                svc = VesselWorkflowService()
+                svc.create_vessel(going, "8M")
+                svc.create_vessel(staying, "8M")
+
+                with mock.patch.object(
+                    workflow_mod.access_cue_service, "clear_references"
+                ) as clear:
+                    svc.delete_vessel(going, confirmation="DELETE VESSEL")
+
+                clear.assert_not_called()
 
     def test_delete_vessel_rejects_wrong_confirmation(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests_optional/test_ai_gate.py
+++ b/tests_optional/test_ai_gate.py
@@ -201,7 +201,6 @@ class AIGateTemplateTests(unittest.TestCase):
             # Binding needs the empty view first, so the scene shot has to be in
             # place before capture_reference gets as far as the similarity check.
             gate.scene_frame = np.zeros((480, 640, 3), dtype=np.uint8)
-            gate.scene_gray = np.zeros((480, 640), dtype=np.uint8)
             with (
                 mock.patch.object(
                     gate.matcher,


### PR DESCRIPTION
Three capture failures reported from hardware, plus one found while proving the first.

## 1. Binding an object failed on a plain wall

Two-shot object capture (added in #184) refused almost every real object: the empty-scene shot succeeded, the object shot failed, and when it did succeed `Protect file` failed after it. The cause is in the #184 implementation, not in how the object was being presented.

The scene frame and the object frame were compared **after** `cv2.equalizeHist`. Equalisation is a *global* remap driven by each frame's own histogram, so introducing an object changes the mapping for the wall behind it as well. The difference then describes the exposure shift rather than the object.

Measured on a plain wall — the case a camera on a desk actually sees:

| | changed area reported | object's true area |
|---|---|---|
| equalised difference | 6.4%, fragmented | 17.2% |
| raw difference | 17.3% | 17.2% |

For a brighter object on the same wall the equalised path produced **no mask at all** — the refusal the operator kept hitting.

Fix:

- `ObjectCueMatcher.to_diff_gray()` — unequalised grayscale, for comparing two frames of the same scene. `to_gray()` stays equalised and is still what ORB describes, so the template lives in the same space as the live frames it is matched against. The two are not interchangeable and the docstrings now say so.
- `object_reference_state()` and `AIGate.capture_reference()` build the mask from `to_diff_gray` and cut descriptors from `to_gray`.
- `AIGate.scene_gray` removed. Holding one greyscale for two purposes is what made this bug easy to write; only the scene frame is kept, and each greyscale is derived where it is used.

## 2. A replaced view could pass as an object

Found while proving the above. The area ceiling was applied to the **largest connected region**, not to the total changed area — and a wholly different view of the same room still has a largest region of object-like size, so it passed.

- The ceiling now applies to the total changed area.
- New `MIN_OBJECT_DOMINANCE` (0.60) requires one region to account for most of the change. Measured: an object held up scores 0.96–1.00, a replaced view 0.47.
- `change_binary()` / `change_profile()` expose the measurement so `AIGate` can say *which* failure occurred without repeating the pipeline. "Hold it closer" and "stop moving the camera" ask for opposite things, and an operator given the wrong one keeps making the capture worse.

## 3. Saving to a bound entry offered to replace it instead of asking for its object

Reported as an unexpected "Advanced: replace an existing protected space" panel. `/store` re-checks the object cue at save time, and with no live match it fell through to the same branch as "no free entry", which prompts for replacement. Saving to an entry that already has an object is not a replacement — it needs that object held up. It now returns `ENTRY_OBJECT_NOT_PRESENT` without `overwrite_required`, and the page says the cue is checked again at save time so putting the object down after capturing does not come as a surprise.

This branch was invisible until now: with the reference template covering the whole frame, the background satisfied the live check by itself and nobody ever reached it.

## 4. Deleting a Vessel did not release its object cues

Reported as "capture still fails after deleting the Vessel — is a frame being held somewhere?" It was, in a sense: the object-cue store is device-wide rather than scoped to a Vessel, so deleting the Vessel left its templates behind and the next Store found an entry already bound to an object belonging to data that no longer existed — routing the operator into the Replace flow again.

`create_vessel` already cleared them for exactly this reason. `delete_vessel` now does too, but only when no Vessel is left to own them: a device-wide clear would take a surviving Vessel's bindings with it.

## Tests

`tests/test_object_cue_background.py` grows a plain-wall scene alongside the existing textured one:

- the object binds against a plain wall and the empty wall does not open it, end to end
- the raw difference recovers the object's area to within 2 points
- the equalised difference leaves under a quarter of it — pinned as a characterisation, so a regression reads as a regression rather than as a new bug
- a wholly replaced view is refused

`tests/test_vessel_workflow_service.py` covers both halves of the delete case: the last Vessel releases the cues, and one of two does not.

638 tests in `tests/` and 124 in `tests_optional/` pass; mypy and black are clean.

## Not covered here

Hardware verification is still outstanding — specifically the negative case (object hidden → decrypt refused), which is the demo's central claim and cannot be settled from synthetic scenes. The CLI and TUI capture paths, and registration from an image file, still use the single-shot whole-frame method and are unchanged by this PR.