### PR TITLE
show the cue scores on the preview, where the camera is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ and this project follows SemVer-style release intent for documented interfaces.
   rather than `PHASMID_CUE_GOOD_MATCH_RATIO`, so lowering the ratio moves
   nothing and the object itself has to change. Reads the same reference store
   the console uses and writes nothing.
+- `PHASMID_CUE_DEBUG` draws the live cue scores along the bottom of the camera
+  preview — keypoints, good matches, inliers, and the bar each has to clear.
+  The measuring script above answers the same question but cannot show what the
+  lens is looking at, and aiming a camera is iterative: closer, turned, relit,
+  each step needing to know whether it helped. Reported from the device as the
+  blind version being awkward to work with, which it was. Off by default and
+  deliberately given no UI control: the preview is a capture-visible surface
+  and these numbers describe the mechanism (CLM-05), so this is for rehearsing
+  with nobody watching. Costs one extra feature extraction per frame while
+  enabled, and nothing at all when it is off.
+
+### Changed
+
+- The Lowe ratio and the RANSAC reprojection tolerance are named constants on
+  `ObjectCueMatcher` rather than literals inside the matching path, and the new
+  `score_frame` / `score_descriptors` read the same ones the gate decides on.
+  A diagnostic reporting different numbers from the ones being applied is worse
+  than no diagnostic, because it is believed — someone would tune against it
+  and take the result on stage. `tests/test_cue_scores.py` holds the two paths
+  to the same answer in both directions, matching and refusing.
 
 ## [0.6.0] - 2026-08-01
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,6 +47,7 @@ All `PHASMID_*` reads are centralized in `src/phasmid/config.py`.
 | `PHASMID_DUMMY_FALLBACK_THRESHOLD` | float (`0.0`-`1.0`) | `0.40` | Object cue routing | Confidence floor used by demo fallback routing policy | `config.dummy_fallback_threshold()` |
 | `PHASMID_CUE_GOOD_MATCH_RATIO` | float (`0.0`-`1.0`) | `0.25` | Object cue matching | Share of the reference template that must be re-found for a match. Capped by `MIN_GOOD_MATCHES`, floored at `GOOD_MATCH_FLOOR` | `config.cue_good_match_ratio()` |
 | `PHASMID_CUE_INLIER_RATIO` | float (`0.0`-`1.0`) | `0.15` | Object cue matching | Share of the template whose geometry must agree. Capped by `MIN_INLIERS`, floored at `INLIER_FLOOR` | `config.cue_inlier_ratio()` |
+| `PHASMID_CUE_DEBUG` | bool | `false` | Camera preview | Draws the live cue scores (keypoints, good matches, inliers, and the bar each must clear) along the bottom of the preview, so a camera can be aimed against a number instead of a yes/no badge. **Bench use only** — the preview is capture-visible and the scores describe the mechanism (CLM-05). Costs one extra feature extraction per frame while enabled | `config.cue_debug_overlay_enabled()` |
 | `PHASMID_ENABLE_DISPLAY` | bool | `false` | Bridge UI simulator | Enables OpenCV preview window for display simulator | `config.display_enabled()` |
 | `PHASMID_DARK` | bool | `false` | TUI theming | Optional dark theme selection flag | `config.tui_dark_enabled()` |
 | `PHASMID_LIGHT` | bool | `false` | TUI theming | Optional light theme selection flag | `config.tui_light_enabled()` |

--- a/scripts/pi_zero2w/README.md
+++ b/scripts/pi_zero2w/README.md
@@ -81,7 +81,24 @@ already answers that — but *by how much*. An object clearing its threshold by
 one point and an object clearing it threefold look identical on screen, right
 up until the lighting changes.
 
