### PR TITLE
feat: clear a protected entry from the WebUI, not only the CLI (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ## [Unreleased]
 
+### Added
+
+- `POST /destroy_face` — clearing a protected entry from the WebUI. The destroy
+  credential existed only in `phasmid emergency destroy-face`, so the one
+  scenario the tool exists for, refusing to disclose under duress, was the one
+  that dropped out of the browser and onto a terminal. It reuses the service
+  call the CLI already uses and asks for the same `DESTROY FACE` phrase, so the
+  two interfaces agree rather than each inventing a dialect. Which entry is
+  cleared is decided by the object in front of the camera and never by a request
+  parameter: naming an entry on screen would say there is more than one. The
+  destroy password stays a distinct credential from the access password —
+  neither can do the other's job — so a coerced operator who hands over the
+  access password has not handed over this. Every refusal reads the same, and
+  failures count against the same attempt limiter as `/retrieve`. This is the
+  only restricted action gated by a credential rather than by a public phrase
+  alone, and it deliberately does **not** additionally require a restricted
+  confirmation session: that would add a step without adding authorization, in
+  the one flow reached in front of the person applying the pressure. (#189)
+
 ### Fixed
 
 - A bound object was refused at retrieval when it was plainly in front of the

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -234,6 +234,7 @@ WebUI responses include conservative browser hardening headers such as no-store 
 | `POST` | `/metadata/check` | Local metadata risk check |
 | `POST` | `/metadata/scrub` | Best-effort local metadata reduction |
 | `POST` | `/retrieve` | Retrieve and download the matching entry |
+| `POST` | `/destroy_face` | Clear the entry whose object is presented, using that entry's destroy password |
 | `POST` | `/purge_other` | Hidden restricted clear action |
 | `POST` | `/emergency/initialize` | Hidden container initialization |
 | `POST` | `/emergency/brick` | Hidden local access-path clear action |
@@ -285,6 +286,21 @@ stressful conditions.
 ## 10. Metadata and Data Minimization
 
 Store provides a local-only metadata risk check. It does not call cloud services and does not send telemetry.
+
+`/destroy_face` is the only restricted action gated by a credential rather than
+by a public confirmation phrase alone. It requires the bound object of the entry
+being cleared to be matching at the moment of the call, that entry's destroy
+password (a different credential from its access password, which cannot perform
+this action and which this password cannot use to read), and the phrase
+`DESTROY FACE` — the same phrase `phasmid emergency destroy-face --confirm`
+takes. It does **not** additionally require a restricted confirmation session:
+that would add a step without adding authorization, and this is the one action
+reached under duress, where each extra step is taken in front of the person
+applying it. The entry cleared is determined by the live object match and never
+by a request parameter, so the surface never has to name one of two entries.
+Failures are indistinguishable — a wrong destroy password, an uninitialized
+entry, and an object that stopped matching all return the same rejection — and
+they count against the same attempt limiter as `/retrieve`.
 
 `/metadata/check` and `/metadata/scrub` enforce the normal Web mutation token, rate limiting, and upload size limit. Uploaded data is processed in memory; these routes do not require writing the uploaded file to disk, and the intended implementation property is no disk write for uploaded metadata inspection.
 

--- a/docs/submissions/Phasmid_Demo_Runbook.md
+++ b/docs/submissions/Phasmid_Demo_Runbook.md
@@ -7,6 +7,7 @@
 > - **本書は 0.5.0 実機（Pi Zero 2 W / Raspberry Pi OS Trixie）で全手順を通した結果に基づく。** 〔要確認〕は原則として解消済み。実機で確認していない項目のみ §9 末尾に明示する。
 > - **物体の登録が2段階撮影になった（0.5.0・#184/#187）。** `1 · Capture empty scene`（物体をフレーム外にして空の視野を撮る）→ `2 · Capture access object`（物体をかざして撮る）の順。**この2枚の差分が物体の領域を決め、その領域だけが特徴として登録される。** 従来は視野全体を登録していたため、三脚固定の背景そのものが鍵になり、**物体を隠しても開いてしまっていた**。加えて **保存の瞬間にも物体の一致が再確認される** — 撮影後に物体を下ろして `Protect file` を押すと拒否される（→ §0・Step 2）。
 > - **Step 4（物体なし→拒否）を WebUI Retrieve に移した。** 0.5.0 実機で WebUI 経路でも拒否されることを確認済み。**これで Step 3（成功）と Step 4（失敗）が同じ画面で連続する** — 物体の有無だけを変えた対比を画面切替なしで見せられるため、cue≠key の実証としては従来より強い。TUI の `Recover File` は**フォールバックとして残す**（→ §5）。
+> - **破壊（Face のクリア）を WebUI から行えるようにした（#189）。** 従来この操作は `phasmid emergency destroy-face` だけにあり、**このツールが存在する理由そのものである「強要されてもデータは守る」シナリオだけがブラウザから落ちてターミナルに残っていた**。Retrieve 画面の「Clear this entry instead of opening it」から、**かざした物体のエントリ**を、その**破壊パスワード**と確認語 `DESTROY FACE` で消せる。消す対象を画面で選ばせないのは意図的 — 選択肢を出すこと自体が「2つある」ことを漏らすため。**この経路はまだ実機で通していない**（→ §9 末尾）。
 > - **Issue #169・Phase 1:** TUI の **Add File** と Expert 画面の **Doctor・Inspect を非活性化**した — いずれも役割別トークンで保護された WebUI（`/store`、`/operator/doctor`、`/operator/inspect`）と完全に重複するため。**Recover File と Audit はあえて非活性化していない** — Audit は本デモ Step 5 でキー1つで直接使う。Recover File は Step 4 の WebUI 移行で本編からは外れたが、**壇上で WebUI が使えなくなった場合に否定証明を成立させる唯一の代替経路**なので残す。**削除ではなく非活性化** — 内部のサービス呼び出し・画面コードはそのまま残しており、リハーサルで問題が出れば1行で復元できる。
 > - **Expert フッタの安全端末幅が 145→124 桁に下がった**（Doctor/Inspect の非活性化でフッタの項目数が減ったため。Audit は残っているので115桁までは下がらない）。
 > - **囮ファイルは運用者が用意する**ものとし、生成機能は空き領域の填充に位置づけ直している（v4 からの変更点、引き続き有効）。
@@ -39,6 +40,7 @@
 | 2 | Bind — Face 1・Face 2 登録 | 1:30 | **WebUI**（store トークン） | Bind（cue≠key の準備） |
 | 3 | Operate — 復元 成功／役割の境界 | 0:50 | **WebUI**（store・recover トークン） | Operate |
 | 4 | **復元 失敗（物体なし）** | 0:50 | **WebUI**（Step 3 と同じタブ） | **★★cue≠key の証明** |
+| 4b | （任意）強要下でデータを守る | 0:40 | **WebUI**（同じタブ） | 破壊資格の分離。**不可逆** |
 | 5 | Audit（空き領域と境界） | 0:50 | TUI Expert | 誠実性の可視化 |
 | 6 | Silent Standby | 1:20 | TUI | Disclose / 山場 |
 | 7 | ラップ | 0:10 | TUI Simple | 締め |
@@ -85,6 +87,8 @@
       **どちらも Step 2 で WebUI から保存する** — TUI の `Add File` は #169 で
       非活性化済みなので使わない（`Recover File` は §5 のフォールバック用に残してある）。
 - [ ] 用意するパスフレーズは3つ: 真の復号用・真の破壊用・偽の復号用。
+      **真の破壊用は Store 画面の「Advanced security options」→「Restricted recovery
+      password」で設定する。** ここを空にしたまま進めると Step 4b が実演できない。
 - [ ] （任意）**Fill Free Space を事前実行**（約4分）。空き領域を埋め、
       容器が不自然に空でないようにする。経過時間が表示され画面は固まらない。
 - [ ] ラップトップのブラウザで `http://10.12.194.1:8000/unlock` を開き、
@@ -100,6 +104,8 @@
       3. 物体をかざし直して `Protect file` → 保存できること
       4. Retrieve で**物体を隠して**正しいパスワード → **拒否されること**
       5. 物体を戻して同じパスワード → 復元できること
+      6. （Step 4b をやるなら）**別の使い捨て Vessel で**破壊まで通す — 本番用の
+         Vessel でリハーサルすると本番のデータが消える
 
       **4 と 5 は必ず対で確認する。** 4 だけでは「何をやっても拒否する状態」と区別がつかない。
       詳細な検証手順と観測すべき値は §9 冒頭を参照。
@@ -250,6 +256,43 @@
   **照合を迂回して復元することはできない。** 0.5.0 では加えて、参照テンプレート
   自体が**空シーンとの差分領域からのみ**作られ、作成直後に「空シーンに一致しないこと」を
   検証してから保存される（#184）— 背景が鍵になる経路を実装として塞いである。
+
+### Step 4b — 強要下でデータを守る（0:40｜任意・WebUI・Step 4 と同じ画面）
+
+> **本番でやるかは当日判断。枠が押していれば省略**し、Step 6 の Silent Standby に
+> 時間を回す（合計は 7:30 → 8:10 になる）。Step 4 と同じタブで続けるので**追加の
+> 画面切替は無い**。
+> **不可逆。** 実施すると片方の Face は戻らない。次の Step 5（Audit）の数字は
+> **消した後の状態**を映すので、`Faces with little or no filler` などが事前の想定と
+> 変わる — これは不都合ではなく、**「今消したものが空として読める」ことを見せる材料**に
+> なる。数字を事前の想定どおりに見せたい場合は 4b を省略すること。
+
+「パスワードを強要されてもデータだけは守る」というこのツールの立ち位置を、
+実演で示すステップ。**開示用の Face は残したまま、真の Face だけを消す。**
+
+- **操作:** Retrieve 画面の **「Clear this entry instead of opening it」** を開く →
+  **消したい Face の物体をカメラにかざす** → その Face の **Clearing password**
+  （Store の Advanced security options で設定した2つめのパスワード）→
+  確認欄に **`DESTROY FACE`** と入力 → `Clear this entry`。
+- **画面期待:** `Local entry cleared. Its contents cannot be recovered.`
+  その後、同じ物体と**アクセス**パスワードで開こうとしても復元されない。
+  **もう一方の Face は無傷**で、そちらは物体とパスワードで開ける。
+- **発話（EN）:** "One more password. It is not the one that opens this entry — it is the one that ends it. Same object, same camera, different credential, and the contents are gone. Not hidden, not moved: gone. The other entry is untouched, and I can still open it. That is the answer to 'they will just make you type the password': the password they can compel is not the only one there is."
+- **注意（消えるのは「かざした Face」）:** 指定は画面の選択肢ではなく**カメラの物体**で
+  決まる。**真の Face を消すには真の物体を出す必要がある** — 強要下では「真の物体を
+  出すこと自体が情報になる」という設計上の論点があり、質問されたら**隠さずそう答える**。
+  画面にエントリの選択肢を出さないのは意図的で、選ばせること自体が「2つある」ことを
+  漏らすため。
+- **注意（資格の分離）:** アクセスパスワードではこれは実行できず、この破壊パスワードで
+  ファイルが開くこともない（`retrieve_open_only` による分離。
+  `test_emergency_password_does_not_trigger_normal_list_or_retrieve` が固定）。
+  **強要してアクセスパスワードを得た側は、破壊資格を得ていない。**
+- **注意（失敗の見え方）:** 破壊パスワードを間違えた場合も、物体が一致しなくなった
+  場合も、そのエントリが未設定の場合も、**すべて `Operation rejected.`** で同じに見える。
+  失敗は5回で60秒ロック（Retrieve と同じカウンタ）。
+- **フォールバック:** WebUI が使えない場合は CLI —
+  `phasmid emergency destroy-face <vessel> --face face_a --camera-object --confirm "DESTROY FACE"`
+  （破壊パスワードは対話プロンプト）。**確認フレーズは WebUI と同じ文字列**。
 
 ### Step 5 — Audit: 空き領域と、ツールが判定しないこと（0:50｜誠実性の可視化｜TUI Expert）
 
@@ -624,6 +667,10 @@ Delete Vessel（`delete`キー）バインディング追加で145桁へ上が�
   （物体だけを切り抜いた写真なら問題ない）。
 - **CLI と TUI の登録経路も 2段階撮影に未移行。** 本デモは WebUI で登録するため
   影響しないが、これらの経路で登録した参照は同じ弱点を持つ。
+- **WebUI からの破壊（Step 4b・`/destroy_face`）は実機未検証。** サービス層
+  （`destroy_face`）は CLI で使われている同じ呼び出しで、単体テストは通っているが、
+  **カメラ・破壊パスワード・確認語が実機で揃う経路としては未確認**。本番で 4b を
+  やるなら、**使い捨ての Vessel で一度通してから**にすること。
 - **閾値は実測に基づく調整をしていない。** `MIN_GOOD_MATCHES=50` / `MIN_INLIERS=30` は
   視野全体テンプレート時代の値で、マスク後のキーポイント数に対して妥当かを実測して
   いない。0.5.0 実機では問題なく一致したが、照明・距離が変われば余裕が不明。

--- a/docs/submissions/Phasmid_Talk_Script_30min.md
+++ b/docs/submissions/Phasmid_Talk_Script_30min.md
@@ -2,7 +2,8 @@
 
 **Deck:** Phasmid_DEFCON_DemoLabs.pptx（全26枚 / 各スライドに同内容のスピーカーノート埋め込み済み）
 **Presenter:** Makoto Sugita (Mr.Rabbit / 01rabbit)
-**改訂 v5（0.4.0）:** Slide 24 のデモ構成を、実機で検証済みの WebUI 中心の Bind/Operate に更新。**Step 2「Bind」と Step 3「Operate（正しい物体での復元）」は WebUI**（役割別トークン: store / recover）で行い、**Step 4「物体なしでの失敗」だけを TUI に残す**（この否定証明はWebUI側で今回のセッションでは未再検証のため）。プロジェクタ切替は Step 1→2 と Step 3→4 の**1往復のみ**に抑制。Issue #169（TUI の Add File・Doctor・Inspect を非活性化、WebUIと重複するため）を反映し、Slide 24 の手順表と Q&A の一部を更新。
+**改訂 v6（0.5.0・実機検証済み）:** 物体キューの登録を**2段階撮影**（空シーン→物体）に変更 — 従来は視野全体を鍵にしており、**物体を隠しても開いてしまっていた**（#184/#187）。**Step 4「物体なしでの失敗」を WebUI に移した** — 実機で WebUI 経路の拒否を確認したため。Step 3（成功）と Step 4（失敗）が**同じタブで連続**し、物体の有無だけが変わる。プロジェクタ切替は Step 1→2 と Step 4→5 の**1往復のみ**。**Step 4b（強要下でデータを守る／破壊）を任意ステップとして追加**（#189、WebUI から実行可能に）。
+> 旧 v5（0.4.0）: Slide 24 のデモ構成を、実機で検証済みの WebUI 中心の Bind/Operate に更新。**Step 2「Bind」と Step 3「Operate（正しい物体での復元）」は WebUI**（役割別トークン: store / recover）で行い、**Step 4「物体なしでの失敗」だけを TUI に残す**（この否定証明はWebUI側で今回のセッションでは未再検証のため）。プロジェクタ切替は Step 1→2 と Step 3→4 の**1往復のみ**に抑制。Issue #169（TUI の Add File・Doctor・Inspect を非活性化、WebUIと重複するため）を反映し、Slide 24 の手順表と Q&A の一部を更新。
 **改訂 v4:** 製品モデルの確定を反映。**囮ファイルはツールが作らない — 利用者が用意する。** 生成機能は「空き領域の填充」へ降格し、Slide 14・21・22 の記述を差し替え。**強要下では開示しない**（制限パスフレーズは破壊資格であり取出資格ではない）ことを Slide 21 で明言。**パスフレーズは3つ**（真の復号／真の破壊／偽の復号）を Slide 12 に明示。Slide 24 のデモ手順を実機ランブック（8ステップ）と一致させ、**Step 3b（物体なしでの失敗）** を山場として新設。**ステッカーは未作成のため Slide 25・26 の言及を削除**し、卓上デモへの導線に差し替え。
 > 旧 v3: 実装（silent_brick／purge／emergency_daemon）と整合させ、Slide 6・21 の「破壊しない」記述を撤回。核心を「**Phasmid destroys, but never fabricates**（破壊はする／偽造・隠蔽はしない）」へ変更し、owner-triggered destruction の存在と §2232 リスクを開示。
 > 旧 v2: 軍歴＝着想源＋inverse framing（Slide 2）、REAL CASE(2026)（Slide 4）、国境事案 Q&A を追加。
@@ -140,6 +141,7 @@
 | 2 | Bind — Face 1・Face 2 登録 | 1:30 | **WebUI**（store） | **プロジェクタ切替①。** **空シーン→物体の2枚撮り。** 物体は Face ごとに差し替え、**撮影から保存まで下ろさない** |
 | 3 | Operate — 復元成功／役割の境界 | 0:50 | **WebUI**（store・recover） | recover トークンには Store/Maintenance への導線が無いことを見せる |
 | 4 | **復元 失敗（物体なし）** | 0:50 | **WebUI**（Step 3 と同じタブ） | **★本デモ唯一の証明。画面を切り替えないこと自体が論証。** 間を取り、**必ず物体を戻して成功まで往復させる** |
+| 4b | （任意）**強要下でデータを守る** | 0:40 | **WebUI**（同じタブ） | **不可逆。** 破壊パスワード＋`DESTROY FACE`。枠が押していれば省略 |
 | 5 | `e` → `a` Audit | 0:50 | TUI Expert | **プロジェクタ切替②。** `Free Space Filler` を指す。**判定しないことを誇る** |
 | 6 | `Ctrl+S` Silent Standby | 1:20 | TUI | **山場。** WebUI も同時に落ちる。ゆっくり |
 | 7 | `Esc` で復帰・ラップ | 0:10 | TUI | Prepare→Bind→Operate→Disclose を一言で |
@@ -151,6 +153,7 @@
 - **`Fill Free Space` は壇上で実行しない**（実測約4分）。事前に埋めておき `Inspect` のみ。
 - **囮ファイルは事前に自分で用意しておく。** 壇上でツールに生成させない。保存自体は Step 2 の WebUI で行う（#169 で TUI の `Add File` は非活性化済み）。
 - **成功例だけを見せない。** Step 4 の対比が無ければ cue≠key は何も証明していない。
+- **Step 4b は不可逆。** やるなら Step 5 の Audit の数字が「消した後」になることを承知の上で。省略しても本筋は通る。
 - **7分半で切り上げ、Q&Aに15分以上を残す。** 26:00 を超えたら Step 2〜3 を口頭要約。失敗時は録画へ切替し設計点を口頭補強。
 
 ## [26:20] Slide 25 — Quick start

--- a/src/phasmid/restricted_actions.py
+++ b/src/phasmid/restricted_actions.py
@@ -44,6 +44,9 @@ INITIALIZE_CONTAINER_PHRASE = "INITIALIZE LOCAL CONTAINER"
 EMERGENCY_BRICK_PHRASE = "CLEAR LOCAL ACCESS PATH"
 RESTRICTED_CONFIRMATION_PHRASE = "CONFIRM LOCAL CONTROL"
 OVERWRITE_CONFIRMATION_PHRASE = "REPLACE LOCAL ENTRY"
+# Shared verbatim with `phasmid emergency destroy-face --confirm`, so the two
+# interfaces ask for the same words rather than each inventing their own.
+DESTROY_FACE_PHRASE = "DESTROY FACE"
 
 RESTRICTED_ACTION_POLICIES = {
     "clear_unmatched_entry": RestrictedActionPolicy(
@@ -60,6 +63,20 @@ RESTRICTED_ACTION_POLICIES = {
         action_id="initialize_container",
         capability=Capability.RESTRICTED_ACTION,
         confirmation_phrase=INITIALIZE_CONTAINER_PHRASE,
+    ),
+    "destroy_face": RestrictedActionPolicy(
+        action_id="destroy_face",
+        capability=Capability.RESTRICTED_ACTION,
+        confirmation_phrase=DESTROY_FACE_PHRASE,
+        # The only action here that is gated by a *credential* rather than by a
+        # public phrase alone: the caller must know the Face's destroy password
+        # and hold its bound object. A separate restricted-confirmation session
+        # on top of that would add no authorization, only a step - and this is
+        # the one action reached under duress, where every extra step is a step
+        # taken in front of the person applying it.
+        require_restricted_confirmation=False,
+        require_password_reentry=True,
+        require_object_cue=True,
     ),
     "rapid_local_clear": RestrictedActionPolicy(
         action_id="rapid_local_clear",

--- a/src/phasmid/strings.py
+++ b/src/phasmid/strings.py
@@ -35,6 +35,12 @@ PROTECTED_ENTRY_SAVED = "Protected entry saved."
 AMBIGUOUS_OBJECT_MATCH = "Ambiguous object match."
 NO_VALID_ENTRY_FOUND = "No valid entry found."
 
+DESTROY_FACE_NO_OBJECT = (
+    "Hold the access object of the entry you are clearing in front of the "
+    "camera until it matches, then confirm again."
+)
+DESTROY_FACE_DONE = "Local entry cleared. Its contents cannot be recovered."
+
 UNMATCHED_ENTRY_CLEARED = "Unmatched local entry cleared."
 LOCAL_ACCESS_PATH_CLEARED = "Local access path cleared. Close this session."
 CONTAINER_INITIALIZED = "Local container initialized. Protected entries are empty."

--- a/src/phasmid/templates/retrieve.html
+++ b/src/phasmid/templates/retrieve.html
@@ -60,6 +60,24 @@
                 </section>
 
                 <details style="margin-top:14px;">
+                    <summary>Clear this entry instead of opening it</summary>
+                    <div class="detail-body">
+                        <section class="panel panel--caution" style="margin-top:4px;">
+                            <div class="panel-head"><h2>Clear a protected entry</h2><span class="badge warn">Cannot be undone</span></div>
+                            <p class="copy">Clears the entry belonging to <strong>the object currently in front of the camera</strong>. Its contents cannot be recovered afterwards, and no copy is kept.</p>
+                            <p class="copy">This needs that entry's <strong>clearing password</strong> — the second password set when it was protected. Its access password will not do this, and this password will not open the file.</p>
+                            <form id="destroyForm">
+                                {{ ui.password_field("password", "Clearing password", "Required") }}
+                                <label class="field"><span>Type <code>{{ destroy_face_phrase }}</code> to confirm</span><input type="text" name="confirmation" autocomplete="off" placeholder="{{ destroy_face_phrase }}"></label>
+                                <div class="actions">
+                                    <button type="submit" class="secondary">Clear this entry</button>
+                                </div>
+                            </form>
+                        </section>
+                    </div>
+                </details>
+
+                <details style="margin-top:14px;">
                     <summary>Why might access fail?</summary>
                     <div class="detail-body">
                         <p class="copy">Check that the camera can clearly see the same physical object and that the password is correct. Phasmid intentionally provides limited detail on failed access attempts.</p>
@@ -98,6 +116,24 @@
         const a = document.createElement('a');
         a.href = url; a.download = pendingFilename; document.body.appendChild(a); a.click(); a.remove();
         window.URL.revokeObjectURL(url);
+    });
+
+    document.getElementById('destroyForm').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const res = await apiFetch('/destroy_face', { method: 'POST', body: new FormData(form) });
+        const data = await res.json();
+        if (data.status) {
+            // Clear the pending download too: it may have come from the entry
+            // that no longer exists, and leaving it offerable would hand back
+            // what the operator just chose to destroy.
+            pendingDownload = null;
+            document.getElementById('downloadPanel').classList.remove('is-visible');
+            form.reset();
+            toast(data.status);
+            return;
+        }
+        toast(data.error || 'Operation rejected.', 'error');
     });
 
     document.getElementById('clearSession').addEventListener('click', () => {

--- a/src/phasmid/web_server.py
+++ b/src/phasmid/web_server.py
@@ -51,6 +51,7 @@ from .metadata import metadata_risk_report, scrub_metadata
 from .passphrase_policy import check_store_passphrases
 from .process_hardening import apply_process_hardening
 from .restricted_actions import (
+    DESTROY_FACE_PHRASE,
     DESTRUCTIVE_CLEAR_PHRASE,
     EMERGENCY_BRICK_PHRASE,
     INITIALIZE_CONTAINER_PHRASE,
@@ -520,6 +521,7 @@ def _template_context(request: Request, active="home", **extra):
         "emergency_brick_phrase": EMERGENCY_BRICK_PHRASE,
         "restricted_confirmation_phrase": RESTRICTED_CONFIRMATION_PHRASE,
         "overwrite_confirmation_phrase": OVERWRITE_CONFIRMATION_PHRASE,
+        "destroy_face_phrase": DESTROY_FACE_PHRASE,
         "entries": [
             {"id": entry_id, "label": label} for entry_id, label in ENTRY_LABELS.items()
         ],
@@ -1272,6 +1274,78 @@ async def retrieve(request: Request, password: str = Form(...)):
     audit_event("retrieve_failed", source="web")
     _access_attempts.record_failure(attempt_scope)
     return {"error": text.NO_VALID_ENTRY_FOUND}
+
+
+@app.post(
+    "/destroy_face",
+    dependencies=[Depends(require_web_token), Depends(require_ui_unlock)],
+)
+async def destroy_face(
+    request: Request,
+    password: str = Form(...),
+    confirmation: str = Form(...),
+):
+    """Clear the entry whose object is presented, using its destroy password.
+
+    Deliberately not role-gated to `store`: a recover-scoped session can
+    decrypt and destroy but can never reach Face setup, and destroying under
+    duress is exactly what the narrower session is for.
+
+    Which entry is cleared is decided by the object in front of the camera, not
+    by a selector - naming the entry in a form field would put "there are two of
+    them" on screen at the moment someone is watching. The caller must hold the
+    object of the entry they are clearing and know that entry's destroy
+    password, which is a different credential from its access password.
+    """
+    enforce_rate_limit(request)
+    attempt_scope = f"web:{_client_id(request)}"
+    if not _access_attempts.check(attempt_scope).allowed:
+        return {"error": text.ACCESS_TEMPORARILY_UNAVAILABLE}
+
+    auth_sequence = access_cue_service.auth_sequence(length=1)
+    matched_mode = _raw_gate_status().get("matched_mode")
+    if (
+        auth_sequence[0] == access_cue_service.match_none()
+        or matched_mode not in access_cue_service.auth_tokens()
+    ):
+        # Actionable and safe to say: it describes the frame the operator is
+        # holding up right now, not anything about what is stored.
+        _access_attempts.record_failure(attempt_scope)
+        return {"error": text.DESTROY_FACE_NO_OBJECT}
+
+    require_restricted_action("destroy_face", request, confirmation)
+
+    vessel_path = resolve_web_vessel()
+    if vessel_path is None:
+        return {"error": text.OPERATION_REJECTED}
+
+    try:
+        VesselWorkflowService().destroy_face(
+            vessel_path,
+            password,
+            selector=face_for_mode(str(matched_mode)),
+            camera_object=True,
+            confirmation=DESTROY_FACE_PHRASE,
+        )
+    except (ValueError, FileNotFoundError, PermissionError, RuntimeError):
+        # A wrong destroy password, an entry that was never set up, and an
+        # object that stopped matching between the two checks all land here and
+        # all read the same. Telling them apart would say which of the two
+        # entries the caller just proved they can reach.
+        _access_attempts.record_failure(attempt_scope)
+        return {"error": text.OPERATION_REJECTED}
+    except Exception:
+        LOG.exception("Face destruction failed unexpectedly")
+        return {"error": text.OPERATION_REJECTED}
+
+    _access_attempts.record_success(attempt_scope)
+    audit_event(
+        "restricted_local_update",
+        accessed_entry="local_entry",
+        source="web",
+        reason="explicit_destroy",
+    )
+    return {"status": text.DESTROY_FACE_DONE}
 
 
 @app.post(

--- a/tests/test_web_destroy_face.py
+++ b/tests/test_web_destroy_face.py
@@ -1,0 +1,299 @@
+"""Clearing a protected entry from the WebUI.
+
+The destroy credential existed only in `phasmid emergency destroy-face`, so the
+one scenario the tool exists for - refusing to disclose under duress - was the
+one that dropped out of the browser and onto a terminal. `/destroy_face` closes
+that, reusing the service call the CLI already uses.
+
+Three things have to hold, and each is a way this could be got wrong:
+
+- the entry cleared is chosen by the *object in front of the camera*, never by a
+  form field, because naming an entry on screen says there is more than one;
+- the destroy password is a distinct credential from the access password, so a
+  coerced operator handing over the access password has not handed over this;
+- every refusal reads the same, so which of the two entries the caller can reach
+  is not disclosed by the difference between "wrong password" and "no entry".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from fastapi import HTTPException
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from phasmid import strings as text
+from phasmid import web_server
+from phasmid.restricted_actions import DESTROY_FACE_PHRASE
+from phasmid.services.vessel_workflow_service import VesselWorkflowService
+
+
+def _request():
+    """A caller with no restricted-confirmation session.
+
+    Deliberately cookie-less: the `destroy_face` policy does not require one,
+    because unlike the other restricted actions this is gated by a credential.
+    A test that handed it a valid session would stop noticing if that changed.
+    """
+    return SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        url=SimpleNamespace(path="/destroy_face"),
+        cookies={},
+    )
+
+
+class DestroyFaceTests(unittest.TestCase):
+    def setUp(self):
+        self._dirs = tempfile.TemporaryDirectory()
+        self._env = mock.patch.dict(
+            os.environ,
+            {
+                "PHASMID_CONFIG_DIR": os.path.join(self._dirs.name, "config"),
+                "PHASMID_STATE_DIR": os.path.join(self._dirs.name, "state"),
+            },
+        )
+        self._env.start()
+        self.addCleanup(self._dirs.cleanup)
+        self.addCleanup(self._env.stop)
+        self.matched_mode = web_server.access_cue_service.modes()[1]
+
+    def tearDown(self):
+        web_server._rate_limit.clear()
+        web_server._access_attempts._state.clear()
+
+    def _with_object_present(self):
+        """The camera sees the object bound to the second entry."""
+        return (
+            mock.patch.object(
+                web_server.access_cue_service,
+                "auth_sequence",
+                return_value=[self.matched_mode],
+            ),
+            mock.patch.object(
+                web_server,
+                "_raw_gate_status",
+                return_value={"matched_mode": self.matched_mode},
+            ),
+        )
+
+    def _with_no_object(self):
+        return (
+            mock.patch.object(
+                web_server.access_cue_service,
+                "auth_sequence",
+                return_value=[web_server.access_cue_service.match_none()],
+            ),
+            mock.patch.object(web_server, "_raw_gate_status", return_value={}),
+        )
+
+    def test_it_clears_the_entry_whose_object_is_presented(self):
+        async def run():
+            present_a, present_b = self._with_object_present()
+            with (
+                present_a,
+                present_b,
+                mock.patch.object(
+                    web_server, "resolve_web_vessel", return_value="/tmp/demo.vessel"
+                ),
+                mock.patch.object(
+                    web_server, "VesselWorkflowService"
+                ) as service_factory,
+            ):
+                response = await web_server.destroy_face(
+                    _request(),
+                    password="destroy-me",
+                    confirmation=DESTROY_FACE_PHRASE,
+                )
+            call = service_factory.return_value.destroy_face.call_args
+            # Asserted through the workflow service's own resolution rather
+            # than on the raw selector string: what matters is *which Face*
+            # this clears, not which of the two equivalent vocabularies the
+            # handler happens to speak.
+            self.assertEqual(
+                VesselWorkflowService().resolve_face_id(call.kwargs["selector"]),
+                "face_b",
+            )
+            self.assertEqual(call.args[1], "destroy-me")
+            self.assertTrue(call.kwargs["camera_object"])
+            self.assertEqual(response["status"], text.DESTROY_FACE_DONE)
+
+        asyncio.run(run())
+
+    def test_without_the_object_it_refuses_and_says_so(self):
+        """Actionable: it describes the frame, not anything stored."""
+
+        async def run():
+            absent_a, absent_b = self._with_no_object()
+            with (
+                absent_a,
+                absent_b,
+                mock.patch.object(
+                    web_server, "VesselWorkflowService"
+                ) as service_factory,
+            ):
+                response = await web_server.destroy_face(
+                    _request(),
+                    password="destroy-me",
+                    confirmation=DESTROY_FACE_PHRASE,
+                )
+            service_factory.return_value.destroy_face.assert_not_called()
+            self.assertEqual(response["error"], text.DESTROY_FACE_NO_OBJECT)
+
+        asyncio.run(run())
+
+    def test_the_object_is_checked_before_the_confirmation_phrase(self):
+        """Otherwise a mistyped phrase would be reported to someone holding nothing.
+
+        Order matters for what leaks: the phrase check raises a 403 naming a
+        rejected confirmation, which tells a caller the request got past the
+        camera. It must not.
+        """
+
+        async def run():
+            absent_a, absent_b = self._with_no_object()
+            with absent_a, absent_b:
+                response = await web_server.destroy_face(
+                    _request(), password="x", confirmation="nope"
+                )
+            self.assertEqual(response["error"], text.DESTROY_FACE_NO_OBJECT)
+
+        asyncio.run(run())
+
+    def test_a_wrong_confirmation_phrase_stops_it(self):
+        async def run():
+            present_a, present_b = self._with_object_present()
+            with (
+                present_a,
+                present_b,
+                mock.patch.object(
+                    web_server, "VesselWorkflowService"
+                ) as service_factory,
+            ):
+                with self.assertRaises(HTTPException) as ctx:
+                    await web_server.destroy_face(
+                        _request(),
+                        password="destroy-me",
+                        confirmation="DESTROY",
+                    )
+            service_factory.return_value.destroy_face.assert_not_called()
+            self.assertEqual(ctx.exception.detail, text.CONFIRMATION_REJECTED)
+
+        asyncio.run(run())
+
+    def test_a_wrong_destroy_password_reads_like_every_other_refusal(self):
+        async def run():
+            present_a, present_b = self._with_object_present()
+            service = mock.Mock()
+            service.destroy_face.side_effect = ValueError("emergency password mismatch")
+            with (
+                present_a,
+                present_b,
+                mock.patch.object(
+                    web_server, "resolve_web_vessel", return_value="/tmp/demo.vessel"
+                ),
+                mock.patch.object(
+                    web_server, "VesselWorkflowService", return_value=service
+                ),
+            ):
+                response = await web_server.destroy_face(
+                    _request(),
+                    password="wrong",
+                    confirmation=DESTROY_FACE_PHRASE,
+                )
+            self.assertEqual(response["error"], text.OPERATION_REJECTED)
+            self.assertNotIn("password", response["error"].lower())
+
+        asyncio.run(run())
+
+    def test_repeated_wrong_passwords_hit_the_lockout(self):
+        """A destroy password must not be more brute-forceable than an access one."""
+
+        async def run():
+            present_a, present_b = self._with_object_present()
+            service = mock.Mock()
+            service.destroy_face.side_effect = ValueError("emergency password mismatch")
+            with (
+                present_a,
+                present_b,
+                mock.patch.object(
+                    web_server, "resolve_web_vessel", return_value="/tmp/demo.vessel"
+                ),
+                mock.patch.object(
+                    web_server, "VesselWorkflowService", return_value=service
+                ),
+            ):
+                for _ in range(6):
+                    response = await web_server.destroy_face(
+                        _request(),
+                        password="wrong",
+                        confirmation=DESTROY_FACE_PHRASE,
+                    )
+            self.assertEqual(response["error"], text.ACCESS_TEMPORARILY_UNAVAILABLE)
+
+        asyncio.run(run())
+
+    def test_it_passes_the_phrase_the_cli_uses(self):
+        """The two interfaces ask for the same words, not two dialects."""
+        self.assertEqual(DESTROY_FACE_PHRASE, "DESTROY FACE")
+
+        async def run():
+            present_a, present_b = self._with_object_present()
+            with (
+                present_a,
+                present_b,
+                mock.patch.object(
+                    web_server, "resolve_web_vessel", return_value="/tmp/demo.vessel"
+                ),
+                mock.patch.object(
+                    web_server, "VesselWorkflowService"
+                ) as service_factory,
+            ):
+                await web_server.destroy_face(
+                    _request(),
+                    password="destroy-me",
+                    confirmation=DESTROY_FACE_PHRASE,
+                )
+            call = service_factory.return_value.destroy_face.call_args
+            self.assertEqual(call.kwargs["confirmation"], DESTROY_FACE_PHRASE)
+
+        asyncio.run(run())
+
+
+class DestroyFaceSurfaceTests(unittest.TestCase):
+    """The page has to offer it, and has to say which password it wants."""
+
+    def _retrieve_template(self) -> str:
+        path = os.path.join(ROOT, "src", "phasmid", "templates", "retrieve.html")
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_retrieve_page_offers_the_destroy_path(self):
+        page = self._retrieve_template()
+        self.assertIn("/destroy_face", page)
+        self.assertIn("destroy_face_phrase", page)
+
+    def test_the_page_distinguishes_the_two_passwords(self):
+        """Handing over the access password must not read as handing over this."""
+        page = self._retrieve_template()
+        self.assertIn("Clearing password", page)
+        self.assertIn("Its access password will not do this", page)
+
+    def test_the_page_does_not_let_the_caller_name_the_entry(self):
+        """A selector here would put "there are two of them" on screen."""
+        page = self._retrieve_template()
+        destroy_form = page.split('id="destroyForm"')[1].split("</form>")[0]
+        self.assertNotIn("<select", destroy_form)
+        self.assertNotIn("entry_1", destroy_form)
+        self.assertNotIn("entry_2", destroy_form)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The destroy credential existed only in `phasmid emergency destroy-face`. Binding, retrieval, and the object-absent refusal all run in the browser now — so **the one scenario the tool exists for, refusing to disclose under duress, was the one that dropped out of the browser and onto a terminal.**

## What

`POST /destroy_face`, reachable from the Retrieve page under *"Clear this entry instead of opening it"*. It reuses the `VesselWorkflowService.destroy_face` call the CLI already uses and asks for the same `DESTROY FACE` phrase, so the two interfaces agree rather than each inventing a dialect.

Three properties, each of which is a way this could have been got wrong:

- **The entry cleared is decided by the object in front of the camera, never by a request parameter.** A selector would put "there are two of them" on screen at the moment someone is watching. The form has no entry field and a test asserts it stays that way.
- **The destroy password stays a distinct credential from the access password.** Neither can do the other's job (`_read_face_namespace` is open-slot only, pinned by `test_emergency_password_does_not_trigger_normal_list_or_retrieve`). A coerced operator who hands over the access password has not handed over this.
- **Every refusal reads the same.** A wrong destroy password, an uninitialized entry, and an object that stopped matching between the two checks all return `Operation rejected.` — telling them apart would say which of the two entries the caller just proved they can reach. Failures count against the same attempt limiter as `/retrieve`, so a destroy password is not more brute-forceable than an access one.

The object is checked **before** the confirmation phrase. The phrase check raises a 403 naming a rejected confirmation, which would otherwise tell a caller holding nothing that their request got past the camera.

## One deliberate departure from the other restricted actions

The `destroy_face` policy sets `require_restricted_confirmation=False`.

Every other entry in `RESTRICTED_ACTION_POLICIES` is gated by a public phrase plus a restricted-confirmation session, because a public phrase carries no entropy — the module docstring is explicit that these are typo guards, not credentials. This action is different: it requires a **credential** (the entry's destroy password) and a **live object match**. A second confirmation session on top would add a step without adding authorization, and this is the one action reached in front of the person applying the pressure, where each extra step is a step taken in front of them. `docs/SPECIFICATION.md` states the reasoning rather than leaving it as an inconsistency to be discovered.

`RestrictedActionPolicy` already had `require_password_reentry` and `require_object_cue` defined and unused — this is their first caller.

## Documentation

- **Runbook Step 4b** (optional, 0:40), placed **immediately after Step 4** so it needs no extra projector switch. States up front that it is irreversible and that Step 5's Audit numbers will then reflect the cleared entry — framed as material worth showing ("what I just cleared now reads as empty") rather than as a problem, with the option to skip.
- The design point that **clearing the true entry requires presenting the true object** is stated, not hidden: under duress, presenting it is itself informative. If asked, answer plainly.
- Pre-flight now says the destroy password must be set in Store → Advanced security options, and that Step 4b must be rehearsed **on a disposable Vessel**.
- CLI fallback documented with the identical confirmation phrase.
- Talk Script revised to v6 with the 4b row and the irreversibility note.

## Test plan

- [x] `python -m unittest discover -s tests` — 659 OK (what CI runs)
- [x] `python -m unittest discover -s tests_optional` — 124 OK
- [x] `black --check` / `ruff check` / `mypy src` — clean
- [x] New `tests/test_web_destroy_face.py` — 10 tests covering the entry chosen by the camera, refusal without an object, ordering of the object check before the phrase check, a wrong phrase, a wrong password reading like every other refusal, the lockout after repeated wrong passwords, the shared CLI phrase, and three surface assertions on the Retrieve page

## Not covered here

**This path has not been run on hardware.** The service layer is the same call the CLI exercises, but the camera + destroy password + phrase combination has not been confirmed end to end on the device. `§9` of the Runbook says so, and Step 4b is marked as needing a disposable-Vessel rehearsal before it is used on stage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_