### PR TITLE
fix(scripts): say why the network check failed, not just that it did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,22 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ### Fixed
 
+- **`deploy_to_device.sh` reported "cannot reach pypi.org" without saying why.**
+  Reported from the bench on a Mac whose default route was correctly on Wi-Fi
+  and which had just cloned from GitHub. Two faults in one check: it fetched
+  `/simple/`, the entire package index, under a timeout meant for a handshake;
+  and it discarded curl's stderr, so the one piece of evidence went to
+  `/dev/null`.
+
+  It now sends HEAD, checks the file host as well as the index, and names the
+  cause from curl's exit code. That distinction matters here — comparing
+  interfaces catches the device holding the *route*, but not the device holding
+  the *resolver*. macOS merges DNS servers from every active service, so a
+  gadget lease carrying `dhcp-option 6` can put the device in the resolver list
+  while routing looks perfect, which is the likelier explanation for the report
+  and was invisible to the old check.
+
+
 - **The WebUI froze, and Home never came back.** Reported from the device in
   the middle of the demonstration sequence: clear an entry with its destroy
   password, confirm its access password no longer opens it, press Home - and

--- a/scripts/pi_zero2w/README.md
+++ b/scripts/pi_zero2w/README.md
@@ -230,10 +230,31 @@ remove the route to its own directly-connected subnet, and `phasmid-pi.local`
 keeps resolving because mDNS is link-local multicast and does not use the
 default route at all.
 
-**On the Pi, better:** stop advertising a router at all, and no laptop has the
-problem — including a borrowed one at the venue. If the gadget address is
-handed out by `dnsmasq`, adding these to its config and restarting it makes the
-lease carry an address and nothing else:
+### When the route looks right and the network still does not work
+
+Reported from the bench after the service order was already fixed: the deploy
+script showed the default route correctly on `en0` and then refused, saying it
+could not reach pypi.org.
+
+Comparing interfaces catches the device holding the **route**. It does not
+catch the device holding the **resolver**. macOS merges DNS servers from every
+active service, so a gadget lease carrying `dhcp-option 6` puts the device in
+the resolver list while the default route stays correctly on Wi-Fi — and name
+resolution fails with routing that looks perfect.
+
+```bash
+scutil --dns | grep -A2 'resolver #1'    # which resolver wins
+networksetup -getdnsservers Wi-Fi
+```
+
+The quickest confirmation is to unplug the device and try again. The script now
+reports curl's exit code and names the cause, so a repeat says `DNS` rather
+than `cannot reach pypi.org`.
+
+**On the Pi, better:** stop advertising a router *or a DNS server* at all, and
+no laptop has either problem — including a borrowed one at the venue. If the
+gadget address is handed out by `dnsmasq`, adding these to its config and
+restarting it makes the lease carry an address and nothing else:
 
 ```
 dhcp-option=3       # no router

--- a/scripts/pi_zero2w/deploy_to_device.sh
+++ b/scripts/pi_zero2w/deploy_to_device.sh
@@ -146,11 +146,53 @@ EOF
     fi
 fi
 
-if ! curl -sS -m 10 -o /dev/null https://pypi.org/simple/ 2>/dev/null; then
-    die "the Mac cannot reach pypi.org. Connect it to a network first - the
-       wheels for the device are downloaded here, not there."
-fi
-info "internet reachable"
+# HEAD, not GET: /simple/ is the entire package index, tens of megabytes, and
+# -m bounds the whole transfer rather than the connection.
+#
+# And the failure is named rather than summarised. Comparing interfaces, as the
+# check above does, catches the Pi holding the *route* - it does not catch the
+# Pi holding the *resolver*. macOS merges DNS servers from every active
+# service, so a gadget lease carrying `dhcp-option 6` can put the device in the
+# resolver list while the default route is correctly on Wi-Fi. Name resolution
+# then fails with routing that looks perfect, which is exactly the shape of the
+# report this replaces: "cannot reach pypi.org" from a Mac that had just cloned
+# from GitHub. curl's exit code tells the two apart, so it is reported.
+for host in https://pypi.org/simple/ https://files.pythonhosted.org/; do
+    reach_error="$(curl -fsS -I --connect-timeout 5 -m 20 -o /dev/null "$host" 2>&1)"
+    reach_code=$?
+    [[ $reach_code -eq 0 ]] && continue
+
+    case $reach_code in
+        6) cause="DNS. The name did not resolve.
+
+       Comparing interfaces does not catch this: macOS merges resolvers from
+       every active service, so the device can be in the resolver list while
+       the default route is correctly on Wi-Fi. Check which resolvers are in
+       play, and in what order:
+
+           scutil --dns | grep -A2 'resolver #1'
+           networksetup -getdnsservers Wi-Fi
+
+       The durable fix is on the device - stop the lease carrying a DNS server
+       at all (dnsmasq: dhcp-option=6). See scripts/pi_zero2w/README.md.
+       To test the theory right now, unplug the device and re-run." ;;
+        7) cause="the connection was refused or unreachable - a route or a firewall,
+       not a name." ;;
+        28) cause="the request timed out. Traffic is being accepted and then dropped,
+       which is what a split-tunnel VPN or a captive portal looks like." ;;
+        *) cause="curl exited $reach_code." ;;
+    esac
+
+    die "the Mac cannot reach $host
+
+       $cause
+
+       curl said: ${reach_error:-nothing}
+
+       The wheels for the device are downloaded here, not there, so this has to
+       work before anything is deployed."
+done
+info "pypi.org and files.pythonhosted.org reachable"
 
 # ── 3. the local tree ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Reported from the bench, running #210 for the first time:

```
== Checking that the device has not taken the default route
   route to the Pi : en12
   default route   : en0

