### PR TITLE
feat(scripts): deploy to the device from the Mac, over USB, offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ phasmid-autotest/
 
 !requirements.txt
 !MIO _Logo.png
+
+# Dependency wheels staged for an offline device deployment.
+.deploy-wheels/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ### Added
 
+- `scripts/pi_zero2w/deploy_to_device.sh` — puts the repository onto the device
+  from the Mac, over the USB link, with no network on the device. `git pull` on
+  the device is the wrong tool for an appliance that is supposed to stay off
+  networks, and on a Pi Zero 2 W a source build of the OpenSSL bindings is not
+  something that finishes; so the wheels are downloaded on the Mac, for the
+  Python the device actually reports rather than one assumed for it, and
+  installed with `--no-index`.
+
+  It also refuses to start when the Mac's default route points at the Pi.
+  Reported from the bench: attaching the device costs the Mac its internet,
+  because the gadget's DHCP lease carries a router option and macOS ranks that
+  service above Wi-Fi. `git pull` then fails in a way that reads as a git
+  problem. The script names the cause and gives both the one-session fix and
+  the permanent one; `scripts/pi_zero2w/README.md` adds the device-side fix,
+  which is the better one because it covers any laptop, including a borrowed
+  one at the venue.
+
+  State is never carried: `.state`, the vault, `*.vessel` and the venv are
+  excluded, so deploying cannot destroy a bound object. Verification runs on
+  the device, not on rsync's exit status.
+
 - `scripts/pi_zero2w/tune_camera.py` — finds the camera settings that give
   *this* object, in *this* room, the most to match on. The defaults above are
   measured, but they are measured against synthetic scenes, and the real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project follows SemVer-style release intent for documented interfaces.
   which is the better one because it covers any laptop, including a borrowed
   one at the venue.
 
+  The ssh destination is `PHASMID_PI_SSH`, passed to `ssh` verbatim so a
+  `~/.ssh/config` block is honoured whole. Nothing is reconstructed from
+  separate user/host/port/key variables: a script that rebuilds half an ssh
+  config gets the other half wrong, and against a real config whose `User` is
+  `phasmid` a default of `pi` connects as the wrong account and deploys into a
+  home directory that does not exist. The remote directory is likewise asked of
+  the device rather than defaulted, and the device's address is read from
+  `SSH_CONNECTION` rather than from a variable — the destination may be an
+  alias or an mDNS name, and the route check needs an address.
+
   State is never carried: `.state`, the vault, `*.vessel` and the venv are
   excluded, so deploying cannot destroy a bound object. Verification runs on
   the device, not on rsync's exit status.

--- a/scripts/pi_zero2w/README.md
+++ b/scripts/pi_zero2w/README.md
@@ -150,6 +150,70 @@ The script reads the same reference store the console uses and registers
 nothing, writes nothing, and changes nothing. The camera is exclusive, so the
 console has to be stopped first.
 
