### PR TITLE
fix(scripts): carry the build requirements too, and stop pip isolating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,29 @@ and this project follows SemVer-style release intent for documented interfaces.
 
 ### Fixed
 
+- **Deploying to the device failed at the last step, offline.** Everything
+  installed, and then `pip install -e .` reached for pypi.org and died on
+  `Could not find a version that satisfies the requirement setuptools>=40.8.0`.
+
+  `--no-deps` suppresses *runtime* dependencies. Building a package is
+  separately isolated: pip creates a fresh environment and fetches setuptools
+  into it, and nothing about `--no-deps` or the outer `--no-index` reaches that
+  subprocess — the device's own `/etc/pip.conf` index list does. Python 3.12
+  also stopped seeding virtual environments with setuptools, and the device
+  runs 3.13, so there was none present to fall back to.
+
+  The build requirements now travel with the dependency wheels, are installed
+  first, and the package is built with `--no-build-isolation`. Reproduced in a
+  virtual environment stripped of setuptools — the old command fails with the
+  same error, the new sequence installs and imports.
+
+- **The network check's own diagnosis was wrong about the first failure.** The
+  resolver on the reporting machine turned out to be the venue's, not the
+  device's, so the DNS explanation this changelog offered did not apply. What
+  actually failed was fetching the entire package index under a ten-second
+  budget. `scripts/pi_zero2w/README.md` now says so instead.
+
+
 - **`deploy_to_device.sh` reported "cannot reach pypi.org" without saying why.**
   Reported from the bench on a Mac whose default route was correctly on Wi-Fi
   and which had just cloned from GitHub. Two faults in one check: it fetched

--- a/scripts/pi_zero2w/README.md
+++ b/scripts/pi_zero2w/README.md
@@ -196,9 +196,11 @@ The remote directory is asked of the device (`$HOME/Phasmid`) unless
 this updates a device, it does not provision a new one.
 
 It fast-forwards the local checkout to `origin/main`, asks the device which
-Python it runs, downloads the matching aarch64 wheels **on the Mac**, syncs
-both, installs with `--no-index`, and then verifies on the device rather than
-trusting rsync's exit status. It refuses to run against a dirty working tree:
+Python it runs, downloads the matching aarch64 wheels **on the Mac** — plus
+`setuptools` and `wheel`, because `pip install -e .` builds the package and
+building is isolated, so `--no-deps` does not stop pip fetching a setuptools of
+its own — syncs both, installs with `--no-index` and `--no-build-isolation`,
+and then verifies on the device rather than trusting rsync's exit status. It refuses to run against a dirty working tree:
 deploying uncommitted work puts a build on the device that exists nowhere else.
 
 `.state`, the vault, `*.vessel` and the venv are excluded, so a deployment
@@ -232,24 +234,26 @@ default route at all.
 
 ### When the route looks right and the network still does not work
 
-Reported from the bench after the service order was already fixed: the deploy
-script showed the default route correctly on `en0` and then refused, saying it
-could not reach pypi.org.
+Seen on the bench once: the default route was correctly on `en0` and the script
+still refused, saying it could not reach pypi.org. That one was the check
+itself — it fetched `/simple/`, the whole package index, under a timeout meant
+for a handshake, which a hotel connection will not finish. It sends HEAD now
+and the same machine passes.
 
-Comparing interfaces catches the device holding the **route**. It does not
-catch the device holding the **resolver**. macOS merges DNS servers from every
-active service, so a gadget lease carrying `dhcp-option 6` puts the device in
-the resolver list while the default route stays correctly on Wi-Fi — and name
-resolution fails with routing that looks perfect.
+Two other causes are worth telling apart, and the script names them from curl's
+exit code rather than leaving it to be guessed. Comparing interfaces catches
+the device holding the **route**; it does not catch the device holding the
+**resolver**. macOS merges DNS servers from every active service, so a gadget
+lease carrying `dhcp-option 6` can put the device in the resolver list while
+the default route stays correctly on Wi-Fi.
 
 ```bash
-scutil --dns | grep -A2 'resolver #1'    # which resolver wins
+scutil --dns | grep -A2 'resolver #1'    # which resolver actually wins
 networksetup -getdnsservers Wi-Fi
 ```
 
-The quickest confirmation is to unplug the device and try again. The script now
-reports curl's exit code and names the cause, so a repeat says `DNS` rather
-than `cannot reach pypi.org`.
+If `resolver #1` names the venue's DNS rather than `10.12.194.1`, that is not
+it. The quickest confirmation either way is to unplug the device and retry.
 
 **On the Pi, better:** stop advertising a router *or a DNS server* at all, and
 no laptop has either problem — including a borrowed one at the venue. If the