STOP: the Mac cannot reach pypi.org.
```

The route check passed. The Mac had just cloned from GitHub. And the message gave nothing to act on.

## Two faults in one line

```bash
if ! curl -sS -m 10 -o /dev/null https://pypi.org/simple/ 2>/dev/null; then
```

- **`/simple/` is the entire package index** — tens of megabytes — and `-m` bounds the whole transfer, not the handshake. Ten seconds is a budget for a connection, not for that.
- **`2>/dev/null` discarded curl's stderr.** `-sS` exists precisely to keep errors while silencing progress, and then the errors were thrown away. The one piece of evidence went in the bin.

## The substantive part

Comparing interfaces catches the device holding the **route**. It does not catch the device holding the **resolver**.

macOS merges DNS servers from every active service. A gadget lease carrying `dhcp-option 6` puts the device in the resolver list while the default route stays correctly on Wi-Fi — so name resolution fails with routing that looks perfect. That fits the report better than the timeout does, and the old check could not have told them apart.

It now sends HEAD, checks `files.pythonhosted.org` as well as the index (a proxy can allow one and refuse the other), and names the cause from curl's exit code:

| exit | reported as |
|---|---|
| 6 | DNS — with `scutil --dns` and `networksetup -getdnsservers Wi-Fi` to confirm, and "unplug the device and re-run" as the quick test |
| 7 | a route or a firewall, not a name |
| 28 | accepted then dropped — split-tunnel VPN or captive portal |
| other | the raw code, plus curl's own message |

`scripts/pi_zero2w/README.md` gains a section for the case where the route is right and the network still does not work, and the device-side fix now says to stop advertising **a router or a DNS server** — `dhcp-option=3` and `dhcp-option=6` together — which removes both problems for any laptop.

## Honest limits

I could not reproduce either theory here: this container reaches `/simple/` in half a second through a proxy, so the timeout is reasoned from how `-m` works rather than observed, and the DNS theory is inference from the evidence rather than a diagnosis. The point of the change is that the **next** run says which it is instead of leaving it to be guessed.

Suite green: 732 tests. `bash -n` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_