+## Deploying an update to the device
+
+The device is meant to stay off networks, which makes `git pull` on the device
+the wrong tool: it needs the internet to work, and the Pi only has the USB link
+to the laptop. Deployment therefore runs **from the Mac**, and carries the
+dependency wheels across with the source.
+
+With the Pi attached over USB and the operator console stopped:
+
+```bash
+export PHASMID_PI_HOST=10.12.194.1      # the address the browser uses
+export PHASMID_PI_USER=pi
+export PHASMID_PI_REMOTE_DIR=/home/pi/Phasmid
+bash scripts/pi_zero2w/deploy_to_device.sh
+```
+
+It fast-forwards the local checkout to `origin/main`, asks the device which
+Python it runs, downloads the matching aarch64 wheels **on the Mac**, syncs
+both, installs with `--no-index`, and then verifies on the device rather than
+trusting rsync's exit status. It refuses to run against a dirty working tree:
+deploying uncommitted work puts a build on the device that exists nowhere else.
+
+`.state`, the vault, `*.vessel` and the venv are excluded, so a deployment
+cannot destroy a bound object or a stored file.
+
+### When the Pi takes over the Mac's default route
+
+Reported from the bench, and the reason the script checks for it before doing
+anything: with the Pi attached, the Mac loses the internet. The gadget hands
+out a DHCP lease that includes a router option, macOS ranks that service above
+Wi-Fi, and every packet meant for the internet is sent to a device that has no
+upstream. `git pull` then fails — and the failure looks like a git problem, not
+a network one.
+
+**On the Mac, once:** System Settings → Network → **⋯** → *Set Service Order*,
+drag **Wi-Fi above the USB gadget service**, Apply. macOS takes the default
+route from the highest-priority active service, so this survives replugging.
+The Pi stays reachable at its own address; only the default route moves back.
+
+To unblock a single session without changing anything permanent:
+
+```bash
+route -n get default | awk '/interface:/{print $2}'   # confirm which one it is
+sudo route -n delete default -interface en5           # substitute the real one
+```
+
+**On the Pi, better:** stop advertising a router at all, and no laptop has the
+problem — including a borrowed one at the venue. If the gadget address is
+handed out by `dnsmasq`, adding these to its config and restarting it makes the
+lease carry an address and nothing else:
+
+```
+dhcp-option=3       # no router
+dhcp-option=6       # no DNS server
+```
+
+Check what is actually serving the lease first — this is configured on the
+device by hand and is not part of this repository:
+
+```bash
+systemctl status dnsmasq
+ip -4 addr show usb0
+```
+
 ## Results
 
 | File | Contents |

--- a/scripts/pi_zero2w/README.md
+++ b/scripts/pi_zero2w/README.md
@@ -157,14 +157,43 @@ the wrong tool: it needs the internet to work, and the Pi only has the USB link
 to the laptop. Deployment therefore runs **from the Mac**, and carries the
 dependency wheels across with the source.
 
-With the Pi attached over USB and the operator console stopped:
+With the Pi attached over USB and the operator console stopped, given a
+`~/.ssh/config` block like
+
+```
+Host phasmid
+    HostName phasmid-pi.local
+    User phasmid
+    IdentityFile ~/.ssh/id_ed25519
+    AddKeysToAgent yes
+    UseKeychain yes
+```
+
+the whole invocation is:
 
 ```bash
-export PHASMID_PI_HOST=10.12.194.1      # the address the browser uses
-export PHASMID_PI_USER=pi
-export PHASMID_PI_REMOTE_DIR=/home/pi/Phasmid
+export PHASMID_PI_SSH=phasmid
 bash scripts/pi_zero2w/deploy_to_device.sh
 ```
+
+`PHASMID_PI_SSH` is passed to `ssh` verbatim, so the config block is honoured
+whole — user, hostname, port, key, agent behaviour. Nothing is reconstructed
+from separate variables, because a script that rebuilds half an ssh config gets
+the other half wrong: with the block above, a `PHASMID_PI_USER` defaulting to
+`pi` connects as the wrong account and deploys into a home directory that does
+not exist.
+
+Without an alias the older variables still work:
+
+```bash
+export PHASMID_PI_HOST=10.12.194.1
+export PHASMID_PI_USER=phasmid
+bash scripts/pi_zero2w/deploy_to_device.sh
+```
+
+The remote directory is asked of the device (`$HOME/Phasmid`) unless
+`PHASMID_PI_REMOTE_DIR` says otherwise, and it must already be a checkout —
+this updates a device, it does not provision a new one.
 
 It fast-forwards the local checkout to `origin/main`, asks the device which
 Python it runs, downloads the matching aarch64 wheels **on the Mac**, syncs