--- a/scripts/pi_zero2w/deploy_to_device.sh
+++ b/scripts/pi_zero2w/deploy_to_device.sh
@@ -245,7 +245,27 @@ python3 -m pip download -r requirements.txt -d "$WHEEL_DIR" \
     --platform manylinux_2_34_aarch64 \
     >/dev/null || die "could not download wheels for $pi_pyver/aarch64.
        Run the same command without the redirect to see which package refused."
+# The build requirements travel too. `pip install -e .` builds the package,
+# and building is isolated: pip creates a fresh environment and fetches
+# setuptools into it. `--no-deps` suppresses runtime dependencies and has no
+# effect on that, so the device reached for pypi.org and failed with
+# "Could not find a version that satisfies the requirement setuptools>=40.8.0"
+# after everything else had already installed cleanly.
+#
+# Python 3.12 stopped seeding new virtual environments with setuptools, and the
+# device runs 3.13, so it is genuinely absent rather than merely unpinned.
+# These are py3-none-any, so the host's own tags are fine.
+python3 -m pip download setuptools wheel -d "$WHEEL_DIR" --only-binary=:all: \
+    >/dev/null || die "could not download the build requirements (setuptools, wheel)."
+
 info "$(find "$WHEEL_DIR" -name '*.whl' | wc -l | tr -d ' ') wheels"
+
+local_pip="$(python3 -m pip --version 2>/dev/null | awk '{print $2}')"
+case "$local_pip" in
+    2[0-3].*) info "note: local pip is $local_pip, which predates some of the
+                 platform tags a 3.13 target can use. If a wheel is missing
+                 below, upgrade it first: python3 -m pip install -U pip" ;;
+esac
 
 # ── 5. carry it across ────────────────────────────────────────────────────────
 # The device's own state is never touched: .state, the vault and the venv are
@@ -275,9 +295,19 @@ rsync -az -e "ssh $(printf '%q ' "${SSH_OPTS[@]}")" \
 
 say "Installing on the device, with no network"
 
+# Three steps, in this order, and none of them may reach a network.
+#   1. the build requirements, so that step 3 has a setuptools to use;
+#   2. the runtime dependencies;
+#   3. the package itself, with build isolation off - otherwise pip discards
+#      the setuptools installed in step 1 and goes looking for another one.
+# PIP_NO_INDEX and PIP_FIND_LINKS are exported as well as passed, so that any
+# subprocess pip spawns inherits the same offline view rather than falling back
+# to the index list in the device's /etc/pip.conf.
 pi_ssh "cd '$PHASMID_PI_REMOTE_DIR' && \
+    export PIP_NO_INDEX=1 PIP_FIND_LINKS='$PHASMID_PI_REMOTE_DIR/.deploy-wheels' && \
+    .venv/bin/pip install --quiet --no-index --find-links .deploy-wheels setuptools wheel && \
     .venv/bin/pip install --quiet --no-index --find-links .deploy-wheels -r requirements.txt && \
-    .venv/bin/pip install --quiet --no-deps -e ." \
+    .venv/bin/pip install --quiet --no-deps --no-build-isolation -e ." \
     || die "the install failed on the device"
 
 # ── 7. verify on the device, not here ─────────────────────────────────────────

--- a/scripts/pi_zero2w/deploy_to_device.sh
+++ b/scripts/pi_zero2w/deploy_to_device.sh
@@ -147,16 +147,19 @@ EOF
 fi
 
 # HEAD, not GET: /simple/ is the entire package index, tens of megabytes, and
-# -m bounds the whole transfer rather than the connection.
+# -m bounds the whole transfer rather than the connection. The first version of
+# this check asked for that whole index inside a 10-second budget and stopped a
+# deployment on a network that was working - the transfer was slow, not absent.
 #
-# And the failure is named rather than summarised. Comparing interfaces, as the
-# check above does, catches the Pi holding the *route* - it does not catch the
-# Pi holding the *resolver*. macOS merges DNS servers from every active
-# service, so a gadget lease carrying `dhcp-option 6` can put the device in the
-# resolver list while the default route is correctly on Wi-Fi. Name resolution
-# then fails with routing that looks perfect, which is exactly the shape of the
-# report this replaces: "cannot reach pypi.org" from a Mac that had just cloned
-# from GitHub. curl's exit code tells the two apart, so it is reported.
+# And the failure is named rather than summarised, because more than one thing
+# produces "cannot reach pypi.org" and they need different fixes. Comparing
+# interfaces, as the check above does, catches the Pi holding the *route* - it
+# does not catch the Pi holding the *resolver*. macOS merges DNS servers from
+# every active service, so a gadget lease carrying `dhcp-option 6` can put the
+# device in the resolver list while the default route is correctly on Wi-Fi;
+# name resolution then fails with routing that looks perfect. curl's exit code
+# separates that from a refused connection and from a timeout, so it is
+# reported instead of guessed at.
 for host in https://pypi.org/simple/ https://files.pythonhosted.org/; do
     reach_error="$(curl -fsS -I --connect-timeout 5 -m 20 -o /dev/null "$host" 2>&1)"
     reach_code=$?
