### PR TITLE
fix: do not recommend settings the device cannot run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,28 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ### Fixed
 
+- **The tuning sweep recommended a configuration the device cannot run**, and
+  recommended it directly underneath its own printed warning not to. Two
+  defects, both found by the first run on hardware:
+  - **The measurement saturated.** The gate's detector caps at
+    `nfeatures=1000` - the right cap for matching, the wrong one for comparing
+    settings. On the device 640x480 reported 919 keypoints and every
+    resolution above it reported exactly 1000, which reads as "bigger is
+    better" and means "the ruler ended here". Worse, `max` then answered ties
+    with whichever option came first in the list: the sharpness sweep was
+    recommended at 1.0 while the same table showed 2.5 with half again as much
+    detail. The probe now counts with the cap lifted, and ties fall through to
+    detail and then to cost.
+  - **The frame budget was printed and then ignored.** 1024x768 measured 272 ms
+    per frame against a 250 ms interval at four frames a second - and the sweep
+    measures *less* work than the console does, since it never matches, encodes
+    or draws. Anything past the budget is now excluded from the ranking, with
+    what was dropped and why said out loud. More pixels than the device can
+    process is not more cue: the match history needs several consecutive
+    frames, and a frame that arrives late has not arrived.
+
+  Replayed against the device's own numbers, the corrected ranking answers
+  640x480 rather than 1024x768, and sharpness 2.5 rather than 1.0.
 - **The camera was opened, never configured.** For most of this project's life
   exactly one control was set on it — `FrameDurationLimits` — and everything
   else was left at defaults tuned for photographs a person will look at. That

--- a/scripts/pi_zero2w/tune_camera.py
+++ b/scripts/pi_zero2w/tune_camera.py
@@ -17,13 +17,17 @@ and **the object sitting in front of the camera, not moving**:
     .venv/bin/python scripts/pi_zero2w/tune_camera.py
 
 It changes nothing. It prints an export line to put in front of
-`run_demo_console.sh` if the sweep finds something better than the defaults.
+`run_demo_console.sh` if the sweep finds something better than the defaults -
+and it will not recommend a setting the device cannot keep up with, however
+well that setting scores.
 
 Two numbers per configuration:
 
-  keypoints  what ORB finds in the whole frame. More is more to match on, and
-             this is the one that decides whether an object can be bound at
-             all - a template needs 60 of its own.
+  keypoints  what ORB finds in the whole frame, counted with the detector's
+             cap lifted so the number keeps meaning something past the point
+             the gate itself stops at. More is more to match on, and this is
+             what decides whether an object can be bound at all - a template
+             needs 60 of its own.
   sharpness  variance of the Laplacian: how much fine detail survives to be
              found. Falls with blur, whether from a lens in the wrong place or
              a shutter open too long. Useful as the reason a keypoint count
@@ -60,6 +64,21 @@ MATCHER = ObjectCueMatcher(
     min_inliers=30,
 )
 
+#: The gate's detector stops at `nfeatures=1000`, which is the right cap for
+#: matching and the wrong one for comparing settings: past a certain amount of
+#: detail every configuration reports exactly 1000 and the sweep can no longer
+#: tell them apart. Measured on the device, 640x480 gave 919 and everything
+#: above it gave 1000 - which reads as "bigger is better" when it is really
+#: "the ruler ended here". So the probe counts with the cap lifted.
+PROBE = cv2.ORB_create(nfeatures=20000)
+
+#: How much of the frame interval the sweep's own work may take. The console
+#: does more per frame than this does - it matches against every bound entry,
+#: encodes a JPEG and draws the overlay - so a configuration that only just
+#: fits here will not fit there. At the console's four frames a second the
+#: interval is 250 ms; this leaves room for the rest of the pipeline.
+FRAME_BUDGET_MS = 150.0
+
 
 def measure(size: tuple[int, int], env: dict[str, str], settle: float = 1.5) -> dict:
     """Open the camera under `env` and report what it delivers."""
@@ -83,7 +102,7 @@ def measure(size: tuple[int, int], env: dict[str, str], settle: float = 1.5) -> 
             if not success or frame is None:
                 continue
             gray = MATCHER.to_gray(frame)
-            found, _des = MATCHER.orb.detectAndCompute(gray, None)
+            found = PROBE.detect(gray, None)
             keypoints.append(len(found) if found else 0)
             sharpness.append(float(cv2.Laplacian(gray, cv2.CV_64F).var()))
         applied = camera.status()
@@ -117,21 +136,57 @@ def show(label: str, result: dict) -> None:
 
 
 def sweep(title: str, options: list, run) -> tuple:
-    """Try each option, print what it gave, and return the best."""
+    """Try each option and return the best one the device can actually run.
+
+    Two things this must not do, both learned from a run that did them:
+
+    Recommend a configuration the console cannot keep up with. More pixels than
+    the device can process is not more cue - the match history needs several
+    consecutive frames, and frames that arrive late are frames that do not
+    arrive. So anything past the budget is out, however well it scores.
+
+    Pick a winner out of a tie. When several options report the same keypoint
+    count the difference is below what this can measure, and `max` would answer
+    with whichever happened to be first in the list. Ties fall through to
+    sharpness, and if that is level too, to the cheapest.
+    """
     print(f"\n{title}")
     scored = []
     for label, option in options:
         result = run(option)
         show(label, result)
-        scored.append((result["keypoints"], label, option, result))
-    if not any(row[0] for row in scored):
-        # Every configuration scored nothing, which is a camera that is not
-        # delivering rather than a tie. Picking a winner here would hand back a
-        # recommendation derived from zeros.
+        scored.append((label, option, result))
+
+    if not any(row[2]["keypoints"] for row in scored):
+        # Not a tie - a camera that is not delivering. A recommendation
+        # computed from zeros would be worse than none.
         raise CameraDeliveredNothing(title)
-    best = max(scored, key=lambda row: row[0])
-    print(f"  -> best: {best[1]}")
-    return best[2], best[3]
+
+    affordable = [row for row in scored if row[2]["interval_ms"] <= FRAME_BUDGET_MS]
+    if not affordable:
+        cheapest = min(scored, key=lambda row: row[2]["interval_ms"])
+        print(
+            f"  ! every option costs more than {FRAME_BUDGET_MS:.0f} ms/frame; "
+            f"falling back to the cheapest ({cheapest[0]})"
+        )
+        affordable = [cheapest]
+    elif len(affordable) < len(scored):
+        dropped = [row[0] for row in scored if row not in affordable]
+        print(f"  ! too slow for the console, not considered: {', '.join(dropped)}")
+
+    best = max(
+        affordable,
+        key=lambda row: (
+            row[2]["keypoints"],
+            row[2]["sharpness"],
+            -row[2]["interval_ms"],
+        ),
+    )
+    tied = [row[0] for row in affordable if row[2]["keypoints"] == best[2]["keypoints"]]
+    if len(tied) > 1:
+        print(f"  ({len(tied)} tied on keypoints; broken by sharpness)")
+    print(f"  -> best: {best[0]}")
+    return best[1], best[2]
 
 
 def main() -> int:

--- a/tests/test_tune_camera_ranking.py
+++ b/tests/test_tune_camera_ranking.py
@@ -1,0 +1,129 @@
+"""The sweep must not recommend something the device cannot run.
+
+Both rules here come from a run on the device that broke them, and the numbers
+below are that run's.
+
+The keypoint count saturated. The gate's detector caps at `nfeatures=1000`,
+which is the right cap for matching and the wrong one for comparing settings:
+640x480 reported 919 and every resolution above it reported exactly 1000. That
+reads as "bigger is better" when it means "the ruler ended here". The probe now
+counts with the cap lifted, and ties are broken rather than resolved by list
+order.
+
+And the frame budget was ignored. 1024x768 cost 272 ms per frame against a
+250 ms interval at four frames a second - and the sweep measures less work than
+the console does, since it never matches, encodes or draws. The old ranking
+recommended it anyway, immediately above its own printed warning not to. More
+pixels than the device can process is not more cue: the match history needs
+several consecutive frames, and a frame that arrives late has not arrived.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+_spec = importlib.util.spec_from_file_location(
+    "tune_camera", os.path.join(ROOT, "scripts", "pi_zero2w", "tune_camera.py")
+)
+tune_camera = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tune_camera)
+
+
+def reading(keypoints: int, sharpness: float, interval_ms: float) -> dict:
+    return {
+        "keypoints": keypoints,
+        "sharpness": sharpness,
+        "interval_ms": interval_ms,
+        "focus": "continuous",
+        "applied": [],
+    }
+
+
+class FrameBudgetTests(unittest.TestCase):
+    def test_a_configuration_over_the_budget_is_not_recommended(self):
+        """The device's own resolution sweep, replayed."""
+        measured = {
+            "640x480": reading(919, 1109.1, 113.0),
+            "1024x768": reading(1000, 828.8, 272.0),
+            "1280x960": reading(1000, 443.1, 391.0),
+        }
+        chosen, _ = tune_camera.sweep(
+            "resolution",
+            [(label, label) for label in measured],
+            lambda option: measured[option],
+        )
+        self.assertEqual(chosen, "640x480")
+
+    def test_when_nothing_fits_the_cheapest_is_offered_rather_than_nothing(self):
+        measured = {
+            "big": reading(1000, 900.0, 400.0),
+            "bigger": reading(1000, 950.0, 900.0),
+        }
+        chosen, _ = tune_camera.sweep(
+            "resolution",
+            [(label, label) for label in measured],
+            lambda option: measured[option],
+        )
+        self.assertEqual(chosen, "big")
+
+    def test_the_budget_leaves_room_for_the_work_the_sweep_does_not_do(self):
+        """Matching, encoding and drawing all land on top of what is measured."""
+        self.assertLess(tune_camera.FRAME_BUDGET_MS, 250.0)
+
+
+class SaturationTests(unittest.TestCase):
+    def test_a_tie_is_broken_by_detail_not_by_list_order(self):
+        """The device's sharpness sweep: all three saturated at 1000.
+
+        The old ranking answered 1.0 - the first of the three - while its own
+        second column said 2.5 had half again as much detail.
+        """
+        measured = {
+            "1.0": reading(1000, 1245.3, 113.0),
+            "1.5": reading(1000, 1254.9, 113.0),
+            "2.5": reading(1000, 1353.3, 113.0),
+        }
+        chosen, _ = tune_camera.sweep(
+            "sharpness",
+            [(label, label) for label in measured],
+            lambda option: measured[option],
+        )
+        self.assertEqual(chosen, "2.5")
+
+    def test_the_probe_counts_past_the_cap_the_gate_stops_at(self):
+        """Otherwise the measurement ends exactly where the question starts."""
+        self.assertGreater(tune_camera.PROBE.getMaxFeatures(), 1000)
+
+    def test_a_real_difference_still_wins_over_detail(self):
+        """Sharpness is the tie-break, not the criterion."""
+        measured = {
+            "more keypoints": reading(900, 500.0, 100.0),
+            "sharper": reading(400, 2000.0, 100.0),
+        }
+        chosen, _ = tune_camera.sweep(
+            "resolution",
+            [(label, label) for label in measured],
+            lambda option: measured[option],
+        )
+        self.assertEqual(chosen, "more keypoints")
+
+
+class NothingMeasuredTests(unittest.TestCase):
+    def test_zeros_are_refused_rather_than_ranked(self):
+        measured = {"a": reading(0, 0.0, 0.0), "b": reading(0, 0.0, 0.0)}
+        with self.assertRaises(tune_camera.CameraDeliveredNothing):
+            tune_camera.sweep(
+                "resolution",
+                [(label, label) for label in measured],
+                lambda option: measured[option],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The first run of `tune_camera.py` on hardware produced a recommendation that was wrong twice over — and wrong **directly underneath its own printed warning** not to do that.

```
  640x480     keypoints   919   sharpness   1109.1      113 ms/frame
  1024x768    keypoints  1000   sharpness    828.8      272 ms/frame
  1280x960    keypoints  1000   sharpness    443.1      391 ms/frame
  -> best: 1024x768
...
Higher resolution costs frame time. If ms/frame above went past about
250, the console will not hold four frames a second
```

## The measurement saturated

The gate's detector caps at `nfeatures=1000` — the right cap for matching, the wrong one for *comparing settings*. 640×480 reported 919 and everything above it reported exactly 1000. That reads as "bigger is better" and means **"the ruler ended here"**.

Once several options report the same number, `max` answers with whichever came first in the list. That is how the sharpness sweep was recommended at **1.0** while the same table showed **2.5** with half again as much detail.

The probe now counts with the cap lifted, and ties fall through to sharpness, then to cost.

## The frame budget was printed and then ignored

1024×768 measured **272 ms/frame against a 250 ms interval**. And the sweep measures *less* work than the console does — it never matches against a template, encodes a JPEG, or draws the overlay. It was recommended anyway.

Anything past the budget is now out of the ranking, with what was dropped and why said out loud:

```
  ! too slow for the console, not considered: 1024x768, 1280x960
  -> best: 640x480
```

More pixels than the device can process is not more cue: the match history needs several consecutive frames, and a frame that arrives late has not arrived.

## Replayed against the device's own numbers

| Sweep | Was | Now |
|---|---|---|
| Resolution | 1024×768 (272 ms) | **640×480** (113 ms) |
| Shutter | 16 ms | 16 ms — same answer, now for a stated reason |
| Sharpness | 1.0 | **2.5** |

Those numbers are the fixtures in `tests/test_tune_camera_ranking.py`, so both rules are pinned to the run that broke them.

## The part that worked

Worth recording alongside the bugs: every control was accepted by the module —

```
controls the camera accepted: exposure-ceiling, focus-continuous, focus-fast,
denoise-minimal, sharpness-1.5, centre-weighted-metering, awb-locked
```

— and 640×480 delivers **919 keypoints** where the old 320×240 could not give an object the 60 it needs to bind at all.

## Checks

- `unittest discover -s tests` — 724 pass (7 new), 4 skipped
- `black --check src tests scripts`, `ruff check src tests scripts` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_