-With the operator console stopped and the object presented:
+There are two ways to see it. **Start with the overlay** — aiming a camera is
+iterative, and the script cannot show you what the lens is looking at:
+
+```bash
+PHASMID_CUE_DEBUG=1 bash scripts/pi_zero2w/run_demo_console.sh
+```
+
+Then press `w`, open the Store or Retrieve page, and hold the object up. The
+scores are drawn along the bottom of the live preview — keypoints, good
+matches, inliers, and the bar each has to clear — so moving the object and
+watching the numbers respond is one continuous action rather than a guess
+followed by a separate measurement.
+
+**Bench use only.** The preview is a capture-visible surface and these numbers
+describe the mechanism, so the flag is off by default and has no UI control.
+
+For a recorded run with statistics rather than a live readout, stop the console
+and, with the object presented:
 
 ```bash
 .venv/bin/python scripts/pi_zero2w/measure_cue_margin.py --frames 30

--- a/scripts/pi_zero2w/measure_cue_margin.py
+++ b/scripts/pi_zero2w/measure_cue_margin.py
@@ -50,6 +50,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 
+import cv2  # noqa: E402
+
 from phasmid.ai_gate import AIGate  # noqa: E402
 
 #: Below this the reported worst case is close enough to the threshold that a
@@ -82,6 +84,7 @@ def report_thresholds(gate) -> list:
         good_bar, inlier_bar = matcher.effective_thresholds(state)
         print(
             f"  entry {mode:<10} keypoints={len(keypoints):<5} "
+            f"shape={state.get('shape')}  "
             f"needs good>{good_bar}  inliers>{inlier_bar}   "
             f"(good bar is {good_bar / len(keypoints):.0%} of the template)"
         )
@@ -95,10 +98,11 @@ def report_thresholds(gate) -> list:
     return bound
 
 
-def sample(gate, bound, frames: int, settle: float) -> dict:
+def sample(gate, bound, frames: int, settle: float, save_to: Path | None) -> dict:
     """Score `frames` live frames against every bound template."""
     matcher = gate.matcher
     tallies: dict[str, list] = {mode: [] for mode, _, _, _ in bound}
+    saved = False
 
     gate.camera.open()
     time.sleep(settle)
@@ -116,6 +120,15 @@ def sample(gate, bound, frames: int, settle: float) -> dict:
                 time.sleep(0.25)
                 continue
             gray = matcher.to_gray(frame)
+
+            if save_to is not None and not saved:
+                saved = True
+                save_to.mkdir(parents=True, exist_ok=True)
+                cv2.imwrite(str(save_to / "frame.png"), frame)
+                cv2.imwrite(str(save_to / "frame-matched-on.png"), gray)
+                print(f"       saved {save_to}/frame.png and frame-matched-on.png")
+                print(f"       frame shape {frame.shape}")
+
             cells = []
             for mode, state, good_bar, inlier_bar in bound:
                 scored = matcher.score_frame(state, gray)
@@ -127,6 +140,7 @@ def sample(gate, bound, frames: int, settle: float) -> dict:
                 matched = good > good_bar and inliers > inlier_bar
                 cells.append(
                     f"{mode}: {'MATCH' if matched else 'miss '} "
+                    f"frame_kp={scored['frame_keypoints']:>4} "
                     f"good={good:>3}/{good_bar:<3} inliers={inliers:>3}/{inlier_bar:<3}"
                 )
                 tallies[mode].append((good, inliers) if matched else None)
@@ -182,6 +196,17 @@ def main() -> int:
         default=1.0,
         help="seconds to let the camera settle before sampling (default 1.0)",
     )
+    parser.add_argument(
+        "--save",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help=(
+            "write the first frame, and the grayscale actually matched on, as "
+            "PNGs. The one question scores cannot answer is whether the object "
+            "is in the picture at all"
+        ),
+    )
     args = parser.parse_args()
 
     gate = AIGate()
@@ -191,7 +216,7 @@ def main() -> int:
         return 1
 
     print(f"\nPresent the object. Sampling {args.frames} frames...\n")
-    tallies = sample(gate, bound, args.frames, args.settle)
+    tallies = sample(gate, bound, args.frames, args.settle, args.save)
     summarise(bound, tallies)
     return 0
 

--- a/scripts/pi_zero2w/measure_cue_margin.py
+++ b/scripts/pi_zero2w/measure_cue_margin.py
@@ -35,9 +35,16 @@ Reading the result:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 from pathlib import Path
+
+# libcamera logs to stderr at INFO, which buries the table this script exists
+# to print under a dozen lines about tuning files. `run_demo_console.sh`
+# silences it for the same reason; this is run outside that script, so it has
+# to do it itself. Set rather than forced, so a deliberate override survives.
+os.environ.setdefault("LIBCAMERA_LOG_LEVELS", "*:ERROR")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
@@ -136,9 +143,15 @@ def sample(gate, bound, frames: int, settle: float) -> dict:
     time.sleep(settle)
     try:
         for index in range(frames):
-            frame = gate.camera.read()
-            if frame is None:
-                print(f"  {index:>3}  no frame from the camera")
+            # `CameraFrameSource.read()` answers (success, frame), the same
+            # pair the gate's own capture loop unpacks. Taking it as a bare
+            # frame reaches cv2 as a tuple and fails several calls later, in a
+            # message about colour conversion.
+            success, frame = gate.camera.read()
+            if not success or frame is None:
+                print(
+                    f"  {index:>3}  no frame from the camera: {gate.camera.status()['last_error']}"
+                )
                 time.sleep(0.25)
                 continue
             gray = matcher.to_gray(frame)

--- a/scripts/pi_zero2w/measure_cue_margin.py
+++ b/scripts/pi_zero2w/measure_cue_margin.py
@@ -49,8 +49,6 @@ os.environ.setdefault("LIBCAMERA_LOG_LEVELS", "*:ERROR")
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-import cv2  # noqa: E402
-import numpy as np  # noqa: E402
 
 from phasmid.ai_gate import AIGate  # noqa: E402
 
@@ -61,43 +59,6 @@ COMFORTABLE_MARGIN = 1.5
 #: Keypoint count below which `GOOD_MATCH_FLOOR` rather than the ratio decides
 #: the threshold, computed from the shipped defaults (12 / 0.25).
 FLOOR_BINDS_BELOW = 48
-
-
-def raw_scores(matcher, ref_state, frame_gray):
-    """Good matches and RANSAC inliers for one frame, without the cutoffs.
-
-    `match_reference_state` returns `None` for anything below threshold, which
-    collapses "scored 17, needed 19" and "scored nothing at all" into the same
-    answer. Those two ask for opposite fixes — one wants a nudge, the other a
-    different object — so they are scored apart here.
-
-    Returns `(frame descriptors, good matches, inliers)`.
-    """
-    ref_des, ref_kp = ref_state["des"], ref_state["kp"]
-    if ref_des is None or ref_kp is None or frame_gray is None:
-        return None
-
-    kp, des = matcher.orb.detectAndCompute(frame_gray, None)
-    if des is None:
-        return (0, 0, 0)
-
-    good = []
-    for pair in matcher.bf.knnMatch(ref_des, des, k=2):
-        if len(pair) < 2:
-            continue
-        candidate, runner_up = pair
-        if candidate.distance < 0.75 * runner_up.distance:
-            good.append(candidate)
-
-    # findHomography needs four correspondences before it can fit anything.
-    if len(good) < 4:
-        return (len(des), len(good), 0)
-
-    src = np.float32([ref_kp[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
-    dst = np.float32([kp[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
-    _homography, mask = cv2.findHomography(src, dst, cv2.RANSAC, 5.0)
-    inliers = 0 if mask is None else int(mask.ravel().tolist().count(1))
-    return (len(des), len(good), inliers)
 
 
 def report_thresholds(gate) -> list:
@@ -157,12 +118,12 @@ def sample(gate, bound, frames: int, settle: float) -> dict:
             gray = matcher.to_gray(frame)
             cells = []
             for mode, state, good_bar, inlier_bar in bound:
-                scored = raw_scores(matcher, state, gray)
+                scored = matcher.score_frame(state, gray)
                 if scored is None:
                     cells.append(f"{mode}: -")
                     tallies[mode].append(None)
                     continue
-                _descriptors, good, inliers = scored
+                good, inliers = scored["good_matches"], scored["inliers"]
                 matched = good > good_bar and inliers > inlier_bar
                 cells.append(
                     f"{mode}: {'MATCH' if matched else 'miss '} "

--- a/src/phasmid/ai_gate.py
+++ b/src/phasmid/ai_gate.py
@@ -638,7 +638,7 @@ class AIGate:
             )
             cv2.putText(
                 image,
-                f"{label}  kp {score['keypoints']}"
+                f"{label}  tpl {score['keypoints']}  frame {score['frame_keypoints']}"
                 f"  good {score['good_matches']}/{score['required_good_matches']}"
                 f"  inliers {score['inliers']}/{score['required_inliers']}",
                 (8, top + line_height * (index + 1) - 3),

--- a/src/phasmid/ai_gate.py
+++ b/src/phasmid/ai_gate.py
@@ -13,6 +13,7 @@ from .camera_frame_source import CameraFrameSource
 from .config import (
     STATE_BLOB_NAME,
     STATE_KEY_NAME,
+    cue_debug_overlay_enabled,
     cue_good_match_ratio,
     cue_inlier_ratio,
     debug_enabled,
@@ -601,6 +602,52 @@ class AIGate:
 
         return True, text.AI_GATE_CUES_CLEARED
 
+    def _cue_scores(self, reference_data: dict, frame_gray: Any) -> list:
+        """Live scores for the preview, when the bench flag asks for them.
+
+        Costs a second feature extraction per frame, so it is not computed
+        unless something is going to display it.
+        """
+        if not cue_debug_overlay_enabled():
+            return []
+        kp, des = self.matcher.orb.detectAndCompute(frame_gray, None)
+        scored = []
+        for index, state in enumerate(reference_data.values()):
+            score = self.matcher.score_descriptors(state, kp, des)
+            if score is not None:
+                scored.append((f"entry {index + 1}", score))
+        return scored
+
+    def _draw_cue_scores(self, image: Any, scores: list) -> None:
+        """Write the scores under the preview, against the bar each has to clear.
+
+        Numbered by position rather than named, matching how the Store page
+        already refers to entries, and so the overlay says nothing the page
+        does not already say about how many there are.
+        """
+        if not scores:
+            return
+        h, w, _ = image.shape
+        line_height = 14
+        top = h - 4 - line_height * len(scores)
+        cv2.rectangle(image, (0, top - 4), (w, h), (0, 0, 0), -1)
+        for index, (label, score) in enumerate(scores):
+            clears = (
+                score["good_matches"] > score["required_good_matches"]
+                and score["inliers"] > score["required_inliers"]
+            )
+            cv2.putText(
+                image,
+                f"{label}  kp {score['keypoints']}"
+                f"  good {score['good_matches']}/{score['required_good_matches']}"
+                f"  inliers {score['inliers']}/{score['required_inliers']}",
+                (8, top + line_height * (index + 1) - 3),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.38,
+                (0, 255, 0) if clears else (0, 165, 255),
+                1,
+            )
+
     def _draw_match_status(self, image: Any) -> None:
         h, w, _ = image.shape
         cv2.rectangle(image, (0, 0), (w, 50), (0, 0, 0), -1)
@@ -761,6 +808,7 @@ class AIGate:
                     mode: self._match_reference_state(state, processed_gray)
                     for mode, state in reference_data.items()
                 }
+                cue_scores = self._cue_scores(reference_data, processed_gray)
                 if self.experimental_object_model_enabled:
                     gate_results = {
                         mode: self.object_gate.evaluate_frame(
@@ -772,6 +820,7 @@ class AIGate:
                 else:
                     self._update_match_result(matches)
                 self._draw_match_status(image)
+                self._draw_cue_scores(image, cue_scores)
 
                 ok, buffer = cv2.imencode(".jpg", image, [cv2.IMWRITE_JPEG_QUALITY, 55])
                 if not ok:

--- a/src/phasmid/config.py
+++ b/src/phasmid/config.py
@@ -299,6 +299,23 @@ def cue_inlier_ratio() -> float:
     return _cue_ratio("PHASMID_CUE_INLIER_RATIO", 0.15)
 
 
+def cue_debug_overlay_enabled() -> bool:
+    """Draw the live cue scores on the camera preview.
+
+    A bench setting, for the one question the badge cannot answer: not whether
+    the object matches, but by how much. Aiming a camera is an iterative act -
+    move it closer, turn the object, change the light - and doing that against
+    a badge that only says yes or no means guessing which way to move.
+
+    Off by default and deliberately not exposed in any UI. The preview is a
+    capture-visible surface, and the scores say more about the mechanism than
+    an operator under observation should be showing (CLM-05). This is for
+    rehearsal with nobody watching, and it is the reason it is an environment
+    variable rather than a button.
+    """
+    return env_flag("PHASMID_CUE_DEBUG", default=False)
+
+
 def display_enabled() -> bool:
     return env_flag("PHASMID_ENABLE_DISPLAY", default=False)
 

--- a/src/phasmid/object_cue_matcher.py
+++ b/src/phasmid/object_cue_matcher.py
@@ -52,6 +52,13 @@ class ObjectCueMatcher:
     # when it is too strict the outcome is a visible refusal, not a bad binding.
     MIN_OBJECT_DOMINANCE = 0.60
 
+    # Lowe's ratio test, and the RANSAC reprojection tolerance in pixels. Named
+    # so the scoring path and the matching path cannot drift apart: a diagnostic
+    # that reports different numbers from the ones the gate acts on is worse
+    # than no diagnostic, because it is believed.
+    LOWE_RATIO = 0.75
+    RANSAC_REPROJECTION = 5.0
+
     def __init__(
         self,
         *,
@@ -363,7 +370,7 @@ class ObjectCueMatcher:
             if len(pair) < 2:
                 continue
             m, n = pair
-            if m.distance < 0.75 * n.distance:
+            if m.distance < self.LOWE_RATIO * n.distance:
                 good_matches.append(m)
 
         if len(good_matches) <= required_good:
@@ -373,7 +380,9 @@ class ObjectCueMatcher:
         src_pts = cast(Any, np.float32(src_points)).reshape(-1, 1, 2)
         dst_points: Any = [kp[m.trainIdx].pt for m in good_matches]
         dst_pts = cast(Any, np.float32(dst_points)).reshape(-1, 1, 2)
-        homography, mask = cv2.findHomography(src_pts, dst_pts, cv2.RANSAC, 5.0)
+        homography, mask = cv2.findHomography(
+            src_pts, dst_pts, cv2.RANSAC, self.RANSAC_REPROJECTION
+        )
         if homography is None or mask is None:
             return None
 
@@ -388,3 +397,68 @@ class ObjectCueMatcher:
             "required_inliers": required_inliers,
             "required_good_matches": required_good,
         }
+
+    def score_frame(self, ref_state, frame_gray):
+        """What *frame_gray* scores against *ref_state*, cutoffs not applied.
+
+        `match_reference_state` answers None for everything below threshold,
+        which collapses "scored 17, needed 19" and "scored nothing at all" into
+        one answer. Those ask for opposite things - the first wants the object
+        moved a little, the second wants a different object - and a person
+        holding the object up cannot tell them apart from a badge that only
+        says no.
+
+        Returns keypoint count, good matches, inliers and the two bars, or None
+        when there is nothing to score against.
+        """
+        if frame_gray is None:
+            return None
+        kp, des = self.orb.detectAndCompute(frame_gray, None)
+        return self.score_descriptors(ref_state, kp, des)
+
+    def score_descriptors(self, ref_state, kp, des):
+        """`score_frame` against descriptors already extracted from the frame.
+
+        Separate so a caller scoring several templates against one frame pays
+        for feature extraction once, which is most of the cost on this
+        hardware.
+        """
+        ref_des = ref_state.get("des")
+        ref_kp = ref_state.get("kp")
+        if ref_des is None or ref_kp is None:
+            return None
+
+        required_good, required_inliers = self.effective_thresholds(ref_state)
+        base = {
+            "keypoints": len(ref_kp),
+            "good_matches": 0,
+            "inliers": 0,
+            "required_good_matches": required_good,
+            "required_inliers": required_inliers,
+        }
+        if des is None or kp is None:
+            return base
+
+        good_matches = []
+        for pair in self.bf.knnMatch(ref_des, des, k=2):
+            if len(pair) < 2:
+                continue
+            m, n = pair
+            if m.distance < self.LOWE_RATIO * n.distance:
+                good_matches.append(m)
+        base["good_matches"] = len(good_matches)
+
+        # findHomography needs four correspondences before it can fit anything.
+        if len(good_matches) < 4:
+            return base
+
+        src_points: Any = [ref_kp[m.queryIdx].pt for m in good_matches]
+        src_pts = cast(Any, np.float32(src_points)).reshape(-1, 1, 2)
+        dst_points: Any = [kp[m.trainIdx].pt for m in good_matches]
+        dst_pts = cast(Any, np.float32(dst_points)).reshape(-1, 1, 2)
+        _homography, mask = cv2.findHomography(
+            src_pts, dst_pts, cv2.RANSAC, self.RANSAC_REPROJECTION
+        )
+        if mask is not None:
+            base["inliers"] = int(mask.ravel().tolist().count(1))
+        return base

--- a/src/phasmid/object_cue_matcher.py
+++ b/src/phasmid/object_cue_matcher.py
@@ -431,6 +431,12 @@ class ObjectCueMatcher:
         required_good, required_inliers = self.effective_thresholds(ref_state)
         base = {
             "keypoints": len(ref_kp),
+            # How much texture the camera is finding *right now*, which decides
+            # whether a low score means "wrong object" or "the camera is seeing
+            # a blur". Without it the two are indistinguishable: a template of
+            # 213 keypoints scoring 5 reads the same whether the frame offered
+            # 900 candidates or 6.
+            "frame_keypoints": 0,
             "good_matches": 0,
             "inliers": 0,
             "required_good_matches": required_good,
@@ -438,6 +444,7 @@ class ObjectCueMatcher:
         }
         if des is None or kp is None:
             return base
+        base["frame_keypoints"] = len(kp)
 
         good_matches = []
         for pair in self.bf.knnMatch(ref_des, des, k=2):

--- a/tests/test_cue_scores.py
+++ b/tests/test_cue_scores.py
@@ -1,0 +1,132 @@
+"""The scores shown on the preview are the scores the gate acts on.
+
+The overlay exists because a badge that says only yes or no cannot be aimed
+against. Aiming a camera is iterative — closer, turned, relit — and each step
+needs to know whether it helped. But a diagnostic that reports numbers other
+than the ones the gate decides on is worse than no diagnostic, because it is
+believed: it would send an operator on stage having tuned against a
+measurement that was never the one being applied.
+
+So `score_frame` has to agree with `match_reference_state` about the same
+frame, in both directions — where it matches and where it does not — and both
+have to be reading the same Lowe ratio and RANSAC tolerance rather than each
+carrying its own copy of 0.75 and 5.0.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+import numpy as np
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from phasmid.object_cue_matcher import ObjectCueMatcher
+
+
+def build_matcher() -> ObjectCueMatcher:
+    return ObjectCueMatcher(
+        min_reference_keypoints=10,
+        min_frame_descriptors=10,
+        min_good_matches=50,
+        min_inliers=30,
+    )
+
+
+def textured(seed: int, shape=(240, 320, 3)) -> np.ndarray:
+    """An image ORB can find plenty of keypoints in."""
+    return np.random.default_rng(seed).integers(0, 255, shape).astype(np.uint8)
+
+
+class ScoreAgreesWithMatchTests(unittest.TestCase):
+    def setUp(self):
+        self.matcher = build_matcher()
+        self.image = textured(11)
+        self.state = self.matcher.reference_state_from_image(self.image)
+        self.assertIsNotNone(self.state["des"])
+
+    def test_the_scores_are_the_ones_the_gate_matched_on(self):
+        gray = self.matcher.to_gray(self.image)
+        matched = self.matcher.match_reference_state(self.state, gray)
+        scored = self.matcher.score_frame(self.state, gray)
+        self.assertIsNotNone(matched, "the identical frame should match")
+        self.assertEqual(scored["good_matches"], matched["good_matches"])
+        self.assertEqual(scored["inliers"], matched["inliers"])
+        self.assertEqual(
+            scored["required_good_matches"], matched["required_good_matches"]
+        )
+        self.assertEqual(scored["required_inliers"], matched["required_inliers"])
+
+    def test_a_frame_the_gate_refuses_scores_below_the_bar(self):
+        """The direction that matters: a refusal has to read as a refusal."""
+        gray = self.matcher.to_gray(textured(999))
+        self.assertIsNone(self.matcher.match_reference_state(self.state, gray))
+        scored = self.matcher.score_frame(self.state, gray)
+        self.assertIsNotNone(scored, "an unrelated frame still deserves a number")
+        clears = (
+            scored["good_matches"] > scored["required_good_matches"]
+            and scored["inliers"] > scored["required_inliers"]
+        )
+        self.assertFalse(clears)
+
+    def test_it_reports_the_bar_the_thresholds_produce(self):
+        good, inliers = self.matcher.effective_thresholds(self.state)
+        scored = self.matcher.score_frame(self.state, self.matcher.to_gray(self.image))
+        self.assertEqual(scored["required_good_matches"], good)
+        self.assertEqual(scored["required_inliers"], inliers)
+        self.assertEqual(scored["keypoints"], len(self.state["kp"]))
+
+    def test_nothing_bound_scores_nothing(self):
+        empty = self.matcher.empty_reference()
+        gray = self.matcher.to_gray(self.image)
+        self.assertIsNone(self.matcher.score_frame(empty, gray))
+
+    def test_a_blank_frame_scores_zero_rather_than_failing(self):
+        blank = np.full((240, 320, 3), 128, np.uint8)
+        scored = self.matcher.score_frame(self.state, self.matcher.to_gray(blank))
+        self.assertEqual(scored["good_matches"], 0)
+        self.assertEqual(scored["inliers"], 0)
+
+    def test_scoring_by_descriptors_matches_scoring_by_frame(self):
+        """The overlay path extracts features once for every entry."""
+        gray = self.matcher.to_gray(self.image)
+        kp, des = self.matcher.orb.detectAndCompute(gray, None)
+        self.assertEqual(
+            self.matcher.score_descriptors(self.state, kp, des),
+            self.matcher.score_frame(self.state, gray),
+        )
+
+
+class SharedConstantsTests(unittest.TestCase):
+    """Both paths read one Lowe ratio and one RANSAC tolerance."""
+
+    def test_changing_the_lowe_ratio_moves_both_paths(self):
+        matcher = build_matcher()
+        image = textured(5)
+        state = matcher.reference_state_from_image(image)
+
+        # A slightly noisy frame rather than the identical one: an exact match
+        # scores distance 0, which passes any ratio at all and would make this
+        # look constant no matter what the constant said.
+        rng = np.random.default_rng(5)
+        noisy = np.clip(image.astype(int) + rng.integers(-8, 9, image.shape), 0, 255)
+        gray = matcher.to_gray(noisy.astype(np.uint8))
+
+        before = matcher.score_frame(state, gray)["good_matches"]
+        matcher.LOWE_RATIO = 0.05
+        after = matcher.score_frame(state, gray)
+        self.assertLess(after["good_matches"], before, "the constant is not being read")
+
+        # The point of the test: the gate moved by exactly the same amount,
+        # because there is one constant and not two copies of 0.75.
+        self.assertEqual(
+            matcher.match_reference_state(state, gray)["good_matches"],
+            after["good_matches"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reported from the device: the measuring script added in #198 is awkward to work with. It is, and the reason is structural rather than a defect I can patch.

## The problem

Aiming a camera is iterative — move it closer, turn the object, change the light — and every step needs to know whether it helped. The script answers in a batch, minutes later, with **no picture of what the lens was looking at**.

The first real run made that concrete:

```
entry <bound>  keypoints=213  needs good>50  inliers>30
   0  miss  good=5/50  inliers=5/30
   ...
   29 miss  good=5/50  inliers=5/30