@@ -165,17 +168,22 @@ for host in https://pypi.org/simple/ https://files.pythonhosted.org/; do
     case $reach_code in
         6) cause="DNS. The name did not resolve.
 
-       Comparing interfaces does not catch this: macOS merges resolvers from
-       every active service, so the device can be in the resolver list while
-       the default route is correctly on Wi-Fi. Check which resolvers are in
-       play, and in what order:
+       Look at the resolver actually being used before assuming a cause -
+       a hotel or conference network answers here far more often than the
+       device does:
 
            scutil --dns | grep -A2 'resolver #1'
            networksetup -getdnsservers Wi-Fi
 
-       The durable fix is on the device - stop the lease carrying a DNS server
-       at all (dnsmasq: dhcp-option=6). See scripts/pi_zero2w/README.md.
-       To test the theory right now, unplug the device and re-run." ;;
+       If the address listed is the device's, macOS has merged its resolver in
+       (it merges resolvers from every active service, so this happens with the
+       default route correctly on Wi-Fi). The durable fix is then on the device
+       - stop the lease carrying a DNS server at all (dnsmasq: dhcp-option=6).
+       See scripts/pi_zero2w/README.md. To confirm, unplug it and re-run.
+
+       If the address belongs to the network you are on, the device is not
+       involved: the venue's resolver is failing, and a public one on Wi-Fi
+       only (networksetup -setdnsservers Wi-Fi 1.1.1.1) gets you moving." ;;
         7) cause="the connection was refused or unreachable - a route or a firewall,
        not a name." ;;
         28) cause="the request timed out. Traffic is being accepted and then dropped,


### PR DESCRIPTION
Reported from the device. Everything installed — `cryptography 50.0.0` included — and then the last step died:

```
ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0
ERROR: Failed to build 'file:///home/phasmid/Phasmid' when installing build dependencies
```

## Why

`--no-deps` suppresses **runtime** dependencies. Building a package is isolated separately: pip creates a fresh environment and fetches `setuptools` into it, and neither `--no-deps` nor the outer `--no-index` reaches that subprocess. The device's own `/etc/pip.conf` does — which is why the log shows it trying `pypi.org` and then `piwheels.org`.

Python 3.12 also stopped seeding virtual environments with `setuptools`, and the device runs **3.13**, so there was nothing present to fall back on. `pyproject.toml` declares no `[build-system]`, so pip uses the legacy fallback — `setuptools>=40.8.0` — and isolates by default.

## The fix

`setuptools` and `wheel` travel with the dependency wheels (`py3-none-any`, so the host's own tags are fine), are installed first, and the package is built with `--no-build-isolation`. `PIP_NO_INDEX` and `PIP_FIND_LINKS` are exported too, so anything pip spawns inherits the same offline view instead of the device's index list.

## Reproduced, not reasoned

The last three attempts at this were inference. This one was tested — a virtual environment with `setuptools` removed, which is what a 3.13 venv is:

```
setuptools present: False

=== 1. the old command, offline (build isolation on):
× pip subprocess to install build dependencies did not run successfully.

=== 2. the fix:
  build requirements installed offline
  phasmid installed offline
  import ok -> /home/user/Phasmid/src/phasmid
```

## Two smaller things from the same run

- The Mac's pip is **22.0.4** (pyenv 3.10.4) against a 3.13 target. It worked — 35 wheels — but the script now says so when it sees a pip old enough to matter, rather than leaving a missing wheel unexplained.
- **The README's account of the earlier network failure was wrong.** `scutil --dns` on that machine showed `10.3.1.191` on `rwlasvegas.com` — the venue's resolver, not the device's. The DNS explanation #211 offered did not apply. What actually failed was fetching the whole package index under a ten-second budget, which the HEAD request fixed; the doc says that now, and keeps the DNS case only as one of the things the exit code distinguishes.

Suite green: 732 tests. `bash -n` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx4dCiPgkqtC2b17GtDU6z)_