@@ -195,6 +224,11 @@ To unblock a single session without changing anything permanent:
 route -n get default | awk '/interface:/{print $2}'   # confirm which one it is
 sudo route -n delete default -interface en5           # substitute the real one
 ```
+
+The device stays reachable either way — removing the default route does not
+remove the route to its own directly-connected subnet, and `phasmid-pi.local`
+keeps resolving because mDNS is link-local multicast and does not use the
+default route at all.
 
 **On the Pi, better:** stop advertising a router at all, and no laptop has the
 problem — including a borrowed one at the venue. If the gadget address is

--- a/scripts/pi_zero2w/deploy_to_device.sh
+++ b/scripts/pi_zero2w/deploy_to_device.sh
@@ -7,10 +7,25 @@
 # Run from macOS, from the repository root, with the Pi attached over USB and
 # the operator console stopped.
 #
-#   export PHASMID_PI_HOST=10.12.194.1      # the gadget address, or the name
-#   export PHASMID_PI_USER=pi
-#   export PHASMID_PI_REMOTE_DIR=/home/pi/Phasmid
+#   export PHASMID_PI_SSH=phasmid           # an ssh_config Host alias
 #   bash scripts/pi_zero2w/deploy_to_device.sh
+#
+# `PHASMID_PI_SSH` is used verbatim as the ssh destination, so a ~/.ssh/config
+# block is honoured whole - user, hostname, port, key, agent behaviour. Nothing
+# here reconstructs any of it, because a script that rebuilds half of an ssh
+# config gets the other half wrong: with
+#
+#     Host phasmid
+#         HostName phasmid-pi.local
+#         User phasmid
+#
+# the older `PHASMID_PI_USER`/`PHASMID_PI_HOST` pair would have connected as
+# `pi` to a machine whose account is `phasmid`, and deployed into a home
+# directory that does not exist.
+#
+# Without an alias, the older variables still work:
+#   export PHASMID_PI_HOST=10.12.194.1
+#   export PHASMID_PI_USER=phasmid
 #
 # Three things this does that a bare `git pull` on the device cannot:
 #
@@ -37,10 +52,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT" || exit 1
 
-: "${PHASMID_PI_USER:=pi}"
-: "${PHASMID_PI_REMOTE_DIR:=/home/pi/Phasmid}"
-: "${PHASMID_PI_SSH_PORT:=22}"
 : "${PHASMID_DEPLOY_REF:=origin/main}"
+# Deliberately not defaulted: the remote directory is asked of the device
+# below, because $HOME depends on the account and the account depends on the
+# ssh config. A default of /home/pi/Phasmid is a guess that deploys silently
+# into the wrong place on any device whose user is not `pi`.
+: "${PHASMID_PI_REMOTE_DIR:=}"
 
 WHEEL_DIR="$REPO_ROOT/.deploy-wheels"
 
@@ -48,22 +65,57 @@ say()  { printf '\n\033[1m== %s\033[0m\n' "$*"; }
 info() { printf '   %s\n' "$*"; }
 die()  { printf '\n\033[1;31mSTOP:\033[0m %s\n' "$*" >&2; exit 1; }
 
-[[ -n "${PHASMID_PI_HOST:-}" ]] || die \
-    "PHASMID_PI_HOST is not set. Use the gadget address the browser uses,
-       export PHASMID_PI_HOST=10.12.194.1"
+SSH_OPTS=(-o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new)
 
-SSH_OPTS=(-p "$PHASMID_PI_SSH_PORT" -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new)
-[[ -n "${PHASMID_PI_SSH_KEY:-}" ]] && SSH_OPTS+=(-i "$PHASMID_PI_SSH_KEY")
-pi_ssh() { ssh "${SSH_OPTS[@]}" "$PHASMID_PI_USER@$PHASMID_PI_HOST" "$@"; }
+if [[ -n "${PHASMID_PI_SSH:-}" ]]; then
+    SSH_DEST="$PHASMID_PI_SSH"
+else
+    [[ -n "${PHASMID_PI_HOST:-}" ]] || die \
+        "Neither PHASMID_PI_SSH nor PHASMID_PI_HOST is set. With a ~/.ssh/config
+       Host block, the short form is all you need:
+           export PHASMID_PI_SSH=phasmid"
+    SSH_DEST="${PHASMID_PI_USER:-pi}@$PHASMID_PI_HOST"
+    SSH_OPTS+=(-p "${PHASMID_PI_SSH_PORT:-22}")
+    [[ -n "${PHASMID_PI_SSH_KEY:-}" ]] && SSH_OPTS+=(-i "$PHASMID_PI_SSH_KEY")
+fi
 
-# ── 1. the default route ──────────────────────────────────────────────────────
-# The reported failure. Checked before anything else, because every later step
-# assumes the Mac can still reach the internet.
+pi_ssh() { ssh "${SSH_OPTS[@]}" "$SSH_DEST" "$@"; }
 
-say "Checking that the Pi has not taken the default route"
+# ── 1. reach the device, and ask it where it is ───────────────────────────────
+# The address is taken from the connection rather than from a variable. The
+# destination may be an ssh_config alias or an mDNS name, and `route -n get`
+# needs an address; asking the far end removes the guess. mDNS keeps working
+# even when the default route is wrong, because it is link-local multicast -
+# which is why this can run before the check below rather than after it.
+
+say "Reaching the device"
+
+conn="$(pi_ssh 'echo "$SSH_CONNECTION"' 2>/dev/null)"
+[[ -n "$conn" ]] || die "cannot ssh to '$SSH_DEST'. Check that the device is
+       attached, that sshd is up, and that the alias resolves:
+           ssh -G $SSH_DEST | head"
+# SSH_CONNECTION is "client-ip client-port server-ip server-port".
+pi_addr="$(awk '{print $3}' <<<"$conn")"
+info "device address  : $pi_addr"
+
+if [[ -z "$PHASMID_PI_REMOTE_DIR" ]]; then
+    PHASMID_PI_REMOTE_DIR="$(pi_ssh 'echo "$HOME/Phasmid"' 2>/dev/null)"
+    [[ -n "$PHASMID_PI_REMOTE_DIR" ]] || die "cannot determine the remote
+       directory. Set PHASMID_PI_REMOTE_DIR explicitly."
+fi
+info "remote directory: $PHASMID_PI_REMOTE_DIR"
+pi_ssh "test -d '$PHASMID_PI_REMOTE_DIR/.git'" || die \
+    "$PHASMID_PI_REMOTE_DIR on the device is not a checkout. Set
+       PHASMID_PI_REMOTE_DIR to the right path."
+
+# ── 2. the default route ──────────────────────────────────────────────────────
+# The reported failure. Checked before any download, because everything after
+# this assumes the Mac can still reach the internet.
+
+say "Checking that the device has not taken the default route"
 
 if command -v route >/dev/null 2>&1; then
-    pi_iface="$(route -n get "$PHASMID_PI_HOST" 2>/dev/null | awk '/interface:/{print $2}')"
+    pi_iface="$(route -n get "$pi_addr" 2>/dev/null | awk '/interface:/{print $2}')"
     default_iface="$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')"
     info "route to the Pi : ${pi_iface:-unknown}"
     info "default route   : ${default_iface:-none}"
@@ -87,8 +139,8 @@ To unblock this session only, without changing anything permanent:
 
   sudo route -n delete default -interface $pi_iface
 
-The Pi stays reachable at $PHASMID_PI_HOST either way - removing the default
-route does not remove the route to its own subnet.
+The device stays reachable at $pi_addr either way - removing the default route
+does not remove the route to its own directly-connected subnet.
 EOF
         die "default route points at the device"
     fi
@@ -100,7 +152,7 @@ if ! curl -sS -m 10 -o /dev/null https://pypi.org/simple/ 2>/dev/null; then
 fi
 info "internet reachable"
 
-# ── 2. the local tree ─────────────────────────────────────────────────────────
+# ── 3. the local tree ─────────────────────────────────────────────────────────
 
 say "Bringing the local repository to $PHASMID_DEPLOY_REF"
 
@@ -117,7 +169,7 @@ git merge --ff-only "$PHASMID_DEPLOY_REF" || die \
     "cannot fast-forward to $PHASMID_DEPLOY_REF. Resolve the local branch first."
 info "at $(git rev-parse --short HEAD)  $(git log -1 --format=%s)"
 
-# ── 3. wheels for the device's own Python ─────────────────────────────────────
+# ── 4. wheels for the device's own Python ─────────────────────────────────────
 # Asked, not assumed: the interpreter on the device decides which wheels match,
 # and guessing produces an install that fails after the files are already there.
 
@@ -153,11 +205,11 @@ python3 -m pip download -r requirements.txt -d "$WHEEL_DIR" \
        Run the same command without the redirect to see which package refused."
 info "$(find "$WHEEL_DIR" -name '*.whl' | wc -l | tr -d ' ') wheels"
 
-# ── 4. carry it across ────────────────────────────────────────────────────────
+# ── 5. carry it across ────────────────────────────────────────────────────────
 # The device's own state is never touched: .state, the vault and the venv are
 # excluded, so a deployment cannot destroy a bound object or a stored file.
 
-say "Syncing to $PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR"
+say "Syncing to $SSH_DEST:$PHASMID_PI_REMOTE_DIR"
 
 rsync -az --delete \
     --exclude '.git/' \
@@ -170,14 +222,14 @@ rsync -az --delete \
     --exclude 'vault.bin' \
     --exclude '__pycache__/' \
     -e "ssh $(printf '%q ' "${SSH_OPTS[@]}")" \
-    "$REPO_ROOT/" "$PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR/" \
+    "$REPO_ROOT/" "$SSH_DEST:$PHASMID_PI_REMOTE_DIR/" \
     || die "rsync failed"
 
 rsync -az -e "ssh $(printf '%q ' "${SSH_OPTS[@]}")" \
-    "$WHEEL_DIR/" "$PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR/.deploy-wheels/" \
+    "$WHEEL_DIR/" "$SSH_DEST:$PHASMID_PI_REMOTE_DIR/.deploy-wheels/" \
     || die "could not copy the wheels"
 
-# ── 5. install, offline ───────────────────────────────────────────────────────
+# ── 6. install, offline ───────────────────────────────────────────────────────
 
 say "Installing on the device, with no network"
 
@@ -186,7 +238,7 @@ pi_ssh "cd '$PHASMID_PI_REMOTE_DIR' && \
     .venv/bin/pip install --quiet --no-deps -e ." \
     || die "the install failed on the device"
 
-# ── 6. verify on the device, not here ─────────────────────────────────────────
+# ── 7. verify on the device, not here ─────────────────────────────────────────
 
 say "Verifying"
 

--- a/scripts/pi_zero2w/deploy_to_device.sh
+++ b/scripts/pi_zero2w/deploy_to_device.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# scripts/pi_zero2w/deploy_to_device.sh
+#
+# Put the current repository onto the device, over the USB link, without the
+# device needing the internet.
+#
+# Run from macOS, from the repository root, with the Pi attached over USB and
+# the operator console stopped.
+#
+#   export PHASMID_PI_HOST=10.12.194.1      # the gadget address, or the name
+#   export PHASMID_PI_USER=pi
+#   export PHASMID_PI_REMOTE_DIR=/home/pi/Phasmid
+#   bash scripts/pi_zero2w/deploy_to_device.sh
+#
+# Three things this does that a bare `git pull` on the device cannot:
+#
+#   * It refuses to start when the Mac's default route points at the Pi. The
+#     gadget hands out a DHCP lease with a router option, macOS ranks that
+#     service above Wi-Fi, and every packet meant for the internet goes to a
+#     device that has no upstream. `git pull` then fails, or worse, quietly
+#     succeeds against a stale cache and you deploy yesterday's tree.
+#   * It carries the dependency wheels across itself. The device is meant to
+#     stay off networks; making it fetch from PyPI to be updated contradicts
+#     the thing being demonstrated, and on a Pi Zero 2 W a source build of the
+#     OpenSSL bindings is not a thing that finishes.
+#   * It verifies afterwards, on the device, rather than reporting success
+#     because rsync exited zero.
+#
+# Optional:
+#   PHASMID_PI_SSH_PORT   default 22
+#   PHASMID_PI_SSH_KEY    path to a private key; ssh-agent is used if unset
+#   PHASMID_DEPLOY_REF    what the local tree must match; default origin/main
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+: "${PHASMID_PI_USER:=pi}"
+: "${PHASMID_PI_REMOTE_DIR:=/home/pi/Phasmid}"
+: "${PHASMID_PI_SSH_PORT:=22}"
+: "${PHASMID_DEPLOY_REF:=origin/main}"
+
+WHEEL_DIR="$REPO_ROOT/.deploy-wheels"
+
+say()  { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+info() { printf '   %s\n' "$*"; }
+die()  { printf '\n\033[1;31mSTOP:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ -n "${PHASMID_PI_HOST:-}" ]] || die \
+    "PHASMID_PI_HOST is not set. Use the gadget address the browser uses,
+       export PHASMID_PI_HOST=10.12.194.1"
+
+SSH_OPTS=(-p "$PHASMID_PI_SSH_PORT" -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new)
+[[ -n "${PHASMID_PI_SSH_KEY:-}" ]] && SSH_OPTS+=(-i "$PHASMID_PI_SSH_KEY")
+pi_ssh() { ssh "${SSH_OPTS[@]}" "$PHASMID_PI_USER@$PHASMID_PI_HOST" "$@"; }
+
+# ── 1. the default route ──────────────────────────────────────────────────────
+# The reported failure. Checked before anything else, because every later step
+# assumes the Mac can still reach the internet.
+
+say "Checking that the Pi has not taken the default route"
+
+if command -v route >/dev/null 2>&1; then
+    pi_iface="$(route -n get "$PHASMID_PI_HOST" 2>/dev/null | awk '/interface:/{print $2}')"
+    default_iface="$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')"
+    info "route to the Pi : ${pi_iface:-unknown}"
+    info "default route   : ${default_iface:-none}"
+
+    if [[ -n "$pi_iface" && "$pi_iface" == "$default_iface" ]]; then
+        cat >&2 <<EOF
+
+The Mac is sending internet traffic to the Pi. The Pi has no upstream, so
+nothing will resolve and nothing will download.
+
+Fix it once, in System Settings > Network > (...) > Set Service Order:
+drag Wi-Fi ABOVE the USB gadget service, then Apply. macOS takes the default
+route from the highest active service, so this survives replugging.
+
+Or from a shell, to see the current order and put Wi-Fi first:
+
+  networksetup -listnetworkserviceorder
+  sudo networksetup -ordernetworkservices "Wi-Fi" "<gadget service name>" <the rest, in order>
+
+To unblock this session only, without changing anything permanent:
+
+  sudo route -n delete default -interface $pi_iface
+
+The Pi stays reachable at $PHASMID_PI_HOST either way - removing the default
+route does not remove the route to its own subnet.
+EOF
+        die "default route points at the device"
+    fi
+fi
+
+if ! curl -sS -m 10 -o /dev/null https://pypi.org/simple/ 2>/dev/null; then
+    die "the Mac cannot reach pypi.org. Connect it to a network first - the
+       wheels for the device are downloaded here, not there."
+fi
+info "internet reachable"
+
+# ── 2. the local tree ─────────────────────────────────────────────────────────
+
+say "Bringing the local repository to $PHASMID_DEPLOY_REF"
+
+remote_name="${PHASMID_DEPLOY_REF%%/*}"
+git fetch "$remote_name" || die "git fetch failed"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    git status --short
+    die "the working tree has uncommitted changes. Deploying it would put a
+       tree on the device that exists nowhere else. Commit or stash first."
+fi
+
+git merge --ff-only "$PHASMID_DEPLOY_REF" || die \
+    "cannot fast-forward to $PHASMID_DEPLOY_REF. Resolve the local branch first."
+info "at $(git rev-parse --short HEAD)  $(git log -1 --format=%s)"
+
+# ── 3. wheels for the device's own Python ─────────────────────────────────────
+# Asked, not assumed: the interpreter on the device decides which wheels match,
+# and guessing produces an install that fails after the files are already there.
+
+say "Collecting dependency wheels for the device"
+
+pi_python="$PHASMID_PI_REMOTE_DIR/.venv/bin/python"
+pi_tags="$(pi_ssh "$pi_python -c \"import sys,sysconfig;print(f'{sys.version_info.major}.{sys.version_info.minor}',sysconfig.get_platform())\"" 2>/dev/null)"
+[[ -n "$pi_tags" ]] || die "cannot run $pi_python on the device. Is it attached,
+       is SSH up, and does the venv exist?"
+
+pi_pyver="${pi_tags%% *}"
+pi_platform="${pi_tags##* }"
+info "device Python   : $pi_pyver"
+info "device platform : $pi_platform"
+
+case "$pi_platform" in
+    *aarch64*) ;;
+    *) die "the device reports '$pi_platform', not aarch64. A 32-bit OS cannot
+       run this - see scripts/pi_zero2w/README.md." ;;
+esac
+
+rm -rf "$WHEEL_DIR"
+mkdir -p "$WHEEL_DIR"
+python3 -m pip download -r requirements.txt -d "$WHEEL_DIR" \
+    --only-binary=:all: \
+    --implementation cp \
+    --python-version "$pi_pyver" \
+    --platform manylinux2014_aarch64 \
+    --platform manylinux_2_17_aarch64 \
+    --platform manylinux_2_28_aarch64 \
+    --platform manylinux_2_34_aarch64 \
+    >/dev/null || die "could not download wheels for $pi_pyver/aarch64.
+       Run the same command without the redirect to see which package refused."
+info "$(find "$WHEEL_DIR" -name '*.whl' | wc -l | tr -d ' ') wheels"
+
+# ── 4. carry it across ────────────────────────────────────────────────────────
+# The device's own state is never touched: .state, the vault and the venv are
+# excluded, so a deployment cannot destroy a bound object or a stored file.
+
+say "Syncing to $PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR"
+
+rsync -az --delete \
+    --exclude '.git/' \
+    --exclude '.venv/' \
+    --exclude '.state/' \
+    --exclude '.deploy-wheels/' \
+    --exclude '_pi_field_test/' \
+    --exclude 'release/' \
+    --exclude '*.vessel' \
+    --exclude 'vault.bin' \
+    --exclude '__pycache__/' \
+    -e "ssh $(printf '%q ' "${SSH_OPTS[@]}")" \
+    "$REPO_ROOT/" "$PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR/" \
+    || die "rsync failed"
+
+rsync -az -e "ssh $(printf '%q ' "${SSH_OPTS[@]}")" \
+    "$WHEEL_DIR/" "$PHASMID_PI_USER@$PHASMID_PI_HOST:$PHASMID_PI_REMOTE_DIR/.deploy-wheels/" \
+    || die "could not copy the wheels"
+
+# ── 5. install, offline ───────────────────────────────────────────────────────
+
+say "Installing on the device, with no network"
+
+pi_ssh "cd '$PHASMID_PI_REMOTE_DIR' && \
+    .venv/bin/pip install --quiet --no-index --find-links .deploy-wheels -r requirements.txt && \
+    .venv/bin/pip install --quiet --no-deps -e ." \
+    || die "the install failed on the device"
+
+# ── 6. verify on the device, not here ─────────────────────────────────────────
+
+say "Verifying"
+
+pi_ssh "cd '$PHASMID_PI_REMOTE_DIR' && \
+    echo -n '   cryptography : ' && .venv/bin/python -c 'import cryptography;print(cryptography.__version__)' && \
+    echo -n '   phasmid      : ' && .venv/bin/python -c 'import phasmid,pathlib;print(pathlib.Path(phasmid.__file__).parent)' && \
+    echo -n '   templates    : ' && (grep -q statusInFlight src/phasmid/templates/base.html && echo 'status poller guarded' || echo 'MISSING - old base.html')" \
+    || die "verification could not run"
+
+expected="$(python3 -c "import re,pathlib;print(re.search(r'cryptography==(\S+)', pathlib.Path('requirements.txt').read_text()).group(1))")"
+say "Done"
+info "requirements.txt pins cryptography==$expected - it must match the line above."
+info "The browser needs a hard reload (Cmd+Shift+R): base.html changed."
+info "Wheels are left in .deploy-wheels/ on both sides; they are gitignored."


### PR DESCRIPTION
Two problems reported from the bench, with one cause between them.

## The Pi takes the Mac's default route

Attaching the device costs the Mac its internet. The gadget's DHCP lease carries a router option, macOS ranks that service above Wi-Fi, and every packet meant for the internet is sent to a device with no upstream.

The symptom is `git pull` failing — which reads as a git problem, not a network one, so it is worth being told plainly. `deploy_to_device.sh` checks it before doing anything else:

```
route to the Pi : en5
default route   : en5
STOP: default route points at the device
```

…and prints both fixes. The permanent one on the Mac is **System Settings → Network → ⋯ → Set Service Order**, Wi-Fi above the gadget: macOS takes the default route from the highest active service, so it survives replugging, and the Pi stays reachable at its own address.

The README adds the **device-side** fix as well, which is the better one because it covers any laptop, including a borrowed one at the venue — if `dnsmasq` serves the lease, `dhcp-option=3` and `dhcp-option=6` make it carry an address and nothing else. That configuration lives on the device by hand and is not in this repository, so the doc says to check what is actually serving the lease first rather than assuming.

## Updating the device by pulling on the device is the wrong shape

It needs the internet to work, and the appliance is meant to stay off networks — making it fetch from PyPI to be updated contradicts the thing being demonstrated. And on a Pi Zero 2 W a source build of the OpenSSL bindings is not something that finishes, which is exactly what `cryptography==50.0.0` would trigger if no matching wheel is found.

So deployment runs from the Mac:

```bash
export PHASMID_PI_HOST=10.12.194.1
export PHASMID_PI_USER=pi
export PHASMID_PI_REMOTE_DIR=/home/pi/Phasmid
bash scripts/pi_zero2w/deploy_to_device.sh
```

1. fast-forwards the local checkout to `origin/main`, and **refuses on a dirty tree** — deploying uncommitted work puts a build on the device that exists nowhere else;
2. asks the device which Python and platform it runs, rather than assuming — a guessed tag produces an install that fails *after* the files are already there;
3. downloads matching aarch64 wheels on the Mac;
4. syncs source and wheels;
5. installs with `--no-index`;
6. verifies **on the device** — `cryptography` version, the package location, and that `base.html` carries the status-poller guard from #207 — because rsync exiting zero says nothing about whether the install took.

## Safety

`.state`, the vault, `*.vessel`, `.venv` and `release/` are excluded from the sync, so a deployment cannot destroy a bound object or a stored file. `.deploy-wheels/` is gitignored on both sides.

Suite green: 732 tests. `bash -n` clean; ruff clean.

## Not verified here

This runs on macOS against real hardware and I have neither, so the interface-comparison preflight and the `pip download --platform` matrix are reasoned, not executed. If a wheel refuses to download for the device's Python, the script says which command to re-run without the redirect to see why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_