```

5 good matches out of a 213-keypoint template is the signature of an object that was **not in frame**. From the numbers alone there is no way to tell that from an object that was in frame and failing — and those ask for completely different responses.

I checked before concluding: `AIGate._to_gray` delegates to `matcher.to_gray`, and the gate matches on `_to_gray(frame)` taken straight from `camera.read()`. The script's pipeline is identical to the running app's. What is missing is not accuracy, it's the picture.

## The change

`PHASMID_CUE_DEBUG=1` draws the same numbers along the bottom of the **live preview** — keypoints, good matches, inliers, and the bar each has to clear, green when it clears and amber when it does not.

```bash
PHASMID_CUE_DEBUG=1 bash scripts/pi_zero2w/run_demo_console.sh
```

Press `w`, open Store or Retrieve, hold the object up. Moving the object and watching the numbers respond becomes one continuous action instead of a guess followed by a separate measurement.

The badge that says only "match" / "no match" is exactly the wrong resolution for aiming — which is the same observation behind #158, from the other side.

## Why an environment variable and not a button

The preview is a **capture-visible surface**, and these numbers describe the mechanism, which CLM-05 says the interface should not reveal. So the flag is off by default, has no UI control, and is documented as a bench setting for rehearsing with nobody watching. No claim changes: with the flag off, every surface behaves exactly as before.

Cost is one extra feature extraction per frame while enabled — `score_descriptors` takes already-extracted descriptors so scoring both entries pays for extraction once — and nothing at all when off.

## Keeping the diagnostic honest

`score_frame` / `score_descriptors` on `ObjectCueMatcher` now back **both** the overlay and the script, and the Lowe ratio and RANSAC tolerance are named constants that the matching path and the scoring path share rather than two copies of `0.75` and `5.0`.

A diagnostic that reports numbers other than the ones the gate acts on is worse than no diagnostic, because it is believed — someone tunes against it and carries the result on stage. `tests/test_cue_scores.py` holds the two paths to the same answer where it matches *and* where it refuses, and fails if either path grows its own copy of the constant.

## Checks

- `unittest discover -s tests` — 684 pass (7 new), 4 skipped
- `unittest discover -s tests_optional` — 124 pass
- `black --check src tests scripts`, `ruff check src tests scripts` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_