### PR TITLE
fix: unpack the camera's (success, frame) pair before scoring it

### DIFF
--- a/scripts/pi_zero2w/measure_cue_margin.py
+++ b/scripts/pi_zero2w/measure_cue_margin.py
@@ -35,9 +35,16 @@ Reading the result:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 from pathlib import Path
+
+# libcamera logs to stderr at INFO, which buries the table this script exists
+# to print under a dozen lines about tuning files. `run_demo_console.sh`
+# silences it for the same reason; this is run outside that script, so it has
+# to do it itself. Set rather than forced, so a deliberate override survives.
+os.environ.setdefault("LIBCAMERA_LOG_LEVELS", "*:ERROR")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
@@ -136,9 +143,15 @@ def sample(gate, bound, frames: int, settle: float) -> dict:
     time.sleep(settle)
     try:
         for index in range(frames):
-            frame = gate.camera.read()
-            if frame is None:
-                print(f"  {index:>3}  no frame from the camera")
+            # `CameraFrameSource.read()` answers (success, frame), the same
+            # pair the gate's own capture loop unpacks. Taking it as a bare
+            # frame reaches cv2 as a tuple and fails several calls later, in a
+            # message about colour conversion.
+            success, frame = gate.camera.read()
+            if not success or frame is None:
+                print(
+                    f"  {index:>3}  no frame from the camera: {gate.camera.status()['last_error']}"
+                )
                 time.sleep(0.25)
                 continue
             gray = matcher.to_gray(frame)


### PR DESCRIPTION
`measure_cue_margin.py` (#198) crashed on the first frame on the device.

```
File "scripts/pi_zero2w/measure_cue_margin.py", line 144, in sample
  gray = matcher.to_gray(frame)
cv2.error: OpenCV(4.13.0) (-5:Bad argument) in function 'cvtColor'
> src is not a numerical tuple
```

## Cause

`CameraFrameSource.read()` answers a **`(success, frame)` pair** — the same pair `AIGate`'s own capture loop unpacks at `ai_gate.py:724`. The script took the return value as a bare frame, so the tuple travelled two calls before cv2 rejected it, in a message about colour conversion that points nowhere near the mistake.

My error in #198: I checked `open()` / `close()` / `status()` against the real class and assumed `read()`.

## Fix

Unpack the pair. The failure branch now reports the camera's own `last_error` rather than a bare "no frame", so a camera that is present but not delivering reads differently from one that is not there at all.

Also silences libcamera. It logs to stderr at INFO by default, and a dozen lines about tuning files and sensor properties landed in the middle of the table this script exists to print — visible in the report from the device. `run_demo_console.sh` silences it for the same reason, but this script runs outside it, so it now does it itself via `os.environ.setdefault`, leaving a deliberate override in place.

## Checks

- Exercised against a stub camera returning the real `(success, frame)` shape, with one frame of three failing, so both branches run
- `unittest discover -s tests` — 677 pass, 4 skipped
- `black --check src tests scripts`, `ruff check src tests scripts` — clean

## Note on the measurement that surfaced this

The run got far enough to print the part that matters:

```
entry <bound>  keypoints=213   needs good>50  inliers>30   (good bar is 23% of the template)
```

At 213 keypoints the **absolute caps (50/30) bind, not the ratios** — so that object faces exactly the same bar as before #188, and is nowhere near the floor region where the tuning knobs stop working. The frame scores are what the re-run will show.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_